### PR TITLE
fix nwbfile data inheritance

### DIFF
--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -182,8 +182,8 @@ class NWBCreater:
 
     @classmethod
     def roi(cls, nwbfile, function_id, roi_list):
-        image_seg = nwbfile.processing["ophys"].data_interfaces["ImageSegmentation"]
         nwbfile = cls.add_plane_segmentation(nwbfile, function_id)
+        image_seg = nwbfile.processing["ophys"].data_interfaces["ImageSegmentation"]
         plane_seg = image_seg.plane_segmentations[function_id]
 
         if roi_list:


### PR DESCRIPTION
## 概要
nwbfileのデータを前回のoutputから継承する際に、dictを上書きしてしまっている問題を解消
(tutorial作成作業中に発覚)

## 事象
以下のようなworkflowで、etaのように新規のinputノード(ここではcsv)が接続されていると、nwbfileオブジェクトが上書きされてそれまでのノードで蓄積していたデータが消失する。

結果として、nwbファイルの保存時に以下のようなエラーとなっていた。

```
Traceback (most recent call last):

  File "/Users/rei_hashimoto/GitHub/barebone-studio/studio/app/common/core/rules/runner.py", line 67, in run
    cls.save_all_nwb(path, output_info["nwbfile"])

  File "/Users/rei_hashimoto/GitHub/barebone-studio/studio/app/common/core/rules/runner.py", line 119, in save_all_nwb
    overwrite_nwbfile(save_path, nwbconfig)

  File "/Users/rei_hashimoto/GitHub/barebone-studio/studio/app/optinist/core/nwb/nwb_creater.py", line 406, in overwrite_nwbfile
    nwbfile = set_nwbconfig(old_nwbfile, config)

  File "/Users/rei_hashimoto/GitHub/barebone-studio/studio/app/optinist/core/nwb/nwb_creater.py", line 369, in set_nwbconfig
    nwbfile = NWBCreater.roi(

  File "/Users/rei_hashimoto/GitHub/barebone-studio/studio/app/optinist/core/nwb/nwb_creater.py", line 187, in roi
    plane_seg = image_seg.plane_segmentations[function_id]

  File "/Users/rei_hashimoto/GitHub/barebone-studio/.snakemake/conda/0653b182fc2f51a6454a28e58375ab0b_/lib/python3.8/site-packages/hdmf/utils.py", line 1034, in __getitem__
    return super().__getitem__(key)

KeyError: 'suite2p_roi_85d76n1n5n'
```

![Screenshot 2023-12-06 at 16 01 29](https://github.com/arayabrain/barebone-studio/assets/42664619/0e0869f8-a4c4-4778-9868-94587c8baa84)

## その他
snakemake上で実行されている処理のエラーについて、GUIでは最後の2行のみの出力となっていたが（おそらく表示を簡易にするため）、かえって調査が困難になるため全体を出力するように修正
また、console上にも同様の内容が表示されるようにした