### PR TITLE
improve reproduce

### DIFF
--- a/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
+++ b/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
@@ -15,6 +15,7 @@ import {
 import IconButton from "@mui/material/IconButton"
 
 import { ExperimentUidContext } from "components/Workspace/Experiment/ExperimentTable"
+import { selectExperimentName } from "store/slice/Experiments/ExperimentsSelectors"
 import { reset } from "store/slice/VisualizeItem/VisualizeItemSlice"
 import { reproduceWorkflow } from "store/slice/Workflow/WorkflowActions"
 import { selectCurrentWorkspaceId } from "store/slice/Workspace/WorkspaceSelector"
@@ -48,6 +49,7 @@ const ConfirmReprodceDialog = memo(function ConfirmReprodceDialog({
   const dispatch: AppDispatch = useDispatch()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const uid = useContext(ExperimentUidContext)
+  const workflowName = useSelector(selectExperimentName(uid))
   const { enqueueSnackbar } = useSnackbar()
 
   const handleClose = () => {
@@ -74,10 +76,8 @@ const ConfirmReprodceDialog = memo(function ConfirmReprodceDialog({
       <DialogTitle>Confirm reproduce workflow</DialogTitle>
       <DialogContent>
         <Typography>
-          Are you sure you want to reproduce workflow: {uid}?
-        </Typography>
-        <Typography>
-          Existing workflow in workflow window will be replaced.
+          Reproduce <span style={{ fontWeight: "bold" }}>{workflowName}</span> (
+          {uid})?
         </Typography>
       </DialogContent>
       <DialogActions>

--- a/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
+++ b/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
@@ -1,9 +1,17 @@
-import { memo, useContext } from "react"
+import { Dispatch, memo, SetStateAction, useContext, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import { useSnackbar } from "notistack"
 
 import ReplyIcon from "@mui/icons-material/Reply"
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 
 import { ExperimentUidContext } from "components/Workspace/Experiment/ExperimentTable"
@@ -13,10 +21,38 @@ import { selectCurrentWorkspaceId } from "store/slice/Workspace/WorkspaceSelecto
 import { AppDispatch } from "store/store"
 
 export const ReproduceButton = memo(function ReproduceButton() {
+  const [open, setOpen] = useState(false)
+  const openDialog = () => {
+    setOpen(true)
+  }
+
+  return (
+    <>
+      <IconButton onClick={openDialog}>
+        <ReplyIcon />
+      </IconButton>
+      <ConfirmReprodceDialog open={open} setOpen={setOpen} />
+    </>
+  )
+})
+
+interface ConfirmReprodceDialogProps {
+  open: boolean
+  setOpen: Dispatch<SetStateAction<boolean>>
+}
+
+const ConfirmReprodceDialog = memo(function ConfirmReprodceDialog({
+  open,
+  setOpen,
+}: ConfirmReprodceDialogProps) {
   const dispatch: AppDispatch = useDispatch()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const uid = useContext(ExperimentUidContext)
   const { enqueueSnackbar } = useSnackbar()
+
+  const handleClose = () => {
+    setOpen(false)
+  }
 
   const onClick = () => {
     if (workspaceId) {
@@ -34,8 +70,24 @@ export const ReproduceButton = memo(function ReproduceButton() {
     }
   }
   return (
-    <IconButton onClick={onClick}>
-      <ReplyIcon />
-    </IconButton>
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Confirm reproduce workflow</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Are you sure you want to reproduce workflow: {uid}?
+        </Typography>
+        <Typography>
+          Existing workflow in workflow window will be replaced.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={onClick}>
+          Reproduce
+        </Button>
+      </DialogActions>
+    </Dialog>
   )
 })

--- a/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
+++ b/frontend/src/store/slice/Workspace/WorkspaceSlice.ts
@@ -49,6 +49,7 @@ export const workspaceSlice = createSlice({
     builder
       .addCase(reproduceWorkflow.fulfilled, (state, action) => {
         state.currentWorkspace.workspaceId = action.meta.arg.workspaceId
+        state.currentWorkspace.selectedTab = 0
       })
       .addCase(getWorkspace.fulfilled, (state, action) => {
         state.currentWorkspace.workspaceId = action.payload.id


### PR DESCRIPTION
reproduceボタンクリック時に確認のダイアログを追加

<img width="486" alt="Screenshot 2023-10-26 at 17 15 44" src="https://github.com/arayabrain/barebone-studio/assets/42664619/141ed28c-fda6-4252-8c2d-8c8bb22b2288">

reproduce実行後、workflow画面に自動的に遷移するよう調整