### PR TITLE
arrow 1d data from hdf5

### DIFF
--- a/studio/app/common/core/rules/file_writer.py
+++ b/studio/app/common/core/rules/file_writer.py
@@ -4,6 +4,7 @@ from studio.app.common.core.snakemake.smk import Rule
 from studio.app.common.dataclass import CsvData, ImageData, TimeSeriesData
 from studio.app.const import FILETYPE
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
+from studio.app.optinist.dataclass.iscell import IscellData
 from studio.app.optinist.routers.mat import MatGetter
 
 
@@ -49,30 +50,16 @@ class FileWriter:
         with h5py.File(rule_config.input, "r") as f:
             data = f[rule_config.hdf5Path][:]
 
-        if data.ndim == 3:
-            info = {rule_config.return_arg: ImageData(data, "")}
-            nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
-            info["nwbfile"] = {}
-            info["nwbfile"][FILETYPE.IMAGE] = nwbfile
-        elif data.ndim == 2:
-            info = {rule_config.return_arg: TimeSeriesData(data, "")}
-
-            if NWBDATASET.TIMESERIES not in nwbfile:
-                nwbfile[NWBDATASET.TIMESERIES] = {}
-
-            nwbfile[NWBDATASET.TIMESERIES][rule_config.return_arg] = info[
-                rule_config.return_arg
-            ]
-            nwbfile.pop("image_series", None)
-            info["nwbfile"] = {"input": nwbfile}
-
-        return info
+        return cls.get_info_from_array_data(rule_config, nwbfile, data)
 
     @classmethod
     def mat(cls, rule_config: Rule):
         nwbfile = rule_config.nwbfile
         data = MatGetter.data(rule_config.input, rule_config.matPath)
+        return cls.get_info_from_array_data(rule_config, nwbfile, data)
 
+    @classmethod
+    def get_info_from_array_data(cls, rule_config: Rule, nwbfile, data):
         if data.ndim == 3:
             info = {rule_config.return_arg: ImageData(data, "")}
             nwbfile["image_series"]["external_file"] = info[rule_config.return_arg]
@@ -89,5 +76,14 @@ class FileWriter:
             ]
             nwbfile.pop("image_series", None)
             info["nwbfile"] = {"input": nwbfile}
+        elif data.ndim == 1:
+            info = {rule_config.return_arg: IscellData(data, "")}
 
+            if NWBDATASET.COLUMN not in nwbfile:
+                nwbfile[NWBDATASET.COLUMN] = {}
+
+            nwbfile[NWBDATASET.COLUMN][rule_config.return_arg] = info[
+                rule_config.return_arg
+            ]
+            info["nwbfile"] = {"input": nwbfile}
         return info


### PR DESCRIPTION
resolve #161 

HDF5(nwb)に1次元の配列データとして保存されるIscellDataをHDF5ノードの入力として利用できるように修正

IscellDataとFluoDataが必要なcorrelationなどのアルゴリズムをnwbファイルをデータ入力として実行可能に
![Screenshot 2024-01-23 at 17 32 28](https://github.com/arayabrain/barebone-studio/assets/42664619/f768829e-e3a1-479f-864a-6c41c9434208)
![Screenshot 2024-01-23 at 17 32 59](https://github.com/arayabrain/barebone-studio/assets/42664619/be1ee23a-6a93-42ff-a31a-56fa5338c3c7)
