### PR TITLE
specify black version for github actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -37,3 +37,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
+        with:
+          version: "~= 23.11"


### PR DESCRIPTION
Python formatterのBlackによるGitHub Actionsがpre-releaseのversion(24)を参照してしまっているため、versionの上限を指定

![Screenshot 2023-12-12 at 16 53 53](https://github.com/arayabrain/barebone-studio/assets/42664619/f7b336ba-f703-40a6-be8f-f6c54701b81e)
