### PR TITLE
docker image verup

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 

--- a/studio/config/docker/Dockerfile.test
+++ b/studio/config/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 python:3.8.18-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
- python:3.8.16-slim -> python:3.8.18-slim