### PR TITLE
add microscope data reader modules (initial)

### DIFF
--- a/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABCMeta, abstractmethod
+
 from pydantic import BaseModel
 
 
@@ -7,6 +8,7 @@ class OMEDataModel(BaseModel):
     """OME(Open Microscopy Environment) aware metadata
     @link https://ome-model.readthedocs.io/en/stable/ome-xml/
     """
+
     image_name: str
     size_x: int
     size_y: int
@@ -21,8 +23,7 @@ class OMEDataModel(BaseModel):
 
 
 class MicroscopeDataReaderBase(metaclass=ABCMeta):
-    """Microscope data reader base class
-    """
+    """Microscope data reader base class"""
 
     LIBRARY_DIR_KEY = "MICROSCOPES_LIBRARY_DIR"
 
@@ -50,12 +51,11 @@ class MicroscopeDataReaderBase(metaclass=ABCMeta):
         """
         Read metadata
         """
-        self.__original_metadata = self._build_original_metadata(
-            handle, data_name)
-        self.__ome_metadata = self._build_ome_metadata(
-            self.__original_metadata)
+        self.__original_metadata = self._build_original_metadata(handle, data_name)
+        self.__ome_metadata = self._build_ome_metadata(self.__original_metadata)
         self.__lab_specific_metadata = self._build_lab_specific_metadata(
-            self.__original_metadata)
+            self.__original_metadata
+        )
 
         """
         Release resources
@@ -64,44 +64,37 @@ class MicroscopeDataReaderBase(metaclass=ABCMeta):
 
     @abstractmethod
     def _init_library(self) -> dict:
-        """Initialize microscope library
-        """
+        """Initialize microscope library"""
         pass
 
     @abstractmethod
     def _load_data_file(self, data_file_path: str) -> object:
-        """Return metadata specific to microscope instruments
-        """
+        """Return metadata specific to microscope instruments"""
         pass
 
     @abstractmethod
     def _build_original_metadata(self, handle: object, data_name: str) -> dict:
-        """Build metadata specific to microscope instruments
-        """
+        """Build metadata specific to microscope instruments"""
         pass
 
     @abstractmethod
     def _build_ome_metadata(self, all_metadata: dict) -> OMEDataModel:
-        """Build OME(Open Microscopy Environment) aware metadata
-        """
+        """Build OME(Open Microscopy Environment) aware metadata"""
         pass
 
     @abstractmethod
     def _build_lab_specific_metadata(self, all_metadata: dict) -> dict:
-        """Build metadata in lab-specific format
-        """
+        """Build metadata in lab-specific format"""
         pass
 
     @abstractmethod
     def _release_resources(self, handle: object) -> None:
-        """Release microscope library resources
-        """
+        """Release microscope library resources"""
         pass
 
     @abstractmethod
     def _get_images_stack(self) -> list:
-        """Return microscope image stacks
-        """
+        """Return microscope image stacks"""
         pass
 
     @property

--- a/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
@@ -1,0 +1,117 @@
+import os
+from abc import ABCMeta, abstractmethod
+from pydantic import BaseModel
+
+
+class OMEDataModel(BaseModel):
+    """OME(Open Microscopy Environment) aware metadata
+    @link https://ome-model.readthedocs.io/en/stable/ome-xml/
+    """
+    image_name: str
+    size_x: int
+    size_y: int
+    size_t: int
+    size_c: int
+
+    # TODO: 以下今後追加想定
+    # SizeZ: int
+    # AcquisitionDate: date
+    # Instrument/(Laser|Detector): str
+    # FrameRate: float  # 正確にはOMEの項目ではない様だが、追加想定
+
+
+class MicroscopeDataReaderBase(metaclass=ABCMeta):
+    """Microscope data reader base class
+    """
+
+    LIBRARY_DIR_KEY = "MICROSCOPES_LIBRARY_DIR"
+
+    def __init__(self):
+        """
+        Initialization
+        """
+        self._init_library()
+
+    def load(self, data_file_path: str):
+        """
+        Reset data
+        """
+        self.__original_metadata = None
+        self.__ome_metadata = None
+        self.__lab_specific_metadata = None
+
+        """
+        Load data
+        """
+        handle = self._load_data_file(data_file_path)
+        self.__data_file_path = data_file_path
+        data_name = os.path.basename(data_file_path)
+
+        """
+        Read metadata
+        """
+        self.__original_metadata = self._build_original_metadata(
+            handle, data_name)
+        self.__ome_metadata = self._build_ome_metadata(
+            self.__original_metadata)
+        self.__lab_specific_metadata = self._build_lab_specific_metadata(
+            self.__original_metadata)
+
+        """
+        Release resources
+        """
+        self._release_resources(handle)
+
+    @abstractmethod
+    def _init_library(self) -> dict:
+        """Initialize microscope library
+        """
+        pass
+
+    @abstractmethod
+    def _load_data_file(self, data_file_path: str) -> object:
+        """Return metadata specific to microscope instruments
+        """
+        pass
+
+    @abstractmethod
+    def _build_original_metadata(self, handle: object, data_name: str) -> dict:
+        """Build metadata specific to microscope instruments
+        """
+        pass
+
+    @abstractmethod
+    def _build_ome_metadata(self, all_metadata: dict) -> OMEDataModel:
+        """Build OME(Open Microscopy Environment) aware metadata
+        """
+        pass
+
+    @abstractmethod
+    def _build_lab_specific_metadata(self, all_metadata: dict) -> dict:
+        """Build metadata in lab-specific format
+        """
+        pass
+
+    @abstractmethod
+    def _release_resources(self, handle: object) -> None:
+        """Release microscope library resources
+        """
+        pass
+
+    @abstractmethod
+    def _get_images_stack(self) -> list:
+        """Return microscope image stacks
+        """
+        pass
+
+    @property
+    def original_metadata(self):
+        return self.__original_metadata
+
+    @property
+    def ome_metadata(self):
+        return self.__ome_metadata
+
+    @property
+    def lab_specific_metadata(self):
+        return self.__lab_specific_metadata

--- a/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
@@ -33,6 +33,11 @@ class MicroscopeDataReaderBase(metaclass=ABCMeta):
         """
         self._init_library()
 
+        # init members
+        self.__original_metadata = None
+        self.__ome_metadata = None
+        self.__lab_specific_metadata = None
+
     def load(self, data_file_path: str):
         """
         Reset data

--- a/studio/app/optinist/microscopes/ND2Reader.py
+++ b/studio/app/optinist/microscopes/ND2Reader.py
@@ -21,17 +21,17 @@ class ND2Reader(MicroscopeDataReaderBase):
 
     @staticmethod
     def get_library_path() -> str:
-        platform_naem = platform.system()
+        platform_name = platform.system()
 
         if __class__.LIBRARY_DIR_KEY not in os.environ:
             return None
 
-        if platform_naem not in __class__.SDK_LIBRARY_FILES:
+        if platform_name not in __class__.SDK_LIBRARY_FILES:
             return None
 
         return (
             os.environ.get(__class__.LIBRARY_DIR_KEY)
-            + __class__.SDK_LIBRARY_FILES[platform_naem]["main"]
+            + __class__.SDK_LIBRARY_FILES[platform_name]["main"]
         )
 
     @staticmethod

--- a/studio/app/optinist/microscopes/ND2Reader.py
+++ b/studio/app/optinist/microscopes/ND2Reader.py
@@ -1,0 +1,195 @@
+import os
+import ctypes
+import json
+import platform
+from MicroscopeDataReaderBase import MicroscopeDataReaderBase, OMEDataModel
+
+
+class ND2Reader(MicroscopeDataReaderBase):
+    """Nikon ND2 data reader
+    """
+
+    WINDOWS_DLL_FILE = "/nikon/windows/nd2readsdk-shared.dll"
+    LINUX_DLL_FILE = "/nikon/linux/libnd2readsdk-shared.so"
+
+    @staticmethod
+    def get_library_path() -> str:
+        DLL_FILE = __class__.WINDOWS_DLL_FILE \
+            if (platform.system() == "Windows") else __class__.LINUX_DLL_FILE
+        return os.environ.get(__class__.LIBRARY_DIR_KEY, "") + DLL_FILE
+
+    @staticmethod
+    def is_available() -> bool:
+        """Determine if library is available
+        """
+        return (__class__.LIBRARY_DIR_KEY in os.environ) and \
+            os.path.isfile(__class__.get_library_path())
+
+    def _init_library(self) -> dict:
+        self.__dll = ctypes.cdll.LoadLibrary(__class__.get_library_path())
+
+        self.__dll.Lim_FileOpenForReadUtf8.argtypes = (ctypes.c_char_p, )
+        self.__dll.Lim_FileOpenForReadUtf8.restype = ctypes.c_void_p
+        self.__dll.Lim_FileGetMetadata.argtypes = (ctypes.c_void_p, )
+        self.__dll.Lim_FileGetMetadata.restype = ctypes.c_char_p
+        self.__dll.Lim_FileGetAttributes.argtypes = (ctypes.c_void_p, )
+        self.__dll.Lim_FileGetAttributes.restype = ctypes.c_char_p
+        self.__dll.Lim_FileGetTextinfo.argtypes = (ctypes.c_void_p, )
+        self.__dll.Lim_FileGetTextinfo.restype = ctypes.c_char_p
+        self.__dll.Lim_FileGetExperiment.argtypes = (ctypes.c_void_p, )
+        self.__dll.Lim_FileGetExperiment.restype = ctypes.c_char_p
+        self.__dll.Lim_FileGetCoordSize.argtypes = (ctypes.c_void_p, )
+        self.__dll.Lim_FileGetCoordSize.restype = ctypes.c_size_t
+        self.__dll.Lim_FileGetCoordsFromSeqIndex.argtypes = (
+            ctypes.c_void_p, ctypes.c_uint, )
+        self.__dll.Lim_FileGetCoordsFromSeqIndex.restype = ctypes.c_size_t
+        self.__dll.Lim_FileClose.argtypes = (ctypes.c_void_p, )
+
+    def _load_data_file(self, data_file_path: str) -> object:
+        handle = self.__dll.Lim_FileOpenForReadUtf8(
+            data_file_path.encode("utf-8"))
+
+        if handle is None:
+            raise FileNotFoundError(data_file_path)
+
+        return handle
+
+    def _build_original_metadata(self, handle: object, data_name: str) -> dict:
+        attributes = self.__dll.Lim_FileGetAttributes(handle)
+        metadata = self.__dll.Lim_FileGetMetadata(handle)
+        textinfo = self.__dll.Lim_FileGetTextinfo(handle)
+        experiment = self.__dll.Lim_FileGetExperiment(handle)
+
+        attributes = json.loads(attributes)
+        metadata = json.loads(metadata)
+        textinfo = json.loads(textinfo)
+        experiment = json.loads(experiment)
+
+        all_metadata = {
+            "data_name": data_name,
+            "attributes": attributes,
+            "metadata": metadata,
+            "textinfo": textinfo,
+            "experiment": experiment,
+        }
+
+        return all_metadata
+
+    def _build_ome_metadata(self, all_metadata: dict) -> OMEDataModel:
+        """
+        @link OME/NativeND2Reader
+        """
+
+        attributes = all_metadata["attributes"]
+        # metadata = all_metadata["metadata"]
+        # textinfo = all_metadata["textinfo"]
+
+        omeData = OMEDataModel(
+            image_name=all_metadata["data_name"],
+            size_x=attributes["widthPx"],
+            size_y=attributes["heightPx"],
+            size_t=attributes["sequenceCount"],
+            size_c=attributes["componentCount"]  # TODO: この内容が正しいか要確認
+        )
+
+        return omeData
+
+    def _build_lab_specific_metadata(self, all_metadata: dict) -> dict:
+
+        # ----------------------------------------
+        # Lab固有仕様のmetadata作成
+        # ----------------------------------------
+
+        # TODO: 既存のMEXコードより、以下のコード移植が必要だが、最新版ライブラリでの各値の取得方法が不明となっている。
+        #     - m_Experiment.uiLevelCount
+        #     - m_Experiment.pAllocatedLevels
+        #     - m_Experiment.pAllocatedLevels[n].uiLoopSize
+        #     - m_Experiment.pAllocatedLevels[n].dInterval
+        #
+        # if(m_Experiment.uiLevelCount==0){
+        #       *type=(char *)"2Ds";
+        # } else if (m_Experiment.uiLevelCount==2){
+        #       *type=(char *)"3Dm";
+        #       *mxGetPr(Loops)= (double)m_Experiment.pAllocatedLevels[0].
+        #           uiLoopSize;
+        #       *mxGetPr(ZSlicenum)=(double)m_Experiment.pAllocatedLevels[1].uiLoopSize;
+        #       *mxGetPr(ZInterval)=(double)m_Experiment.pAllocatedLevels[1].dInterval;
+        # } else {
+        #     if (m_Experiment.pAllocatedLevels[0].uiExpType==2){
+        #           *type=(char *)"3Ds";
+        #           *mxGetPr(ZSlicenum)=(double)m_Experiment.pAllocatedLevels[0].uiLoopSize;
+        #           *mxGetPr(ZInterval)=(double)m_Experiment.pAllocatedLevels[0].dInterval;
+        #     }
+        #     if (m_Experiment.pAllocatedLevels[0].uiExpType==0){
+        #           *type=(char *)"2Dm";
+        #           *mxGetPr(Loops)=(double)m_Experiment.pAllocatedLevels[0].uiLoopSize;
+        #     }
+        # }
+
+        attributes = all_metadata["attributes"]
+        metadata = all_metadata["metadata"]
+        textinfo = all_metadata["textinfo"]
+        # experiment = all_metadata["experiment"]
+
+        # ※一部のデータ項目は ch0 より取得
+        # TODO: 上記の仕様で適切であるか？（要レビュー）
+        metadata_ch0_microscope = metadata["channels"][0]["microscope"]
+
+        lab_specific_metadata = {
+            # /* 11 cinoibebts (From Lab MEX) */
+            "uiWidth": attributes["widthPx"],
+            "uiHeight": attributes["heightPx"],
+            "uiWidthBytes": attributes["widthBytes"],
+            "uiColor": attributes["componentCount"],
+            "uiBpcInMemory": attributes["bitsPerComponentInMemory"],
+            "uiBpcSignificant": attributes["bitsPerComponentSignificant"],
+            "uiSequenceCount": attributes["sequenceCount"],
+            "uiTileWidth": attributes.get("tileWidthPx", None),  # Optional
+            "uiTileHeight": attributes.get("tileHeightPx", None),  # Optional
+            "uiCompression": None,  # TODO: Optional ?
+                                    # TODO: 最新版ライブラリでは該当するパラメータがない？
+                                    # (compressionLevel or compressionType)
+            "uiQuality": None,  # TODO: 最新版ライブラリでは該当するパラメータがない？
+
+            # /* 4 components (From Lab MEX) */
+            "Type": None,  # TODO: 要設定
+            "Loops": None,  # TODO: 要設定
+            "ZSlicenum": None,  # TODO: 要設定
+            "ZInterval": None,  # TODO: 要設定
+
+            # /* 7 components (From Lab MEX) */
+            "dTimeStart": None,  # TODO: 最新版ライブラリでは該当するパラメータがない？
+            "MicroPerPixel": None,  # TODO: 最新版ライブラリでは該当するパラメータがない？
+                                    # metadata.volume.axesCalibrated が該当？
+            "PixelAspect": None,  # TODO: 最新版ライブラリでは該当するパラメータがない？
+            "ObjectiveName": metadata_ch0_microscope.get(
+                "objectiveName", None),  # Optional
+                                         # Note: この値 は channels[0] からの取得と想定
+            "dObjectiveMag": metadata_ch0_microscope.get(
+                "objectiveMagnification",
+                None),  # Optional
+                        # Note: この値 は channels[0] からの取得と想定
+                        # TODO: ライブラリバージョンにより、取得値が異なる可能性がある？
+            "dObjectiveNA": metadata_ch0_microscope.get(
+                "objectiveNumericalAperture",
+                None),  # Optional
+                        # Note: この値 は channels[0] からの取得と想定
+            "dZoom": metadata_ch0_microscope.get(
+                "zoomMagnification", None),  # Optional
+                                             # Note: この値 は channels[0] からの取得と想定
+
+            # /* 3 components (From Lab MEX) */
+            # Note: All elements of textinfo are optional.
+            "wszDescription": textinfo.get("description", None),
+            "wszCapturing": textinfo.get("capturing", None),
+            "Date": textinfo.get("date", None)
+        }
+
+        return lab_specific_metadata
+
+    def _release_resources(self, handle: object) -> None:
+        self.__dll.Lim_FileClose(handle)
+
+    def _get_images_stack(self) -> list:
+        # TODO: under construction
+        return []

--- a/studio/app/optinist/microscopes/test_ND2Reader.py
+++ b/studio/app/optinist/microscopes/test_ND2Reader.py
@@ -1,0 +1,35 @@
+import os
+from ND2Reader import ND2Reader
+import logging
+
+CURRENT_DIR_PATH = os.path.dirname(os.path.abspath(__file__))
+LIBRARY_DIR = CURRENT_DIR_PATH + "/dll"
+TEST_DATA_PATH = CURRENT_DIR_PATH + "/testdata/nikon-oriOD001.nd2"
+
+os.environ[ND2Reader.LIBRARY_DIR_KEY] = LIBRARY_DIR
+
+
+def test_nd2_reader():
+    if not ND2Reader.is_available():
+        # Note: To output the logging contents to the console,
+        #       specify the following options to pytest
+        #   > pytest.exe --log-cli-level=DEBUG
+        logging.warning("ND2Reader is not available.")
+        return
+
+    data_reader = ND2Reader()
+    data_reader.load(TEST_DATA_PATH)
+
+    # # debug print.
+    import json
+    print(json.dumps(data_reader.original_metadata))
+    # print(data_reader.ome_metadata)
+    # print(json.dumps(data_reader.lab_specific_metadata))
+
+    assert data_reader.original_metadata["attributes"]["widthPx"] > 0
+    assert data_reader.ome_metadata.size_x > 0
+    assert data_reader.lab_specific_metadata["uiWidth"] > 0
+
+
+if __name__ == "__main__":
+    test_nd2_reader()

--- a/studio/app/optinist/microscopes/test_ND2Reader.py
+++ b/studio/app/optinist/microscopes/test_ND2Reader.py
@@ -1,6 +1,7 @@
-import os
-from ND2Reader import ND2Reader
 import logging
+import os
+
+from ND2Reader import ND2Reader
 
 CURRENT_DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 LIBRARY_DIR = CURRENT_DIR_PATH + "/dll"
@@ -22,6 +23,7 @@ def test_nd2_reader():
 
     # # debug print.
     import json
+
     print(json.dumps(data_reader.original_metadata))
     # print(data_reader.ome_metadata)
     # print(json.dumps(data_reader.lab_specific_metadata))

--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 

--- a/studio/config/docker/Dockerfile.test
+++ b/studio/config/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
- PR内容
  - 顕微鏡データReaderモジュールの初回push
  - Nikon ND2用モジュール（構築途中）もpush

- 動作確認手順
  - データの配置
    - 以下dllのローカル環境配置（任意のパス）
      - https://drive.google.com/drive/folders/1CUmHsBcbgGDsO3MjGW7gsO8IiuAb8kQg
    - 以下テスト用データのローカル環境配置（任意のパス）
      - https://drive.google.com/drive/folders/1LfrVe-3Dv9yZaj2uwj9Lyn_mGtP6O8Tz

  - テストコード（test_ND2Reader.py）を pytest で実行可能
    - テストコード内の設定（LIBRARY_DIR, TEST_DATA_PATH）で、上で配置した dll,テスト用データ, の格納パスを指定
    - テストコードは Linux/Windows の両環境で動作可能

- レビュー観点
  - 前提
    - コード中TODO個所がいろいろとあるが、随時仕様確認中
  - レビュー観点
    - ここまでの実装段階（Nikonのmetadata取得まで）で、動作や構成が妥当であるかどうか？
  - 備考
    - この後の他フォーマット（Olympus, Inscopix）への対応により、ある程度I/Fの変更も想定される
    - 当モジュールは、optinist には直接依存はしていないので、外部モジュール化も不可ではない
