### PR TITLE
spiking activity datatype

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/FlowChartUtils.ts
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/FlowChartUtils.ts
@@ -10,10 +10,14 @@ export function getHandleType(handleId: string) {
 
 export function isValidConnection(connection: Connection) {
   if (connection.sourceHandle != null && connection.targetHandle != null) {
-    return (
-      getHandleType(connection.sourceHandle) ===
-      getHandleType(connection.targetHandle)
-    )
+    const source = getHandleType(connection.sourceHandle)
+    const target = getHandleType(connection.targetHandle)
+    // NOTE: SpikingActivityData is the same as FluoData. Just renamed for suite2p_spike_deconv.
+    if (source === "SpikingActivityData") {
+      return target === "FluoData" || target === "SpikingActivityData"
+    } else {
+      return source === target
+    }
   } else {
     return true
   }

--- a/frontend/src/store/slice/HandleTypeColor/HandleTypeColorSlice.ts
+++ b/frontend/src/store/slice/HandleTypeColor/HandleTypeColorSlice.ts
@@ -16,6 +16,7 @@ const initialState: HandleTypeColor = {
     TimeSeriesData: MuiColors.yellow[500],
     Suite2pData: MuiColors.green[500],
     FluoData: MuiColors.orange[500],
+    SpikingActivityData: MuiColors.orange[500],
     BehaviorData: MuiColors.yellow[500],
   },
   nextKey: 0,

--- a/studio/app/optinist/dataclass/__init__.py
+++ b/studio/app/optinist/dataclass/__init__.py
@@ -5,6 +5,7 @@ from studio.app.optinist.dataclass.iscell import IscellData
 from studio.app.optinist.dataclass.lccd import LccdData
 from studio.app.optinist.dataclass.nwb import NWBFile
 from studio.app.optinist.dataclass.roi import EditRoiData, RoiData
+from studio.app.optinist.dataclass.spiking_activity import SpikingActivityData
 from studio.app.optinist.dataclass.suite2p import Suite2pData
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "LccdData",
     "NWBFile",
     "RoiData",
+    "SpikingActivityData",
     "Suite2pData",
     "EditRoiData",
 ]

--- a/studio/app/optinist/dataclass/spiking_activity.py
+++ b/studio/app/optinist/dataclass/spiking_activity.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from studio.app.common.schemas.outputs import PlotMetaData
+from studio.app.optinist.dataclass.fluo import FluoData
+
+
+class SpikingActivityData(FluoData):
+    def __init__(
+        self,
+        data,
+        std=None,
+        index=None,
+        params=None,
+        file_name="spiking_activity",
+        meta: Optional[PlotMetaData] = None,
+    ):
+        super().__init__(
+            data=data,
+            std=std,
+            index=index,
+            params=params,
+            file_name=file_name,
+            meta=meta,
+        )

--- a/studio/app/optinist/wrappers/suite2p/spike_deconv.py
+++ b/studio/app/optinist/wrappers/suite2p/spike_deconv.py
@@ -1,10 +1,10 @@
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
-from studio.app.optinist.dataclass import FluoData, Suite2pData
+from studio.app.optinist.dataclass import SpikingActivityData, Suite2pData
 
 
 def suite2p_spike_deconv(
     ops: Suite2pData, output_dir: str, params: dict = None, **kwargs
-) -> dict(ops=Suite2pData, spks=FluoData):
+) -> dict(ops=Suite2pData, spks=SpikingActivityData):
     import numpy as np
     from suite2p import default_ops, extraction
 
@@ -61,7 +61,7 @@ def suite2p_spike_deconv(
 
     info = {
         "ops": Suite2pData(ops),
-        "spks": FluoData(spks, file_name="spks"),
+        "spks": SpikingActivityData(spks, file_name="spks"),
         "nwbfile": nwbfile,
     }
 


### PR DESCRIPTION
Resolves #177 

- suite2p_spike_deconvのoutputのデータ型を`FluoData`→`SpikingActivityData`に変更
  - 機能としては`FluoData`と同様のため、継承して別名で作成
  - 別名のdata typeを結合可能にするため`isValidConnection`を調整


![Screenshot 2024-01-30 at 11 50 51](https://github.com/arayabrain/barebone-studio/assets/42664619/e743173f-f7f6-4efb-8ea1-6ce37d47cc50)

![Screenshot 2024-01-30 at 11 53 07](https://github.com/arayabrain/barebone-studio/assets/42664619/b4436375-106f-4b8c-a48b-e7db351b20bc)

本修正後に`FluoData`の入力ノードへの結合ができること、ワークフローが正常終了すること、結果に差異がないことを確認済。