### PR TITLE
Feature/suite2p image output

### DIFF
--- a/studio/app/optinist/wrappers/suite2p/registration.py
+++ b/studio/app/optinist/wrappers/suite2p/registration.py
@@ -27,7 +27,9 @@ def suite2p_registration(
     if ops.get("do_regmetrics", True) and ops["nframes"] >= 1500:
         ops = registration.get_pc_metrics(ops)
 
-    mv = io.BinaryFile(Lx=ops["Lx"], Ly=ops["Ly"], read_filename=ops["reg_file"]).data
+    mv = io.BinaryFile(
+        Lx=ops["Lx"], Ly=ops["Ly"], read_filename=ops["reg_file"]
+    ).data.copy()
 
     info = {
         "refImg": ImageData(ops["refImg"], output_dir=output_dir, file_name="refImg"),

--- a/studio/app/optinist/wrappers/suite2p/registration.py
+++ b/studio/app/optinist/wrappers/suite2p/registration.py
@@ -4,8 +4,8 @@ from studio.app.optinist.dataclass import Suite2pData
 
 def suite2p_registration(
     ops: Suite2pData, output_dir: str, params: dict = None, **kwargs
-) -> dict(ops=Suite2pData):
-    from suite2p import default_ops, registration
+) -> dict(ops=Suite2pData, mc_images=ImageData):
+    from suite2p import default_ops, io, registration
 
     function_id = output_dir.split("/")[-1]
     print("start suite2p registration:", function_id)
@@ -27,11 +27,14 @@ def suite2p_registration(
     if ops.get("do_regmetrics", True) and ops["nframes"] >= 1500:
         ops = registration.get_pc_metrics(ops)
 
+    mv = io.BinaryFile(Lx=ops["Lx"], Ly=ops["Ly"], read_filename=ops["reg_file"]).data
+
     info = {
         "refImg": ImageData(ops["refImg"], output_dir=output_dir, file_name="refImg"),
         "meanImgE": ImageData(
             ops["meanImgE"], output_dir=output_dir, file_name="meanImgE"
         ),
+        "mc_images": ImageData(mv, output_dir=output_dir, file_name="mc_images"),
         "ops": Suite2pData(ops, file_name="ops"),
     }
 


### PR DESCRIPTION
Closes #169 

- Suite2pのノードoutputとして、registrationが適用されたmovieをImageDataとして追加
- データはsuite2pで出力される`data.bin`が該当
- この実装により、suite2pでmotion_correct(registration)した画像に対してCaImAnでROI抽出をする、などが可能になる
  ![Screenshot 2023-12-11 at 20 49 33](https://github.com/arayabrain/barebone-studio/assets/42664619/398b0e69-74b6-4ee6-82a9-7ba49150d81d)


## 備考

- mc_imagesを再生して確認しようとした際に、以下2点の課題を認識
  - `.json`形式のデータの場合、VISUALIZEのstart/end indexを指定してloadしても指定のindexのデータが取得できない
    - 3次元のデータでjsonとして保存する場合、`:10`のindexの上限が設けられている
      - https://github.com/arayabrain/barebone-studio/blob/86a47c65ea83d7bcd8ab12cde68443d8cff79a91/studio/app/common/dataclass/utils.py#L6-L12
    - output/imagesのAPIでindex指定をかけても、`.json`の場合は無視されている
      - https://github.com/arayabrain/barebone-studio/blob/86a47c65ea83d7bcd8ab12cde68443d8cff79a91/studio/app/common/routers/outputs.py#L124-L138
  - これらの原因により、例えばmc_imagesのindexを0~100などにしてloadしても、10までのデータしか取得できないため、movieの再生がindex10で止まる