### PR TITLE
fix RoiResponseSeries data's shape

### DIFF
--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -230,7 +230,7 @@ def caiman_cnmf(
                 "table_name": "ROIs",
                 "region": list(range(n_rois + n_bg)),
                 "name": "Fluorescence",
-                "data": fluorescence,
+                "data": fluorescence.T,
                 "unit": "lumens",
             }
         }


### PR DESCRIPTION
## 概要
caiman_cnmfのNWBファイル保存に関して、以下の問題を解消

- コンソール上で以下のwarning
    ```
    UserWarning: RoiResponseSeries 'Fluorescence': The second dimension of data does not match the length of rois, but instead the first does. Data is oriented incorrectly and should be transposed.
    ```
- NWBファイルをnwbinspectorでチェックした際に以下のCRITICALエラー
    ```
    0  CRITICAL
    ===========
    
    0.0  caiman_cnmf.nwb: check_roi_response_series_dims - 'RoiResponseSeries' object at location '/processing/ophys/caiman_cnmf_5ptm4hgue5/Fluorescence'
           Message: The second dimension of data does not match the length of rois, but instead the first does. Data is oriented incorrectly and should be transposed.
    
    0.1  caiman_cnmf.nwb: check_data_orientation - 'RoiResponseSeries' object at location '/processing/ophys/caiman_cnmf_5ptm4hgue5/Fluorescence'
           Message: Data may be in the wrong orientation. Time should be in the first dimension, and is usually the longest dimension. Here, another dimension is longer.
    ```

## 原因
- fluorescence (RoiResponseSeries)にはcaimanの場合estimates.C.Tを格納する
  - https://github.com/flatironinstitute/CaImAn/blob/9b0b79ca61f20ce93259b9833e1fe18e26d4e086/caiman/source_extraction/cnmf/estimates.py#L1696-L1697
  - 一方でoptinistではtransposeしていなかった
    - https://github.com/arayabrain/barebone-studio/blob/79b3be7e003e3898d50b40f5500841378a2c6001/studio/app/optinist/wrappers/caiman/cnmf.py#L216-L237
  - なお、edit_ROIの際のNWB保存ではtransposeされている
    - https://github.com/arayabrain/barebone-studio/blob/79b3be7e003e3898d50b40f5500841378a2c6001/studio/app/optinist/core/edit_ROI/wrappers/caiman_edit_roi/utils.py#L32-L42