### PR TITLE
add workspace info to left menu

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
@@ -3,7 +3,7 @@ import { DndProvider } from "react-dnd"
 import { HTML5Backend } from "react-dnd-html5-backend"
 import { useDispatch, useSelector } from "react-redux"
 
-import { Box, FormHelperText, Popover } from "@mui/material"
+import { Box, FormHelperText, Popover, Typography } from "@mui/material"
 import { grey } from "@mui/material/colors"
 import { styled } from "@mui/material/styles"
 
@@ -72,6 +72,9 @@ const FlowChart = memo(function FlowChart(props: UseRunPipelineReturnType) {
             borderColor={grey[300]}
           >
             <CurrentPipelineInfo />
+            <Typography variant="body2" color="textSecondary">
+              NODES
+            </Typography>
             <DrawerContents>
               <AlgorithmTreeView />
             </DrawerContents>

--- a/frontend/src/components/common/CurrentPipelineInfo.tsx
+++ b/frontend/src/components/common/CurrentPipelineInfo.tsx
@@ -1,7 +1,7 @@
 import { FC, memo, MouseEvent, useEffect, useRef, useState } from "react"
 import { useSelector } from "react-redux"
 
-import { Divider, Typography, Grid, Popover } from "@mui/material"
+import { Typography, Grid, Popover } from "@mui/material"
 
 import { IS_STANDALONE } from "const/Mode"
 import {
@@ -28,7 +28,7 @@ export const CurrentPipelineInfo: FC = () => {
               <Typography variant="body2" color="textSecondary">
                 WORKSPACE
               </Typography>
-              <Grid container paddingBottom={1} paddingX={1}>
+              <Grid container paddingBottom={2} paddingX={1}>
                 {workspaceId && (
                   <LabelValueGridRow
                     label="ID"
@@ -44,12 +44,12 @@ export const CurrentPipelineInfo: FC = () => {
                   />
                 )}
               </Grid>
-              <Typography variant="body2" color="textSecondary">
-                WORKFLOW
-              </Typography>
             </>
           )}
-          <Grid container paddingBottom={1} paddingX={1}>
+          <Typography variant="body2" color="textSecondary">
+            WORKFLOW
+          </Typography>
+          <Grid container paddingBottom={2} paddingX={1}>
             <LabelValueGridRow
               label="ID"
               value={workflowId}
@@ -63,7 +63,6 @@ export const CurrentPipelineInfo: FC = () => {
               />
             )}
           </Grid>
-          <Divider />
         </>
       )}
     </>

--- a/frontend/src/components/common/CurrentPipelineInfo.tsx
+++ b/frontend/src/components/common/CurrentPipelineInfo.tsx
@@ -1,25 +1,67 @@
-import { FC, memo } from "react"
+import { FC, memo, MouseEvent, useEffect, useRef, useState } from "react"
 import { useSelector } from "react-redux"
 
-import { Divider, Typography, Grid } from "@mui/material"
+import { Divider, Typography, Grid, Popover } from "@mui/material"
 
+import { IS_STANDALONE } from "const/Mode"
 import {
-  selectExperimentName,
-  selectExperimentsStatusIsFulfilled,
-} from "store/slice/Experiments/ExperimentsSelectors"
-import { selectPipelineLatestUid } from "store/slice/Pipeline/PipelineSelectors"
+  selectCurrentPipelineName,
+  selectPipelineLatestUid,
+} from "store/slice/Pipeline/PipelineSelectors"
+import {
+  selectCurrentWorkspaceId,
+  selectCurrentWorkspaceName,
+} from "store/slice/Workspace/WorkspaceSelector"
 
 export const CurrentPipelineInfo: FC = () => {
-  const uid = useSelector(selectPipelineLatestUid)
-  const isFulFilled = useSelector(selectExperimentsStatusIsFulfilled)
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
+  const workspaceName = useSelector(selectCurrentWorkspaceName)
+  const workflowId = useSelector(selectPipelineLatestUid)
+  const workflowName = useSelector(selectCurrentPipelineName)
 
   return (
     <>
-      {uid && (
+      {workflowId && (
         <>
-          <Grid container paddingX={2} paddingBottom={1}>
-            <ExperimentUidInfo uid={uid} />
-            {isFulFilled && <ExperimentNameInfo uid={uid} />}
+          {!IS_STANDALONE && (
+            <>
+              <Typography variant="body2" color="textSecondary">
+                WORKSPACE
+              </Typography>
+              <Grid container paddingBottom={1} paddingX={1}>
+                {workspaceId && (
+                  <LabelValueGridRow
+                    label="ID"
+                    value={workspaceId.toFixed()}
+                    section="workspace"
+                  />
+                )}
+                {workspaceName && (
+                  <LabelValueGridRow
+                    label="NAME"
+                    value={workspaceName}
+                    section="workspace"
+                  />
+                )}
+              </Grid>
+              <Typography variant="body2" color="textSecondary">
+                WORKFLOW
+              </Typography>
+            </>
+          )}
+          <Grid container paddingBottom={1} paddingX={1}>
+            <LabelValueGridRow
+              label="ID"
+              value={workflowId}
+              section="workflow"
+            />
+            {workflowName && (
+              <LabelValueGridRow
+                label="NAME"
+                value={workflowName}
+                section="workflow"
+              />
+            )}
           </Grid>
           <Divider />
         </>
@@ -28,39 +70,78 @@ export const CurrentPipelineInfo: FC = () => {
   )
 }
 
-interface UidProps {
-  uid: string
-}
-
-const ExperimentUidInfo = memo(function ExperimentUidInfo({ uid }: UidProps) {
-  return <LabelValueGridRow label="ID" value={uid} />
-})
-
-const ExperimentNameInfo = memo(function ExperimentNameInfo({ uid }: UidProps) {
-  const name = useSelector(selectExperimentName(uid))
-  return <LabelValueGridRow label="NAME" value={name} />
-})
-
 interface LabelValueGridRowProps {
   label: string
   value: string
+  section: string
 }
 
 const LabelValueGridRow = memo(function LabelValueGridRow({
   label,
   value,
+  section,
 }: LabelValueGridRowProps) {
+  const [isOverflow, setIsOverflow] = useState(false)
+  const ref = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (element) {
+      setIsOverflow(element.scrollWidth > element.offsetWidth)
+    }
+  }, [ref])
+
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const handlePopoverOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handlePopoverClose = () => {
+    setAnchorEl(null)
+  }
+  const open = Boolean(anchorEl)
+  const id = open ? `pipeline-info-popover-${section}-${label}` : undefined
+
   return (
     <>
-      <Grid item xs={4}>
-        <Typography variant="body2" color="textSecondary">
-          {label}:
-        </Typography>
+      <Grid item xs={3}>
+        <Typography variant="body2">{label}</Typography>
       </Grid>
-      <Grid item xs={8}>
-        <Typography variant="body2" color="textSecondary">
-          {value}
-        </Typography>
+      <Grid item xs={9}>
+        <div>
+          <Typography
+            ref={ref}
+            aria-owns={id}
+            aria-haspopup="true"
+            onMouseEnter={handlePopoverOpen}
+            onMouseLeave={handlePopoverClose}
+            noWrap
+            variant="body2"
+            overflow="hidden"
+            textOverflow="ellipsis"
+          >
+            {value}
+          </Typography>
+          {isOverflow && (
+            <Popover
+              id={id}
+              open={open}
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "left",
+              }}
+              onClose={handlePopoverClose}
+              sx={{
+                pointerEvents: "none",
+              }}
+              disableRestoreFocus
+            >
+              <Typography variant="body2" padding={2}>
+                {value}
+              </Typography>
+            </Popover>
+          )}
+        </div>
       </Grid>
     </>
   )

--- a/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
@@ -15,6 +15,20 @@ export const selectPipelineLatestUid = (state: RootState) => {
   return state.pipeline.currentPipeline?.uid
 }
 
+export const selectCurrentPipelineName = (state: RootState) => {
+  const uid = selectPipelineLatestUid(state)
+  if (uid) {
+    const experiments = state.experiments
+    if (experiments.status === "fulfilled") {
+      return experiments.experimentList[uid].name
+    } else {
+      return undefined
+    }
+  } else {
+    return undefined
+  }
+}
+
 export const selectStartedPipeline = (state: RootState) => {
   return state.pipeline.run
 }

--- a/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSelector.ts
@@ -17,6 +17,9 @@ export const selectActiveTab = (state: RootState) =>
 export const selectCurrentWorkspaceId = (state: RootState) =>
   state.workspace.currentWorkspace.workspaceId
 
+export const selectCurrentWorkspaceName = (state: RootState) =>
+  state.workspace.currentWorkspace.workspaceName
+
 export const selectCurrentWorkspaceOwnerId = (state: RootState) =>
   state.workspace.currentWorkspace.ownerId
 

--- a/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
@@ -52,6 +52,7 @@ export const workspaceSlice = createSlice({
       })
       .addCase(getWorkspace.fulfilled, (state, action) => {
         state.currentWorkspace.workspaceId = action.payload.id
+        state.currentWorkspace.workspaceName = action.payload.name
         state.currentWorkspace.ownerId = action.payload.user.id
         state.loading = false
       })

--- a/frontend/src/store/slice/Workspace/WorkspaceType.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceType.ts
@@ -27,6 +27,7 @@ export type Workspace = {
   workspace: WorkspaceDataDTO
   currentWorkspace: {
     workspaceId?: number
+    workspaceName?: string
     selectedTab: number
     ownerId?: number
   }


### PR DESCRIPTION
workflow画面およびvisualize画面の実行中workflow情報欄にworkspaceの情報を追加
表示はマルチユーザーモードの場合のみ

その他UIの修正として、workflow名・workspace名が長い場合は...での省略表示およびホバーでのPopover表示を追加

![Screenshot 2023-10-26 at 16 46 39](https://github.com/arayabrain/barebone-studio/assets/42664619/5e199e70-1449-4aae-9606-7b46cf46d83e)
