### PR TITLE
[#242] outputの動画のrange指定機能修正

### DIFF
--- a/studio/app/common/dataclass/image.py
+++ b/studio/app/common/dataclass/image.py
@@ -55,14 +55,27 @@ class ImageData(BaseData):
             return np.array(imageio.volread(self.path))
 
     def save_json(self, json_dir):
-        self.json_path = join_filepath([json_dir, f"{self.file_name}.json"])
-        JsonWriter.write_as_split(self.json_path, create_images_list(self.data))
-        JsonWriter.write_plot_meta(json_dir, self.file_name, self.meta)
+        if self.data.ndim < 3:
+            self.json_path = join_filepath([json_dir, f"{self.file_name}.json"])
+            JsonWriter.write_as_split(self.json_path, create_images_list(self.data))
+            JsonWriter.write_plot_meta(json_dir, self.file_name, self.meta)
 
     @property
     def output_path(self) -> OutputPath:
-        return OutputPath(
-            path=self.json_path,
-            type=OutputType.IMAGE,
-            max_index=len(self.data) if self.data.ndim == 3 else 1,
-        )
+        if self.data.ndim == 3:
+            # self.path will be a list if self.data got into else statement on __init__
+            if isinstance(self.path, list) and isinstance(self.path[0], str):
+                _path = self.path[0]
+            else:
+                _path = self.path
+            return OutputPath(
+                path=_path,
+                type=OutputType.IMAGE,
+                max_index=len(self.data),
+            )
+        else:
+            return OutputPath(
+                path=self.json_path,
+                type=OutputType.IMAGE,
+                max_index=1,
+            )

--- a/studio/app/common/dataclass/utils.py
+++ b/studio/app/common/dataclass/utils.py
@@ -4,16 +4,11 @@ import numpy as np
 
 
 def create_images_list(data):
-    if len(data.shape) == 2:
-        save_data = copy.deepcopy(data)
-    elif len(data.shape) == 3:
-        save_data = copy.deepcopy(data[:10])
-    else:
-        assert False, "data is error"
+    assert len(data.shape) == 2, "data is error"
 
-    if len(data.shape) == 2:
-        data = data[np.newaxis, :, :]
-        save_data = save_data[np.newaxis, :, :]
+    save_data = copy.deepcopy(data)
+    data = data[np.newaxis, :, :]
+    save_data = save_data[np.newaxis, :, :]
 
     images = []
     for _img in save_data:

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -118,11 +118,13 @@ async def get_image(
     filepath: str,
     workspace_id: str,
     start_index: Optional[int] = 0,
-    end_index: Optional[int] = 1,
+    end_index: Optional[int] = 10,
 ):
     filename, ext = os.path.splitext(os.path.basename(filepath))
     if ext in ACCEPT_TIFF_EXT:
-        filepath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filepath])
+        if not filepath.startswith(join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])):
+            filepath = join_filepath([DIRPATH.INPUT_DIR, workspace_id, filepath])
+
         save_dirpath = join_filepath(
             [
                 os.path.dirname(filepath),

--- a/studio/app/optinist/wrappers/suite2p/spike_deconv.py
+++ b/studio/app/optinist/wrappers/suite2p/spike_deconv.py
@@ -43,7 +43,7 @@ def suite2p_spike_deconv(
         ).T
         roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
+    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
 
     # Fluorenceを追加
     nwbfile[NWBDATASET.FLUORESCENCE] = {


### PR DESCRIPTION
Closes #242 

ver1.1へマージ予定。

algorithmのoutputにImageDataを含み、かつそのデータが動画(ndim==3)の場合について、jsonではなくtiffファイルのパスをoutput_pathとして設定するように修正
これによって、VISUALIZE Plotでindex指定した際に指定の範囲でのjsonが生成されるようになる。
デフォルトの範囲は0 ~ 10で、json生成済の範囲の場合は再参照する方式なので処理が軽減される。

- 現状該当するoutputはcaiman_mcのmc_imagesのみ
  - #234 の対応でsuite2p_registrationのmc_imagesも追加予定

その他、各関数への影響確認中にsuite2p_spike_deconvでNWB保存の際のエラーが発覚したため本PR内で修正。（NWBへfunction_id単位でデータを保存する対応の際に漏れていた模様。）
