### PR TITLE
update nd2reader

### DIFF
--- a/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
@@ -10,10 +10,10 @@ class OMEDataModel:
     """
 
     image_name: str
-    size_x: int
-    size_y: int
-    size_t: int
-    size_c: int
+    size_x: int  # width
+    size_y: int  # height
+    size_t: int  # time
+    size_c: int  # TODO: 要確認
     fps: int  # frames_per_second  # TODO: OME標準の類似項目に合わせる
 
     # TODO: 以下今後追加想定

--- a/studio/app/optinist/microscopes/test_ND2Reader.py
+++ b/studio/app/optinist/microscopes/test_ND2Reader.py
@@ -31,24 +31,27 @@ def test_nd2_reader():
     # print("[lab_specific_metadata]",
     #    json.dumps(data_reader.lab_specific_metadata, indent=2))
 
-    # dump image stack
-    images_stack = []
-    images_stack = data_reader.get_images_stack()
+    # get image stacks (for all channels)
+    channels_stacks = data_reader.get_images_stack()
 
     # save tiff image (multi page) test
-    if len(images_stack) > 0:
+    if (len(channels_stacks) > 0) and (len(channels_stacks[0]) > 0):
         from PIL import Image
 
-        save_stack = [Image.fromarray(frame) for frame in images_stack]
-        save_path = os.path.basename(TEST_DATA_PATH) + ".out.tiff"
-        print(f"save image: {save_path}")
+        # save stacks for all channels
+        for channel_idx, images_stack in enumerate(channels_stacks):
+            save_stack = [Image.fromarray(frame) for frame in images_stack]
+            save_path = (
+                os.path.basename(TEST_DATA_PATH) + f".out.ch{channel_idx+1}.tiff"
+            )
+            print(f"save image: {save_path}")
 
-        save_stack[0].save(
-            save_path,
-            compression="tiff_deflate",
-            save_all=True,
-            append_images=save_stack[1:],
-        )
+            save_stack[0].save(
+                save_path,
+                compression="tiff_deflate",
+                save_all=True,
+                append_images=save_stack[1:],
+            )
 
     # asserts
     assert data_reader.original_metadata["attributes"]["widthPx"] > 0


### PR DESCRIPTION
### 対応内容

- マルチchannelのnd2ファイルの読み込みに対応

### 動作確認手順

1. サンプルnd2データを取得
    - https://drive.google.com/drive/folders/1vBIgJjKq9GeoEyS6R8YgQdn5hpkoPQZI
      - 1ch-4chまでのデータをローカルへ格納
2. テストプログラムを実行
    - /studio/app/optinist/microscopes/test_ND2Reader.py
      - channel別にtiffファイルが出力される

### レビュー観点

- 処理内容
  - tiffファイル出力結果
- モジュールI/F
  -  一括で全channellのデータを返しているが、この形でOK？など