### PR TITLE
Visualizeのサイドバーコンテンツが追従しない問題の修正

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Editor/TimeSeriesItemEditor.tsx
+++ b/frontend/src/components/Workspace/Visualize/Editor/TimeSeriesItemEditor.tsx
@@ -96,7 +96,7 @@ const Span: React.FC = () => {
             shrink: true,
           }}
           onChange={onChange}
-          defaultValue={span}
+          value={span}
         />
       }
       label="offset std"
@@ -208,7 +208,8 @@ const Xrange: React.FC = () => {
               shrink: true,
             }}
             onChange={onChangeLeft}
-            defaultValue={xrange.left}
+            value={xrange.left ?? ''}
+            defaultValue={undefined}
           />
           <TextField
             label="right"
@@ -218,7 +219,7 @@ const Xrange: React.FC = () => {
               shrink: true,
             }}
             onChange={onChangeRight}
-            defaultValue={xrange.right}
+            value={xrange.right ?? ''}
           />
         </>
       }

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -82,8 +82,6 @@ class ExptConfigWriter:
         ).nodeDict
 
         for node in node_dict.values():
-            print("hoge")
-            print(node.id)
             func_dict[node.id] = ExptFunction(
                 unique_id=node.id, name=node.data.label, hasNWB=False, success="running"
             )


### PR DESCRIPTION
- https://github.com/oist/optinist/issues/506
  - TimeSeriesのVisualize Editor間の選択を切り替えた際に、テキストフィールドの値が更新されない問題を解消
- 併せて別PRで残ってしまっていた不要なprintを削除