### PR TITLE
use common styled dialog ui

### DIFF
--- a/frontend/src/components/Workspace/Experiment/Button/DeleteButton.tsx
+++ b/frontend/src/components/Workspace/Experiment/Button/DeleteButton.tsx
@@ -2,12 +2,9 @@ import { memo, useContext, useState } from "react"
 import { useSelector, useDispatch } from "react-redux"
 
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline"
-import Button from "@mui/material/Button"
-import Dialog from "@mui/material/Dialog"
-import DialogActions from "@mui/material/DialogActions"
-import DialogTitle from "@mui/material/DialogTitle"
 import IconButton from "@mui/material/IconButton"
 
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { ExperimentUidContext } from "components/Workspace/Experiment/ExperimentTable"
 import { deleteExperimentByUid } from "store/slice/Experiments/ExperimentsActions"
 import { selectExperimentName } from "store/slice/Experiments/ExperimentsSelectors"
@@ -30,34 +27,28 @@ export const DeleteButton = memo(function DeleteButton() {
   const name = useSelector(selectExperimentName(uid))
   const [open, setOpen] = useState(false)
 
-  const onClickOpen = () => {
+  const openDialog = () => {
     setOpen(true)
   }
-  const onClickCancel = () => {
-    setOpen(false)
-  }
-  const onClickOk = () => {
-    setOpen(false)
+  const handleDelete = () => {
     dispatch(deleteExperimentByUid(uid))
     uid === currentPipelineUid && dispatch(clearCurrentPipeline())
   }
 
   return (
     <>
-      <IconButton onClick={onClickOpen} disabled={isRunning} color="error">
+      <IconButton onClick={openDialog} disabled={isRunning} color="error">
         <DeleteOutlineIcon />
       </IconButton>
-      <Dialog open={open} onClose={onClickCancel}>
-        <DialogTitle>Are you sure you want to delete {name}?</DialogTitle>
-        <DialogActions>
-          <Button onClick={onClickCancel} variant="outlined">
-            Cancel
-          </Button>
-          <Button onClick={onClickOk} variant="contained" autoFocus>
-            OK
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={open}
+        setOpen={setOpen}
+        onConfirm={handleDelete}
+        title="Delete record?"
+        content={`${name} (${uid})`}
+        confirmLabel="delete"
+        iconType="warning"
+      />
     </>
   )
 })

--- a/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
+++ b/frontend/src/components/Workspace/Experiment/Button/ReproduceButton.tsx
@@ -1,19 +1,12 @@
-import { Dispatch, memo, SetStateAction, useContext, useState } from "react"
+import { memo, useContext, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import { useSnackbar } from "notistack"
 
 import ReplyIcon from "@mui/icons-material/Reply"
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Typography,
-} from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { ExperimentUidContext } from "components/Workspace/Experiment/ExperimentTable"
 import { selectExperimentName } from "store/slice/Experiments/ExperimentsSelectors"
 import { reset } from "store/slice/VisualizeItem/VisualizeItemSlice"
@@ -27,36 +20,12 @@ export const ReproduceButton = memo(function ReproduceButton() {
     setOpen(true)
   }
 
-  return (
-    <>
-      <IconButton onClick={openDialog}>
-        <ReplyIcon />
-      </IconButton>
-      <ConfirmReprodceDialog open={open} setOpen={setOpen} />
-    </>
-  )
-})
-
-interface ConfirmReprodceDialogProps {
-  open: boolean
-  setOpen: Dispatch<SetStateAction<boolean>>
-}
-
-const ConfirmReprodceDialog = memo(function ConfirmReprodceDialog({
-  open,
-  setOpen,
-}: ConfirmReprodceDialogProps) {
   const dispatch: AppDispatch = useDispatch()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const uid = useContext(ExperimentUidContext)
   const workflowName = useSelector(selectExperimentName(uid))
   const { enqueueSnackbar } = useSnackbar()
-
-  const handleClose = () => {
-    setOpen(false)
-  }
-
-  const onClick = () => {
+  const handleOk = () => {
     if (workspaceId) {
       dispatch(reproduceWorkflow({ workspaceId, uid }))
         .unwrap()
@@ -71,24 +40,20 @@ const ConfirmReprodceDialog = memo(function ConfirmReprodceDialog({
       enqueueSnackbar("Workspace id is missing", { variant: "error" })
     }
   }
-
   return (
-    <Dialog open={open} onClose={handleClose}>
-      <DialogTitle>Confirm reproduce workflow</DialogTitle>
-      <DialogContent>
-        <Typography>
-          Reproduce <span style={{ fontWeight: "bold" }}>{workflowName}</span> (
-          {uid})?
-        </Typography>
-      </DialogContent>
-      <DialogActions>
-        <Button variant="outlined" onClick={handleClose}>
-          Cancel
-        </Button>
-        <Button variant="contained" onClick={onClick}>
-          Reproduce
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <>
+      <IconButton onClick={openDialog}>
+        <ReplyIcon />
+      </IconButton>
+      <ConfirmDialog
+        open={open}
+        setOpen={setOpen}
+        onConfirm={handleOk}
+        title="Reproduce workflow?"
+        content={`${workflowName} (${uid})`}
+        confirmLabel="reproduce"
+        iconType="info"
+      />
+    </>
   )
 })

--- a/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
+++ b/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
@@ -21,9 +21,6 @@ import AlertTitle from "@mui/material/AlertTitle"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import Checkbox from "@mui/material/Checkbox"
-import Dialog from "@mui/material/Dialog"
-import DialogActions from "@mui/material/DialogActions"
-import DialogTitle from "@mui/material/DialogTitle"
 import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
 import { styled } from "@mui/material/styles"
@@ -38,6 +35,7 @@ import TableSortLabel from "@mui/material/TableSortLabel"
 import Typography from "@mui/material/Typography"
 
 import { renameExperiment } from "api/experiments/Experiments"
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { useLocalStorage } from "components/utils/LocalStorageUtil"
 import { DeleteButton } from "components/Workspace/Experiment/Button/DeleteButton"
 import {
@@ -150,9 +148,6 @@ const TableImple = memo(function TableImple() {
   const onClickDelete = () => {
     setOpen(true)
   }
-  const onClickCancel = () => {
-    setOpen(false)
-  }
   const onClickOk = () => {
     dispatch(deleteExperimentByList(checkedList))
     checkedList.filter((v) => v === currentPipelineUid).length > 0 &&
@@ -225,17 +220,23 @@ const TableImple = memo(function TableImple() {
           </Button>
         )}
       </Box>
-      <Dialog open={open} onClose={onClickCancel}>
-        <DialogTitle>Are you sure you want to delete?</DialogTitle>
-        <DialogActions>
-          <Button onClick={onClickCancel} variant="outlined">
-            Cancel
-          </Button>
-          <Button onClick={onClickOk} variant="contained" autoFocus>
-            OK
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <ConfirmDialog
+        open={open}
+        setOpen={setOpen}
+        onConfirm={onClickOk}
+        title="Delete records?"
+        content={
+          <>
+            {checkedList.map((uid) => (
+              <Typography key={uid}>
+                ・{experimentList[uid].name} ({uid})
+              </Typography>
+            ))}
+          </>
+        }
+        iconType="warning"
+        confirmLabel="delete"
+      />
       <Paper
         elevation={0}
         variant="outlined"

--- a/frontend/src/components/Workspace/FlowChart/Buttons/ClearWorkflow.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/ClearWorkflow.tsx
@@ -1,23 +1,21 @@
-import { Dispatch, memo, SetStateAction, useState } from "react"
+import { memo, useState } from "react"
 import { useDispatch } from "react-redux"
 
 import { AddToPhotos } from "@mui/icons-material"
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Tooltip,
-} from "@mui/material"
+import { IconButton, Tooltip } from "@mui/material"
 
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
 
 export const CreateWorkflowButton = memo(function CreateWorkflowButton() {
   const [open, setOpen] = useState(false)
+  const dispatch = useDispatch()
+
   const openDialog = () => {
     setOpen(true)
+  }
+  const onConfirm = () => {
+    dispatch(clearFlowElements())
   }
 
   return (
@@ -27,45 +25,15 @@ export const CreateWorkflowButton = memo(function CreateWorkflowButton() {
           <AddToPhotos color="primary" />
         </IconButton>
       </Tooltip>
-      <ConfirmClearDialog open={open} setOpen={setOpen} />
+      <ConfirmDialog
+        open={open}
+        setOpen={setOpen}
+        onConfirm={onConfirm}
+        title="Create new workflow?"
+        content={`Current workflow will be cleared.
+        If the workflow has already been run, the record will NOT be deleted.`}
+        iconType="warning"
+      />
     </>
-  )
-})
-
-interface ConfirmClearDialogProps {
-  open: boolean
-  setOpen: Dispatch<SetStateAction<boolean>>
-}
-
-const ConfirmClearDialog = memo(function ConfirmClearDialog({
-  open,
-  setOpen,
-}: ConfirmClearDialogProps) {
-  const dispatch = useDispatch()
-  const handleClose = () => {
-    setOpen(false)
-  }
-  const handleClear = () => {
-    dispatch(clearFlowElements())
-    setOpen(false)
-  }
-
-  return (
-    <Dialog open={open} onClose={handleClose}>
-      <DialogTitle>Confirm create new workflow</DialogTitle>
-      <DialogContent>
-        To create new workflow, current workflow will be cleared.
-        The record will NOT be deleted if it has already been run.
-        Are you sure?
-      </DialogContent>
-      <DialogActions>
-        <Button variant="outlined" onClick={handleClose}>
-          Cancel
-        </Button>
-        <Button variant="contained" onClick={handleClear}>
-          OK
-        </Button>
-      </DialogActions>
-    </Dialog>
   )
 })

--- a/frontend/src/components/Workspace/FlowChart/Buttons/CreateWorkflow.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/CreateWorkflow.tsx
@@ -32,7 +32,7 @@ export const CreateWorkflowButton = memo(function CreateWorkflowButton() {
         title="Create new workflow?"
         content={`Current workflow will be cleared.
         If the workflow has already been run, the record will NOT be deleted.`}
-        iconType="warning"
+        iconType="info"
       />
     </>
   )

--- a/frontend/src/components/Workspace/FlowChart/Buttons/RunButtons.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/RunButtons.tsx
@@ -222,7 +222,7 @@ const RunDialog = memo(function RunDialog({
   }
   return (
     <Dialog open={open} onClose={handleClose}>
-      <DialogTitle>Name and run flowchart</DialogTitle>
+      <DialogTitle>Name and run workflow</DialogTitle>
       <DialogContent>
         <TextField
           label="name"

--- a/frontend/src/components/Workspace/FlowChart/Dialog/ClearWorkflowIdDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/ClearWorkflowIdDialog.tsx
@@ -1,48 +1,25 @@
 import { memo } from "react"
 
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Typography,
-} from "@mui/material"
-
-type ClearWorkflowIdDialogProps = {
-  open: boolean
-  handleOk: () => void
-  handleCancel: () => void
-}
+  ConfirmDialog,
+  ConfirmDialogProps,
+} from "components/common/ConfirmDialog"
 
 export const ClearWorkflowIdDialog = memo(function ClearWorkflowIdDialog({
   open,
-  handleOk,
-  handleCancel,
-}: ClearWorkflowIdDialogProps) {
+  onConfirm,
+  onCancel,
+}: Pick<ConfirmDialogProps, "open" | "onConfirm" | "onCancel">) {
   return (
-    <Dialog open={open} onClose={handleCancel} fullWidth>
-      <DialogTitle>Confirm running as new workflow</DialogTitle>
-      <DialogContent>
-        <Typography>
-          {"With this operation, all algorithms should be run again."}
-        </Typography>
-        <Typography>
-          {
-            "So, this workflow will be run as new workflow with new ID (RUN ALL)."
-          }
-        </Typography>
-        <Typography>{"Existing nodes are kept as they are."}</Typography>
-        <Typography>{"Are you sure?"}</Typography>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleCancel} variant="outlined">
-          cancel
-        </Button>
-        <Button onClick={handleOk} variant="contained">
-          ok
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <ConfirmDialog
+      open={open}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      title="Change this parameter?"
+      content={`Changing this parameter may affect whole workflow.
+      So, this workflow will be run as new workflow with new ID (RUN ALL).
+      Existing nodes are kept as they are.`}
+      iconType="warning"
+    />
   )
 })

--- a/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
@@ -106,12 +106,12 @@ const FlowChart = memo(function FlowChart(props: UseRunPipelineReturnType) {
             {dialogClearWorkflowId.open && (
               <ClearWorkflowIdDialog
                 open={dialogClearWorkflowId.open}
-                handleOk={() => {
+                onConfirm={() => {
                   dispatch(clearCurrentPipeline())
                   dialogClearWorkflowId.handleOk()
                   setDialogClearWorkflowId(initClearWorkflow)
                 }}
-                handleCancel={() => {
+                onCancel={() => {
                   dialogClearWorkflowId.handleCancel()
                   setDialogClearWorkflowId(initClearWorkflow)
                 }}

--- a/frontend/src/components/Workspace/ToolBar.tsx
+++ b/frontend/src/components/Workspace/ToolBar.tsx
@@ -6,7 +6,7 @@ import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos"
 import { Button } from "@mui/material"
 import Box from "@mui/material/Box"
 
-import { CreateWorkflowButton } from "components/Workspace/FlowChart/Buttons/ClearWorkflow"
+import { CreateWorkflowButton } from "components/Workspace/FlowChart/Buttons/CreateWorkflow"
 import { ImportWorkflowConfigButton } from "components/Workspace/FlowChart/Buttons/ImportWorkflowConfig"
 import { NWBSettingButton } from "components/Workspace/FlowChart/Buttons/NWB"
 import { RunButtons } from "components/Workspace/FlowChart/Buttons/RunButtons"

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,94 @@
+import { Dispatch, FC, SetStateAction, JSX } from "react"
+
+import { HelpOutline } from "@mui/icons-material"
+import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded"
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  DialogTitle,
+  Grid,
+} from "@mui/material"
+
+export interface ConfirmDialogProps {
+  open: boolean
+  setOpen?: Dispatch<SetStateAction<boolean>>
+  onCancel?: () => void
+  onConfirm?: () => void
+  title?: string
+  content: string | JSX.Element
+  confirmLabel?: string
+  iconType?: "warning" | "info"
+}
+
+export const ConfirmDialog: FC<ConfirmDialogProps> = ({
+  open,
+  setOpen,
+  onCancel,
+  onConfirm,
+  title,
+  content,
+  confirmLabel,
+  iconType,
+}) => {
+  const handleClose = () => {
+    onCancel && onCancel()
+    setOpen && setOpen(false)
+  }
+
+  const handleConfirm = () => {
+    onConfirm && onConfirm()
+    setOpen && setOpen(false)
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      sx={{
+        "& .MuiDialog-container": {
+          "& .MuiPaper-root": {
+            minWidth: "300px",
+          },
+        },
+      }}
+    >
+      {title && <DialogTitle>{title}</DialogTitle>}
+      <DialogContent>
+        {iconType ? (
+          <DialogContentWithIcon content={content} iconType={iconType} />
+        ) : (
+          content
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={handleClose}>
+          cancel
+        </Button>
+        <Button variant="contained" onClick={handleConfirm}>
+          {confirmLabel ?? "ok"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+const DialogContentWithIcon: FC<
+  Pick<ConfirmDialogProps, "content" | "iconType">
+> = ({ content, iconType }) => {
+  return (
+    <Grid container alignItems="center">
+      <Grid item xs={2} container justifyContent="center">
+        {iconType === "warning" ? (
+          <WarningAmberRoundedIcon color="warning" fontSize="large" />
+        ) : (
+          <HelpOutline color="info" fontSize="large" />
+        )}
+      </Grid>
+      <Grid item xs={10}>
+        {content}
+      </Grid>
+    </Grid>
+  )
+}

--- a/frontend/src/pages/AccountManager/index.tsx
+++ b/frontend/src/pages/AccountManager/index.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
   Input,
   styled,
+  Typography,
 } from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 import { SelectChangeEvent } from "@mui/material/Select"
@@ -39,6 +40,7 @@ import { isRejectedWithValue } from "@reduxjs/toolkit"
 
 import { ROLE } from "@types"
 import { AddUserDTO, UserDTO } from "api/users/UsersApiDTO"
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import InputError from "components/common/InputError"
 import Loading from "components/common/Loading"
 import PaginationCustom from "components/common/PaginationCustom"
@@ -70,13 +72,6 @@ type ModalComponentProps = {
   dataEdit?: {
     [key: string]: string
   }
-}
-
-type PopupType = {
-  open: boolean
-  handleClose: () => void
-  handleOkDel: () => void
-  name?: string
 }
 
 const initState = {
@@ -273,26 +268,6 @@ const ModalComponent = ({
       </ModalBox>
       {isDisabled ? <Loading /> : null}
     </Modal>
-  )
-}
-
-const PopupDelete = ({ open, handleClose, handleOkDel, name }: PopupType) => {
-  if (!open) return null
-
-  return (
-    <Box>
-      <Dialog open={open} onClose={handleClose} sx={{ margin: 0 }}>
-        <DialogTitle>{`Do you want delete User "${name}"?`}</DialogTitle>
-        <DialogActions>
-          <Button variant="outlined" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button variant="contained" onClick={handleOkDel}>
-            Ok
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
   )
 }
 
@@ -716,21 +691,21 @@ const AccountManager = () => {
         return (
           <>
             <IconButton
-              sx={{ color: "red" }}
               onClick={() =>
                 handleEdit({ id, role_id: role, name, email } as UserFormDTO)
               }
             >
-              <EditIcon sx={{ color: "black" }} />
+              <EditIcon />
             </IconButton>
             {!(params.row?.id === user?.id) ? (
               <IconButton
                 sx={{ ml: 1.25 }}
+                color="error"
                 onClick={() =>
                   handleOpenPopupDel(params.row?.id, params.row?.name)
                 }
               >
-                <DeleteIcon sx={{ color: "red" }} />
+                <DeleteIcon />
               </IconButton>
             ) : null}
           </>
@@ -780,11 +755,19 @@ const AccountManager = () => {
           limit={Number(limit)}
         />
       ) : null}
-      <PopupDelete
+      <ConfirmDialog
         open={openDel?.open || false}
-        handleClose={handleClosePopupDel}
-        handleOkDel={handleOkDel}
-        name={openDel?.name}
+        onCancel={handleClosePopupDel}
+        onConfirm={handleOkDel}
+        title="Delete user?"
+        content={
+          <>
+            <Typography>ID: {openDel?.id}</Typography>
+            <Typography>Name: {openDel?.name}</Typography>
+          </>
+        }
+        confirmLabel="delete"
+        iconType="warning"
       />
       {openModal ? (
         <ModalComponent

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -18,6 +18,8 @@ import {
   DialogActions,
   Input,
   Tooltip,
+  Typography,
+  IconButton,
 } from "@mui/material"
 import {
   GridEventListener,
@@ -31,6 +33,7 @@ import {
 import { isRejectedWithValue } from "@reduxjs/toolkit"
 
 import { UserDTO } from "api/users/UsersApiDTO"
+import { ConfirmDialog } from "components/common/ConfirmDialog"
 import Loading from "components/common/Loading"
 import PaginationCustom from "components/common/PaginationCustom"
 import PopupShare from "components/Workspace/PopupShare"
@@ -115,9 +118,9 @@ const columns = (
             </span>
           </Tooltip>
           {isMine(user, row?.user?.id) ? (
-            <ButtonIcon onClick={() => onEdit?.(row.id)}>
-              <EditIcon style={{ fontSize: 16 }} />
-            </ButtonIcon>
+            <IconButton onClick={() => onEdit?.(row.id)} size="small">
+              <EditIcon fontSize="small" />
+            </IconButton>
           ) : null}
         </Box>
       )
@@ -209,9 +212,12 @@ const columns = (
     sortable: false, // todo enable when api complete
     renderCell: (params: GridRenderCellParams<GridValidRowModel>) =>
       isMine(user, params.row?.user?.id) ? (
-        <ButtonIcon onClick={() => handleOpenPopupShare(params.row.id)}>
-          <GroupsIcon color={params.row.shared_count ? "primary" : "inherit"} />
-        </ButtonIcon>
+        <IconButton
+          onClick={() => handleOpenPopupShare(params.row.id)}
+          color={params.row.shared_count ? "primary" : "default"}
+        >
+          <GroupsIcon />
+        </IconButton>
       ) : null,
   },
   {
@@ -223,11 +229,12 @@ const columns = (
     sortable: false, // todo enable when api complete
     renderCell: (params: GridRenderCellParams<GridValidRowModel>) =>
       isMine(user, params.row?.user?.id) ? (
-        <ButtonIcon
+        <IconButton
           onClick={() => handleOpenPopupDel(params.row.id, params.row.name)}
+          color="error"
         >
-          <DeleteIcon color="error" />
-        </ButtonIcon>
+          <DeleteIcon />
+        </IconButton>
       ) : null,
   },
 ]
@@ -264,33 +271,6 @@ const PopupNew = ({
             Cancel
           </Button>
           <Button variant={"contained"} onClick={handleOkNew}>
-            Ok
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
-  )
-}
-
-const PopupDelete = ({
-  open,
-  handleClose,
-  handleOkDel,
-  nameWorkspace,
-}: PopupType) => {
-  if (!open) return null
-
-  return (
-    <Box>
-      <Dialog open={open} onClose={handleClose} sx={{ margin: 0 }}>
-        <DialogTitle>
-          {`Do you want delete Workspace "${nameWorkspace}"?`}
-        </DialogTitle>
-        <DialogActions>
-          <Button variant={"outlined"} onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button variant={"contained"} onClick={handleOkDel}>
             Ok
           </Button>
         </DialogActions>
@@ -563,11 +543,19 @@ const Workspaces = () => {
           id={open.shareId}
         />
       ) : null}
-      <PopupDelete
+      <ConfirmDialog
         open={open.del}
-        handleClose={handleClosePopupDel}
-        handleOkDel={handleOkDel}
-        nameWorkspace={workspaceDel?.name}
+        onCancel={handleClosePopupDel}
+        onConfirm={handleOkDel}
+        title={"Delete Workspace?"}
+        content={
+          <>
+            <Typography>ID: {workspaceDel?.id}</Typography>
+            <Typography>Name: {workspaceDel?.name}</Typography>
+          </>
+        }
+        iconType="warning"
+        confirmLabel="delete"
       />
       <PopupNew
         open={open.new}
@@ -590,23 +578,5 @@ const WorkspacesWrapper = styled(Box)(({ theme }) => ({
 }))
 
 const WorkspacesTitle = styled("h1")(() => ({}))
-
-const ButtonIcon = styled("button")(() => ({
-  minWidth: "32px",
-  minHeight: "32px",
-  width: "32px",
-  height: "32px",
-  color: "#444",
-  border: "none",
-  borderRadius: "50%",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  cursor: "pointer",
-  background: "transparent",
-  "&:hover": {
-    background: "rgb(239 239 239)",
-  },
-}))
 
 export default Workspaces


### PR DESCRIPTION
Closes #162 

Confirm用のDialogの汎用コンポーネントを作成。
また、multiuserモードのユーザー登録Dialogなど、機能が複雑なDialogは適用対象外。

DialogTitle, DialogContent, DialogActionsをベースとして使用
- titleについてはoptional
- actionsのOKボタンはデフォルトではOKだが、labelConfirm属性でラベルを変更可能
- iconType属性で以下のようにwarning, infoのアイコン表示も実装
  ![Screenshot 2023-11-30 at 18 08 55](https://github.com/arayabrain/barebone-studio/assets/42664619/95ad442a-ead5-4825-b8d1-0b366551679c)
  ![Screenshot 2023-11-30 at 18 09 04](https://github.com/arayabrain/barebone-studio/assets/42664619/f0895c18-a2ba-4251-93f6-4c0f41faadbc)

本実装にあたり、Dialogの文言なども簡易化した。
