### PR TITLE
reproduce outputs

### DIFF
--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -3,7 +3,6 @@ import axios from 'utils/axios'
 import { BASE_URL } from 'const/API'
 import { OutputPathsDTO } from 'api/run/Run'
 import { EXPERIMENTS_STATUS } from 'store/slice/Experiments/ExperimentsType'
-import { WorkflowConfigDTO } from 'api/workflow/Workflow'
 
 export type ExperimentsDTO = {
   [uid: string]: ExperimentDTO
@@ -39,8 +38,6 @@ export type ExperimentDTO = {
   hasNWB: boolean
   nwb: NWBType
 }
-
-export type FetchExperimentDTO = ExperimentDTO & WorkflowConfigDTO
 
 export async function getExperimentsApi(
   workspaceId: number,
@@ -96,15 +93,6 @@ export async function downloadExperimentConfigApi(
     {
       responseType: 'blob',
     },
-  )
-  return response.data
-}
-
-export async function fetchExperimentApi(
-  workspace_id: number,
-): Promise<FetchExperimentDTO> {
-  const response = await axios.get(
-    `${BASE_URL}/experiments/fetch/${workspace_id}`,
   )
   return response.data
 }

--- a/frontend/src/api/workflow/Workflow.ts
+++ b/frontend/src/api/workflow/Workflow.ts
@@ -2,16 +2,25 @@ import axios from 'utils/axios'
 
 import { EdgeDict, NodeDict } from 'api/run/Run'
 import { BASE_URL } from 'const/API'
+import { ExperimentDTO } from 'api/experiments/Experiments'
 
 export type WorkflowConfigDTO = {
   nodeDict: NodeDict
   edgeDict: EdgeDict
 }
+export type WorkflowWithResultDTO = ExperimentDTO & WorkflowConfigDTO
+
+export async function fetchWorkflowApi(
+  workspace_id: number,
+): Promise<WorkflowWithResultDTO> {
+  const response = await axios.get(`${BASE_URL}/workflow/fetch/${workspace_id}`)
+  return response.data
+}
 
 export async function reproduceWorkflowApi(
   workspaceId: number,
   uid: string,
-): Promise<WorkflowConfigDTO> {
+): Promise<WorkflowWithResultDTO> {
   const response = await axios.get(
     `${BASE_URL}/workflow/reproduce/${workspaceId}/${uid}`,
   )

--- a/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
+++ b/frontend/src/store/slice/AlgorithmNode/AlgorithmNodeSlice.ts
@@ -6,10 +6,10 @@ import {
   deleteFlowNodeById,
 } from '../FlowElement/FlowElementSlice'
 import { NODE_TYPE_SET } from '../FlowElement/FlowElementType'
-import { fetchExperiment } from '../Experiments/ExperimentsActions'
 import {
   reproduceWorkflow,
   importWorkflowConfig,
+  fetchWorkflow,
 } from 'store/slice/Workflow/WorkflowActions'
 import { getAlgoParams } from './AlgorithmNodeActions'
 import { ALGORITHM_NODE_SLICE_NAME, AlgorithmNode } from './AlgorithmNodeType'
@@ -74,9 +74,9 @@ export const algorithmNodeSlice = createSlice({
       })
       .addMatcher(
         isAnyOf(
+          fetchWorkflow.fulfilled,
           reproduceWorkflow.fulfilled,
           importWorkflowConfig.fulfilled,
-          fetchExperiment.fulfilled,
         ),
         (_, action) => {
           const newState: AlgorithmNode = {}

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -1,11 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import {
   ExperimentsDTO,
-  FetchExperimentDTO,
   getExperimentsApi,
   deleteExperimentByUidApi,
   deleteExperimentByListApi,
-  fetchExperimentApi,
 } from 'api/experiments/Experiments'
 import { EXPERIMENTS_SLICE_NAME } from './ExperimentsType'
 import { selectCurrentWorkspaceId } from '../Workspace/WorkspaceSelector'
@@ -64,15 +62,3 @@ export const deleteExperimentByList = createAsyncThunk<
     return thunkAPI.rejectWithValue('workspace id does not exist.')
   }
 })
-
-export const fetchExperiment = createAsyncThunk<FetchExperimentDTO, number>(
-  `${EXPERIMENTS_SLICE_NAME}/fetchExperiment`,
-  async (workspaceId, thunkAPI) => {
-    try {
-      const response = await fetchExperimentApi(workspaceId)
-      return response
-    } catch (e) {
-      return thunkAPI.rejectWithValue(e)
-    }
-  },
-)

--- a/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSlice.ts
@@ -4,7 +4,6 @@ import {
   getExperiments,
   deleteExperimentByUid,
   deleteExperimentByList,
-  fetchExperiment,
 } from './ExperimentsActions'
 import {
   convertToExperimentListType,
@@ -15,6 +14,7 @@ import {
   run,
   runByCurrentUid,
 } from '../Pipeline/PipelineActions'
+import { fetchWorkflow, reproduceWorkflow } from '../Workflow/WorkflowActions'
 
 export const initialState: Experiments = {
   status: 'uninitialized',
@@ -69,12 +69,15 @@ export const experimentsSlice = createSlice({
           })
         }
       })
-      .addCase(fetchExperiment.fulfilled, (state, action) => {
-        if (state.status === 'fulfilled') {
-          state.experimentList[action.payload.unique_id] =
-            convertToExperimentType(action.payload)
-        }
-      })
+      .addMatcher(
+        isAnyOf(fetchWorkflow.fulfilled, reproduceWorkflow.fulfilled),
+        (state, action) => {
+          if (state.status === 'fulfilled') {
+            state.experimentList[action.payload.unique_id] =
+              convertToExperimentType(action.payload)
+          }
+        },
+      )
       .addMatcher(isAnyOf(run.fulfilled, runByCurrentUid.fulfilled), () => {
         return {
           status: 'uninitialized',

--- a/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
@@ -23,10 +23,10 @@ import {
   INITIAL_IMAGE_ELEMENT_NAME,
   REACT_FLOW_NODE_TYPE_KEY,
 } from 'const/flowchart'
-import { fetchExperiment } from '../Experiments/ExperimentsActions'
 import {
   reproduceWorkflow,
   importWorkflowConfig,
+  fetchWorkflow,
 } from 'store/slice/Workflow/WorkflowActions'
 import { setInputNodeFilePath } from 'store/slice/InputNode/InputNodeActions'
 import { isInputNodePostData } from 'api/run/RunUtils'
@@ -197,12 +197,12 @@ export const flowElementSlice = createSlice({
           }
         }
       })
-      .addCase(fetchExperiment.rejected, () => initialState)
+      .addCase(fetchWorkflow.rejected, () => initialState)
       .addMatcher(
         isAnyOf(
           reproduceWorkflow.fulfilled,
           importWorkflowConfig.fulfilled,
-          fetchExperiment.fulfilled,
+          fetchWorkflow.fulfilled,
         ),
         (state, action) => {
           state.flowPosition = initialFlowPosition

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -1,10 +1,10 @@
 import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
 import { isInputNodePostData } from 'api/run/RunUtils'
 import { INITIAL_IMAGE_ELEMENT_ID } from 'const/flowchart'
-import { fetchExperiment } from '../Experiments/ExperimentsActions'
 import {
   reproduceWorkflow,
   importWorkflowConfig,
+  fetchWorkflow,
 } from 'store/slice/Workflow/WorkflowActions'
 import { uploadFile } from '../FileUploader/FileUploaderActions'
 import { addInputNode } from '../FlowElement/FlowElementActions'
@@ -146,7 +146,7 @@ export const inputNodeSlice = createSlice({
           }
         }
       })
-      .addCase(fetchExperiment.rejected, () => initialState)
+      .addCase(fetchWorkflow.rejected, () => initialState)
       .addCase(importWorkflowConfig.fulfilled, (_, action) => {
         const newState: InputNode = {}
         Object.values(action.payload.nodeDict)
@@ -174,7 +174,7 @@ export const inputNodeSlice = createSlice({
         return newState
       })
       .addMatcher(
-        isAnyOf(reproduceWorkflow.fulfilled, fetchExperiment.fulfilled),
+        isAnyOf(fetchWorkflow.fulfilled, reproduceWorkflow.fulfilled),
         (_, action) => {
           const newState: InputNode = {}
           Object.values(action.payload.nodeDict)

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -16,10 +16,8 @@ import {
 } from './PipelineActions'
 import { selectFilePathIsUndefined } from '../InputNode/InputNodeSelectors'
 import { selectAlgorithmNodeNotExist } from '../AlgorithmNode/AlgorithmNodeSelectors'
-import {
-  fetchExperiment,
-  getExperiments,
-} from '../Experiments/ExperimentsActions'
+import { getExperiments } from '../Experiments/ExperimentsActions'
+import { fetchWorkflow } from '../Workflow/WorkflowActions'
 import { useSnackbar, VariantType } from 'notistack'
 import { RUN_STATUS } from './PipelineType'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -32,7 +30,7 @@ import {
 import { clearExperiments } from '../Experiments/ExperimentsSlice'
 import { getWorkspace } from 'store/slice/Workspace/WorkspaceActions'
 import { selectIsWorkspaceOwner } from '../Workspace/WorkspaceSelector'
-import { AppDispatch } from "../../store";
+import { AppDispatch } from '../../store'
 
 const POLLING_INTERVAL = 5000
 
@@ -50,12 +48,12 @@ export function useRunPipeline() {
   React.useEffect(() => {
     if (IS_STANDALONE) {
       dispatch(setCurrentWorkspace(STANDALONE_WORKSPACE_ID))
-      dispatch(fetchExperiment(STANDALONE_WORKSPACE_ID))
+      dispatch(fetchWorkflow(STANDALONE_WORKSPACE_ID))
     } else {
       appDispatch(getWorkspace({ id: _workspaceId }))
         .unwrap()
         .then((_) => {
-          dispatch(fetchExperiment(_workspaceId))
+          dispatch(fetchWorkflow(_workspaceId))
           const selectedTab = location.state?.tab
           selectedTab && dispatch(setActiveTab(selectedTab))
         })

--- a/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
+++ b/frontend/src/store/slice/RightDrawer/RightDrawerSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
-import { fetchExperiment } from '../Experiments/ExperimentsActions'
 import {
   reproduceWorkflow,
   importWorkflowConfig,
+  fetchWorkflow,
 } from 'store/slice/Workflow/WorkflowActions'
 import {
   deleteFlowNodes,
@@ -23,7 +23,7 @@ export const RIGHT_DRAWER_MODE = {
 } as const
 
 export type RIGHT_DRAWER_MODE_TYPE =
-  typeof RIGHT_DRAWER_MODE[keyof typeof RIGHT_DRAWER_MODE]
+  (typeof RIGHT_DRAWER_MODE)[keyof typeof RIGHT_DRAWER_MODE]
 
 const initialState: RightDrawer = {
   open: false,
@@ -97,8 +97,8 @@ export const rightDrawerSlice = createSlice({
         isAnyOf(
           reproduceWorkflow.fulfilled,
           importWorkflowConfig.fulfilled,
-          fetchExperiment.fulfilled,
-          fetchExperiment.rejected,
+          fetchWorkflow.fulfilled,
+          fetchWorkflow.rejected,
         ),
         () => initialState,
       )

--- a/frontend/src/store/slice/Workflow/WorkflowActions.ts
+++ b/frontend/src/store/slice/Workflow/WorkflowActions.ts
@@ -1,13 +1,27 @@
 import { WORKFLOW_SLICE_NAME } from './WorkflowType'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import {
+  fetchWorkflowApi,
   reproduceWorkflowApi,
   importWorkflowConfigApi,
   WorkflowConfigDTO,
+  WorkflowWithResultDTO,
 } from 'api/workflow/Workflow'
 
+export const fetchWorkflow = createAsyncThunk<WorkflowWithResultDTO, number>(
+  `${WORKFLOW_SLICE_NAME}/fetchExperiment`,
+  async (workspaceId, thunkAPI) => {
+    try {
+      const response = await fetchWorkflowApi(workspaceId)
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)
+
 export const reproduceWorkflow = createAsyncThunk<
-  WorkflowConfigDTO,
+  WorkflowWithResultDTO,
   { workspaceId: number; uid: string }
 >(
   `${WORKFLOW_SLICE_NAME}/reproduceWorkflow`,

--- a/frontend/src/store/test/record/RecordReproduce.test.ts
+++ b/frontend/src/store/test/record/RecordReproduce.test.ts
@@ -6,6 +6,56 @@ describe('RecordReproduce', () => {
   const initialState = store.getState()
 
   const reproduceWorkflowPayload = {
+    workspace_id: 1,
+    unique_id: '96844a59',
+    name: 'dummy',
+    started_at: '2023-10-13 15:03:13',
+    finished_at: '2023-10-13 15:03:59',
+    success: 'success',
+    hasNWB: true,
+    function: {
+      input_0: {
+        unique_id: 'input_0',
+        name: 'hoge.tif',
+        success: 'success',
+        hasNWB: false,
+        message: null,
+        outputPaths: null,
+        started_at: '2023-,10-13 15:03:13',
+        finished_at: '2023-10-13 15:03:13',
+      },
+      dummy_image2image_c8tqfxw0mq: {
+        unique_id: 'dummy_image2image_c8tqfxw0mq',
+        name: 'dummy_image2image',
+        success: 'success',
+        hasNWB: false,
+        message: 'success',
+        outputPaths: {
+          dummyImage: {
+            path: '/tmp/optinist/output/96844a59/dummy_image2image_c8tqfxw0mq/image.tif',
+            type: 'images',
+            max_index: 1,
+          },
+        },
+        started_at: '2023-10-13 15:03:14',
+        finished_at: '2023-10-13 15:03:40',
+      },
+      dummy_image2image8time_4mrz8h7hyk: {
+        unique_id: 'dummy_image2image8time_4mrz8h7hyk',
+        name: 'dummy_image2image8time',
+        success: 'success',
+        hasNWB: false,
+        outputPaths: {
+          dummyImage2: {
+            path: '/tmp/optinist/output/96844a59/dummy_image2image8time_4mrz8h7hyk/image2.tif',
+            type: 'images',
+            max_index: 1,
+          },
+        },
+        started_at: '2023-10-13 15:03:40',
+        finished_at: '2023-10-13 15:03:59',
+      },
+    },
     nodeDict: {
       input_0: {
         id: 'input_0',
@@ -211,7 +261,160 @@ describe('RecordReproduce', () => {
     nwb: { params: {} },
     snakemake: { params: {} },
     pipeline: {
-      run: { status: 'StartUninitialized' },
+      run: {
+        status: 'Finished',
+        runPostData: {
+          edgeDict: {
+            'reactflow__edge-dummy_image2image_c8tqfxw0mqdummy_image2image_c8tqfxw0mq--image2image--ImageData-dummy_image2image8time_4mrz8h7hykdummy_image2image8time_4mrz8h7hyk--image1--ImageData':
+              {
+                animated: false,
+                id: 'reactflow__edge-dummy_image2image_c8tqfxw0mqdummy_image2image_c8tqfxw0mq--image2image--ImageData-dummy_image2image8time_4mrz8h7hykdummy_image2image8time_4mrz8h7hyk--image1--ImageData',
+                source: 'dummy_image2image_c8tqfxw0mq',
+                sourceHandle:
+                  'dummy_image2image_c8tqfxw0mq--image2image--ImageData',
+                style: {
+                  border: null,
+                  borderRadius: null,
+                  height: null,
+                  padding: null,
+                  width: 5,
+                },
+                target: 'dummy_image2image8time_4mrz8h7hyk',
+                targetHandle:
+                  'dummy_image2image8time_4mrz8h7hyk--image1--ImageData',
+                type: 'buttonedge',
+              },
+            'reactflow__edge-input_0input_0--image--ImageData-dummy_image2image_c8tqfxw0mqdummy_image2image_c8tqfxw0mq--image--ImageData':
+              {
+                animated: false,
+                id: 'reactflow__edge-input_0input_0--image--ImageData-dummy_image2image_c8tqfxw0mqdummy_image2image_c8tqfxw0mq--image--ImageData',
+                source: 'input_0',
+                sourceHandle: 'input_0--image--ImageData',
+                style: {
+                  border: null,
+                  borderRadius: null,
+                  height: null,
+                  padding: null,
+                  width: 5,
+                },
+                target: 'dummy_image2image_c8tqfxw0mq',
+                targetHandle: 'dummy_image2image_c8tqfxw0mq--image--ImageData',
+                type: 'buttonedge',
+              },
+          },
+          forceRunList: [],
+          name: 'dummy',
+          nodeDict: {
+            dummy_image2image8time_4mrz8h7hyk: {
+              data: {
+                fileType: null,
+                hdf5Path: null,
+                label: 'dummy_image2image8time',
+                param: {},
+                path: 'dummy/dummy_image2image8time',
+                type: 'algorithm',
+              },
+              id: 'dummy_image2image8time_4mrz8h7hyk',
+              position: {
+                x: 600,
+                y: 164.03341976235507,
+              },
+              style: {
+                border: null,
+                borderRadius: 0,
+                height: 100,
+                padding: 0,
+                width: 180,
+              },
+              type: 'AlgorithmNode',
+            },
+            dummy_image2image_c8tqfxw0mq: {
+              data: {
+                fileType: null,
+                hdf5Path: null,
+                label: 'dummy_image2image',
+                param: {
+                  sample: {
+                    path: 'sample',
+                    type: 'child',
+                    value: 'test',
+                  },
+                },
+                path: 'dummy/dummy_image2image',
+                type: 'algorithm',
+              },
+              id: 'dummy_image2image_c8tqfxw0mq',
+              position: {
+                x: 350,
+                y: 151.3534781075913,
+              },
+              style: {
+                border: null,
+                borderRadius: 0,
+                height: 100,
+                padding: 0,
+                width: 180,
+              },
+              type: 'AlgorithmNode',
+            },
+            input_0: {
+              data: {
+                fileType: 'image',
+                hdf5Path: null,
+                label: 'hoge.tif',
+                param: {},
+                path: ['/tmp/optinist/input/hoge/hoge.tif'],
+                type: 'input',
+              },
+              id: 'input_0',
+              position: {
+                x: 51,
+                y: 150,
+              },
+              style: {
+                border: '1px solid #777',
+                borderRadius: null,
+                height: 120,
+                padding: null,
+                width: null,
+              },
+              type: 'ImageFileNode',
+            },
+          },
+          nwbParam: {},
+          snakemakeParam: {},
+        },
+        runResult: {
+          dummy_image2image8time_4mrz8h7hyk: {
+            message: '',
+            name: 'dummy_image2image8time',
+            outputPaths: {
+              dummyImage2: {
+                path: '/tmp/optinist/output/96844a59/dummy_image2image8time_4mrz8h7hyk/image2.tif',
+                type: 'image',
+              },
+            },
+            status: 'success',
+          },
+          dummy_image2image_c8tqfxw0mq: {
+            message: 'success',
+            name: 'dummy_image2image',
+            outputPaths: {
+              dummyImage: {
+                path: '/tmp/optinist/output/96844a59/dummy_image2image_c8tqfxw0mq/image.tif',
+                type: 'image',
+              },
+            },
+            status: 'success',
+          },
+          input_0: {
+            message: '',
+            name: 'hoge.tif',
+            status: 'error',
+          },
+        },
+        uid: '96844a59',
+      },
       runBtn: RUN_BTN_OPTIONS.RUN_ALREADY,
       currentPipeline: { uid: uid },
     },

--- a/studio/app/common/core/workflow/workflow.py
+++ b/studio/app/common/core/workflow/workflow.py
@@ -102,9 +102,3 @@ class RunItem(BaseModel):
     snakemakeParam: dict = {}
     nwbParam: dict = {}
     forceRunList: List[ForceRun]
-
-
-@dataclass
-class WorkflowConfig:
-    nodeDict: Dict[str, Node]
-    edgeDict: Dict[str, Edge]

--- a/studio/app/common/core/workflow/workflow_builder.py
+++ b/studio/app/common/core/workflow/workflow_builder.py
@@ -1,4 +1,4 @@
-from studio.app.common.core.workflow.workflow import WorkflowConfig
+from studio.app.common.schemas.workflow import WorkflowConfig
 
 
 class WorkflowConfigBuilder:

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -8,8 +8,8 @@ from studio.app.common.core.workflow.workflow import (
     NodeData,
     NodePosition,
     Style,
-    WorkflowConfig,
 )
+from studio.app.common.schemas.workflow import WorkflowConfig
 
 
 class WorkflowConfigReader:

--- a/studio/app/common/core/workflow/workflow_writer.py
+++ b/studio/app/common/core/workflow/workflow_writer.py
@@ -3,8 +3,9 @@ from typing import Dict
 
 from studio.app.common.core.utils.config_handler import ConfigWriter
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.workflow.workflow import Edge, Node, WorkflowConfig
+from studio.app.common.core.workflow.workflow import Edge, Node
 from studio.app.common.core.workflow.workflow_builder import WorkflowConfigBuilder
+from studio.app.common.schemas.workflow import WorkflowConfig
 from studio.app.dir_path import DIRPATH
 
 

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from dataclasses import asdict
 from glob import glob
 from typing import Dict
 
@@ -9,18 +8,12 @@ from fastapi.responses import FileResponse
 
 from studio.app.common.core.experiment.experiment import ExptConfig
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
-from studio.app.common.core.experiment.experiment_utils import ExptUtils
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
     is_workspace_owner,
 )
-from studio.app.common.schemas.experiment import (
-    DeleteItem,
-    FetchExptResponse,
-    RenameItem,
-)
+from studio.app.common.schemas.experiment import DeleteItem, RenameItem
 from studio.app.dir_path import DIRPATH
 
 router = APIRouter(prefix="/experiments", tags=["experiments"])
@@ -91,28 +84,6 @@ async def delete_experiment_list(workspace_id: str, deleteItem: DeleteItem):
         return True
     except Exception:
         return False
-
-
-@router.get(
-    "/fetch/{workspace_id}",
-    response_model=FetchExptResponse,
-    dependencies=[Depends(is_workspace_available)],
-)
-async def fetch_last_experiment(workspace_id: str):
-    last_expt_config = ExptUtils.get_last_experiment(workspace_id)
-    if last_expt_config:
-        workflow_config_path = join_filepath(
-            [
-                DIRPATH.OUTPUT_DIR,
-                workspace_id,
-                last_expt_config.unique_id,
-                DIRPATH.WORKFLOW_YML,
-            ]
-        )
-        workflow_config = WorkflowConfigReader.read(workflow_config_path)
-        return FetchExptResponse(**asdict(last_expt_config), **asdict(workflow_config))
-    else:
-        raise HTTPException(status_code=404)
 
 
 @router.get(

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -1,31 +1,65 @@
 import os
+from dataclasses import asdict
 
 import yaml
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_utils import ExptUtils
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.workflow.workflow import WorkflowConfig
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
 )
+from studio.app.common.schemas.workflow import WorkflowConfig, WorkflowWithResults
 from studio.app.dir_path import DIRPATH
 
 router = APIRouter(prefix="/workflow", tags=["workflow"])
 
 
 @router.get(
+    "/fetch/{workspace_id}",
+    response_model=WorkflowWithResults,
+    dependencies=[Depends(is_workspace_available)],
+)
+async def fetch_last_experiment(workspace_id: str):
+    last_expt_config = ExptUtils.get_last_experiment(workspace_id)
+    if last_expt_config:
+        workflow_config_path = join_filepath(
+            [
+                DIRPATH.OUTPUT_DIR,
+                workspace_id,
+                last_expt_config.unique_id,
+                DIRPATH.WORKFLOW_YML,
+            ]
+        )
+        workflow_config = WorkflowConfigReader.read(workflow_config_path)
+        return WorkflowWithResults(
+            **asdict(last_expt_config), **asdict(workflow_config)
+        )
+    else:
+        raise HTTPException(status_code=404)
+
+
+@router.get(
     "/reproduce/{workspace_id}/{unique_id}",
-    response_model=WorkflowConfig,
+    response_model=WorkflowWithResults,
     dependencies=[Depends(is_workspace_available)],
 )
 async def reproduce_experiment(workspace_id: str, unique_id: str):
-    config_filepath = join_filepath(
+    experiment_config_path = join_filepath(
+        [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+    )
+    workflow_config_path = join_filepath(
         [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.WORKFLOW_YML]
     )
-    if os.path.exists(config_filepath):
-        return WorkflowConfigReader.read(config_filepath)
+    if os.path.exists(experiment_config_path) and os.path.exists(workflow_config_path):
+        experiment_config = ExptConfigReader.read(experiment_config_path)
+        workflow_config = WorkflowConfigReader.read(workflow_config_path)
+        return WorkflowWithResults(
+            **asdict(experiment_config), **asdict(workflow_config)
+        )
     else:
         raise HTTPException(status_code=404, detail="file not found")
 

--- a/studio/app/common/schemas/experiment.py
+++ b/studio/app/common/schemas/experiment.py
@@ -1,10 +1,6 @@
-from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import List
 
 from pydantic import BaseModel
-
-from studio.app.common.core.experiment.experiment import ExptFunction
-from studio.app.common.core.workflow.workflow import Edge, Node
 
 
 class DeleteItem(BaseModel):
@@ -13,17 +9,3 @@ class DeleteItem(BaseModel):
 
 class RenameItem(BaseModel):
     new_name: str
-
-
-@dataclass
-class FetchExptResponse:
-    workspace_id: str
-    unique_id: str
-    name: str
-    started_at: str
-    finished_at: Optional[str]
-    success: Optional[str]
-    hasNWB: bool
-    function: Dict[str, ExptFunction]
-    nodeDict: Dict[str, Node]
-    edgeDict: Dict[str, Edge]

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from studio.app.common.core.experiment.experiment import ExptFunction
+from studio.app.common.core.workflow.workflow import Edge, Node
+
+
+@dataclass
+class WorkflowConfig:
+    nodeDict: Dict[str, Node]
+    edgeDict: Dict[str, Edge]
+
+
+@dataclass
+class WorkflowWithResults:
+    workspace_id: str
+    unique_id: str
+    name: str
+    started_at: str
+    finished_at: Optional[str]
+    success: Optional[str]
+    hasNWB: bool
+    function: Dict[str, ExptFunction]
+    nodeDict: Dict[str, Node]
+    edgeDict: Dict[str, Edge]

--- a/studio/tests/app/common/core/workflow/test_workflow_reader.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_reader.py
@@ -4,9 +4,9 @@ from studio.app.common.core.workflow.workflow import (
     NodeData,
     NodePosition,
     Style,
-    WorkflowConfig,
 )
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
+from studio.app.common.schemas.workflow import WorkflowConfig
 from studio.app.dir_path import DIRPATH
 
 workflow_filepath = f"{DIRPATH.DATA_DIR}/output_test/0123/workflow.yaml"

--- a/studio/tests/app/common/core/workflow/test_workflow_writer.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_writer.py
@@ -1,13 +1,9 @@
 import os
 import shutil
 
-from studio.app.common.core.workflow.workflow import (
-    Edge,
-    Node,
-    NodeData,
-    WorkflowConfig,
-)
+from studio.app.common.core.workflow.workflow import Edge, Node, NodeData
 from studio.app.common.core.workflow.workflow_writer import WorkflowConfigWriter
+from studio.app.common.schemas.workflow import WorkflowConfig
 from studio.app.dir_path import DIRPATH
 
 node_data = NodeData(label="a", param={}, path="", type="")


### PR DESCRIPTION
- reproduceの際にRUNを実行せずとも結果のVisualizeが可能なように修正
- fetchとresponse内容が重複することや、実行内容からexperiments/fetch -> workflow/fetchにAPIエンドポイントやスキーマのリファクタを実施
  - before
    - experiments/fetch
    - workflow/reproduce
  - after
    - workflow/fetch
    - workflow/reproduce
