### PR TITLE
remove large file check on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,6 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-added-large-files
-        exclude: frontend/build
     -   id: check-toml
     -   id: check-yaml
         args:


### PR DESCRIPTION
sample-dataなど大きいファイルをリポジトリで管理するケースが多いため、当面はpre-commitから除外