### PR TITLE
add nodeId copy button

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/NodeContainer.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/NodeContainer.tsx
@@ -1,6 +1,9 @@
 import { FC, ReactNode } from "react"
 
-import { Box, Typography } from "@mui/material"
+import { useSnackbar } from "notistack"
+
+import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded"
+import { Box, IconButton, Tooltip, Typography } from "@mui/material"
 import { grey } from "@mui/material/colors"
 import { alpha, useTheme } from "@mui/material/styles"
 
@@ -11,6 +14,12 @@ export const NodeContainer: FC<{
   updated?: boolean
 }> = ({ children, nodeId, selected, updated }) => {
   const theme = useTheme()
+  const { enqueueSnackbar } = useSnackbar()
+
+  const handleNodeIdClick = () => {
+    navigator.clipboard.writeText(nodeId)
+    enqueueSnackbar("Node ID copied to clipboard", { variant: "success" })
+  }
 
   let backgroundColor
   if (updated) {
@@ -36,18 +45,32 @@ export const NodeContainer: FC<{
       }}
     >
       <Box margin={1}>{children}</Box>
-      <Typography
-        marginX={1}
-        marginTop="auto"
-        marginBottom="4px"
-        color={grey[600]}
-        fontSize={13}
-        paragraph
-        variant="body2"
-        sx={{ overflowWrap: "break-word" }}
+      <div
+        style={{
+          marginLeft: 8,
+          marginRight: 8,
+          marginTop: "auto",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+        }}
       >
-        {nodeId}
-      </Typography>
+        <Typography
+          color={grey[600]}
+          fontSize={13}
+          paragraph
+          variant="body2"
+          marginBottom={0}
+          sx={{ overflowWrap: "break-word" }}
+        >
+          {nodeId}
+        </Typography>
+        <Tooltip title="copy node ID to clipboard">
+          <IconButton onClick={handleNodeIdClick} size="small">
+            <ContentCopyRoundedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/NodeContainer.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/NodeContainer.tsx
@@ -1,9 +1,6 @@
 import { FC, ReactNode } from "react"
 
-import { useSnackbar } from "notistack"
-
-import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded"
-import { Box, IconButton, Tooltip, Typography } from "@mui/material"
+import { Box, Tooltip, Typography } from "@mui/material"
 import { grey } from "@mui/material/colors"
 import { alpha, useTheme } from "@mui/material/styles"
 
@@ -14,12 +11,6 @@ export const NodeContainer: FC<{
   updated?: boolean
 }> = ({ children, nodeId, selected, updated }) => {
   const theme = useTheme()
-  const { enqueueSnackbar } = useSnackbar()
-
-  const handleNodeIdClick = () => {
-    navigator.clipboard.writeText(nodeId)
-    enqueueSnackbar("Node ID copied to clipboard", { variant: "success" })
-  }
 
   let backgroundColor
   if (updated) {
@@ -45,32 +36,19 @@ export const NodeContainer: FC<{
       }}
     >
       <Box margin={1}>{children}</Box>
-      <div
-        style={{
-          marginLeft: 8,
-          marginRight: 8,
-          marginTop: "auto",
-          display: "flex",
-          flexDirection: "row",
-          alignItems: "center",
-        }}
-      >
+      <Tooltip title={nodeId} placement="bottom-start">
         <Typography
+          marginX={1}
+          marginTop="auto"
+          marginBottom="4px"
           color={grey[600]}
-          fontSize={13}
-          paragraph
+          fontSize={14}
           variant="body2"
-          marginBottom={0}
-          sx={{ overflowWrap: "break-word" }}
+          overflow="ellipsis"
         >
           {nodeId}
         </Typography>
-        <Tooltip title="copy node ID to clipboard">
-          <IconButton onClick={handleNodeIdClick} size="small">
-            <ContentCopyRoundedIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </div>
+      </Tooltip>
     </div>
   )
 }


### PR DESCRIPTION
node idのコピーボタンを追加

<img width="731" alt="Screenshot 2023-12-01 at 15 59 35" src="https://github.com/arayabrain/barebone-studio/assets/42664619/f4cf8db0-b976-4024-9855-c11091c295bd">
