### PR TITLE
fix multiple run

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/Buttons/RunButtons.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/RunButtons.tsx
@@ -52,6 +52,8 @@ export const RunButtons = memo(function RunButtons(
   const runBtnOption = useSelector(selectPipelineRunBtn)
   const isStartedSuccess = useSelector(selectPipelineIsStartedSuccess)
 
+  const sendingRunRequest = useRef(false)
+
   const [dialogOpen, setDialogOpen] = useState(false)
   const { enqueueSnackbar } = useSnackbar()
   const handleClick = () => {
@@ -70,12 +72,22 @@ export const RunButtons = memo(function RunButtons(
       if (runBtnOption === RUN_BTN_OPTIONS.RUN_NEW) {
         setDialogOpen(true)
       } else {
+        if (sendingRunRequest.current) return
+        sendingRunRequest.current = true
         handleRunPipelineByUid()
+        setTimeout(() => {
+          sendingRunRequest.current = false
+        }, 3000)
       }
     }
   }
   const onClickDialogRun = (name: string) => {
+    if (sendingRunRequest.current) return
+    sendingRunRequest.current = true
     handleRunPipeline(name)
+    setTimeout(() => {
+      sendingRunRequest.current = false
+    }, 3000)
     setDialogOpen(false)
   }
   const onClickCancel = () => {

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -1,3 +1,9 @@
+import shutil
+
+from studio.app.common.core.utils.filepath_creater import (
+    create_directory,
+    join_filepath,
+)
 from studio.app.common.dataclass import ImageData
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass import RoiData
@@ -82,5 +88,12 @@ def caiman_mc(
         "rois": RoiData(rois, output_dir=output_dir, file_name="rois"),
         "nwbfile": nwbfile,
     }
+
+    # Clean up temporary files
+    mmap_output_dir = join_filepath([output_dir, "mmap"])
+    create_directory(mmap_output_dir)
+    for mmap_file in mc.mmap_file:
+        shutil.move(mmap_file, mmap_output_dir)
+    shutil.move(fname_new, mmap_output_dir)
 
     return info

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -32,7 +32,7 @@ def caiman_mc(
 
     # memory mapping
     fname_new = save_memmap(
-        mc.mmap_file, base_name="memmap_", order="C", border_to_0=border_to_0
+        mc.mmap_file, base_name=function_id, order="C", border_to_0=border_to_0
     )
 
     stop_server(dview=dview)


### PR DESCRIPTION
複数Workflow同時実行時のエラー解消の一環として、以下の対応を実施

- caiman_mcのmemmapファイルのprefixにfunction_idを使用してユニーク化
  - https://github.com/arayabrain/optinist-for-server/pull/191 と同等の対応ですが、uuidではなくfunction_idを使用しています
- RUN ALL, RUNボタンの連打防止
  - useRefでのフラグ管理とフラグ更新に3秒のwaitで対応（時間等は根拠が明確ではないので調整の余地あり）
  - 連打によって`The name all is already used by another rule`の`CreateRuleException`が発生するため
    - 複数画面で検証している中で、ボタンクリックの際に画面へのフォーカスとボタンクリックで2回クリックが必要で、その過程で必要以上に連打してしまった際に気付きました
