### PR TITLE
pyprojectの更新

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ zip-safe = false
 py-modules = ["Snakefile"]
 
 [tool.setuptools.packages.find]
-exclude = ["studio.tests.*"]
+exclude = ["studio.tests.*", "conda.env.*"]
 
 [tool.setuptools.package-data]
 frontend = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   "pyrebase4==4.7.1",
   "pydantic[email]",
   "pydantic[dotenv]",
-  "requests-toolbelt==0.10.1",
   "python-jose[cryptography]",
 ]
 


### PR DESCRIPTION
- requests-toolbeltをdependencyから削除
  - pyrebase4が依存しているパッケージ
    - pyrebase4 4.6.0でパッケージ側でdependencyの登録が漏れていたため暫定で手動で追加していたもの
    - pyrebase4 4.7.1のアップデートで解消されたため、こちらからは削除
- package探索時にローカルの`conda/env`にconda環境を構築している場合にそれらも含まれてしまう問題を解消