### PR TITLE
update pytest config

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     environment:
       PYTHONPATH: .
       TZ: Asia/Tokyo
-    command: bash -c "poetry install --no-root --with test && poetry run python3 -m pytest -s ."
+    command: bash -c "poetry install --no-root --with test && poetry run python3 -m pytest -s"
     volumes:
       - .:/app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ profile = "black"
 
 [tool.pytest.ini_options]
 pythonpath = "."
-testpaths="studio/tests"
+testpaths = "studio/tests"
 env = ["OPTINIST_DIR=studio/test_data"]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ profile = "black"
 
 [tool.pytest.ini_options]
 pythonpath = "."
+testpaths="studio/tests"
 env = ["OPTINIST_DIR=studio/test_data"]
 
 [tool.codespell]


### PR DESCRIPTION
PR #291 の Github Action での pytest が通らない件について、先に pyproject.toml の修正を develop-main へ当てておく必要がありそうであるため、このPRを発行します。