### PR TITLE
add sample inscopix reader node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tensorflow-2.4.1-py3-none-any.whl
 
 .env*
 !*.env.example
+
+Inscopix Data Processing*

--- a/studio/app/common/wrappers/__init__.py
+++ b/studio/app/common/wrappers/__init__.py
@@ -1,4 +1,5 @@
 # from studio.app.optinist.wrappers.dummy_wrapper import dummy_wrapper_dict
+from studio.app.common.wrappers.inscopix import inscopix_wrapper_dict
 
-# wrapper_dict = {}
-# wrapper_dict.update(**dummy_wrapper_dict)
+wrapper_dict = {}
+wrapper_dict.update(**inscopix_wrapper_dict)

--- a/studio/app/common/wrappers/inscopix/__init__.py
+++ b/studio/app/common/wrappers/inscopix/__init__.py
@@ -1,0 +1,10 @@
+from studio.app.common.wrappers.inscopix.read_inscopix import read_inscopix
+
+inscopix_wrapper_dict = {
+    "inscopix": {
+        "read_inscopix": {
+            "function": read_inscopix,
+            "conda_name": "isxenv",
+        },
+    }
+}

--- a/studio/app/common/wrappers/inscopix/params/read_inscopix.yaml
+++ b/studio/app/common/wrappers/inscopix/params/read_inscopix.yaml
@@ -1,0 +1,1 @@
+sample: "test"

--- a/studio/app/common/wrappers/inscopix/read_inscopix.py
+++ b/studio/app/common/wrappers/inscopix/read_inscopix.py
@@ -1,0 +1,39 @@
+import logging
+from pprint import pprint
+
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.common.dataclass import ImageData
+from studio.app.dir_path import DIRPATH
+from studio.app.optinist.microscopes.IsxdReader import IsxdReader
+
+
+def read_inscopix(
+    image: ImageData, output_dir: str, params: dict = None, **kwargs
+) -> dict(imgs=ImageData):
+    print("■■■: read_inscopix")
+    if not IsxdReader.is_available():
+        # Note: To output the logging contents to the console,
+        #       specify the following options to pytest
+        #   > pytest --log-cli-level=DEBUG
+        logging.warning("IsxdReader is not available.")
+        return
+
+    # initialize
+    data_reader = IsxdReader()
+    data_reader.load(
+        join_filepath([DIRPATH.INPUT_DIR, "1", "fixed-oist-sample_data_short.isxd"])
+    )
+
+    # debug print.
+    import json
+
+    # dump attributes
+    pprint(json.dumps(data_reader.original_metadata))
+    pprint(data_reader.ome_metadata)
+    pprint(json.dumps(data_reader.lab_specific_metadata))
+
+    # dump image stack
+    # images_stack = data_reader.get_images_stack()
+    # pprint(len(images_stack))
+
+    return {"imgs": image}

--- a/studio/app/optinist/microscopes/IsxdReader.py
+++ b/studio/app/optinist/microscopes/IsxdReader.py
@@ -1,7 +1,14 @@
 import sys
 
-import isx
-from MicroscopeDataReaderBase import MicroscopeDataReaderBase, OMEDataModel
+try:
+    import isx
+except ModuleNotFoundError:
+    pass
+
+from studio.app.optinist.microscopes.MicroscopeDataReaderBase import (
+    MicroscopeDataReaderBase,
+    OMEDataModel,
+)
 
 
 class IsxdReader(MicroscopeDataReaderBase):

--- a/studio/app/wrappers.py
+++ b/studio/app/wrappers.py
@@ -1,6 +1,6 @@
-# from studio.app.common.wrappers import wrapper_dict as common_wrapper_dict
+from studio.app.common.wrappers import wrapper_dict as common_wrapper_dict
 from studio.app.optinist.wrappers import wrapper_dict as optinist_wrapper_dict
 
 wrapper_dict = {}
-# wrapper_dict.update(**common_wrapper_dict)
+wrapper_dict.update(**common_wrapper_dict)
 wrapper_dict.update(**optinist_wrapper_dict)


### PR DESCRIPTION
https://github.com/arayabrain/barebone-studio/pull/257#issuecomment-1870070236
こちらの案4について検証してみました。


optinistは`./conda/envs/{CONDA_ENV_NAME}`にconda環境を生成してあると、yamlから環境生成ではなく、生成済みの環境を使用します。
docker環境で、以下のコマンドで事前に環境を生成しました。
```
conda env create --prefix /app/conda/envs/isxenv -f /app/Inscopix\ Data\ Processing.linux/Contents/API/Python/environment.yml --force
```

このブランチでは、test_IsxdReader.pyと同等の内容の処理を実行する関数をwrappersに組み込んで実行するようにしています。
関数ノードにしている都合上、入出力にImageDataを挟んでいます。

ひとまずread自体は成功していますが、そもそもsnakemakeでパス指定の環境を利用するとExceptionが発生しますね。
```
2023-12-28 14:17:50   File "/root/.cache/pypoetry/virtualenvs/optinist-9TtSrW0h-py3.8/lib/python3.8/site-packages/snakemake/shell.py", line 61, in check_output
2023-12-28 14:17:50     return sp.check_output(cmd, shell=True, executable=executable, **kwargs)
2023-12-28 14:17:50   File "/usr/local/lib/python3.8/subprocess.py", line 415, in check_output
2023-12-28 14:17:50     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
2023-12-28 14:17:50   File "/usr/local/lib/python3.8/subprocess.py", line 516, in run
2023-12-28 14:17:50     raise CalledProcessError(retcode, process.args,
2023-12-28 14:17:50 subprocess.CalledProcessError: Command 'conda env export --name '/app/conda/envs/isxenv'' returned non-zero exit status 1.
```
既知の問題（ https://github.com/snakemake/snakemake/issues/1674 ）のようで、PRも出ていますがmergeされていないようです。


## 懸念事項
現状は問題が起きていませんが、このPRのコードだと`read_inscopix.py`ではImageData, join_filepathなど、python3.8のoptinist上での想定で書かれたコードがpython3.10からreadされるので、そのような差異で問題が生じないか注意が必要かと思います。