### PR TITLE
Microscope Reader Module 4D data support

### DIFF
--- a/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
+++ b/studio/app/optinist/microscopes/MicroscopeDataReaderBase.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABCMeta, abstractmethod
+from ctypes import c_uint8, c_uint16, c_uint32
 from dataclasses import dataclass
 
 from numpy import uint8 as np_uint8
@@ -75,6 +76,18 @@ class OMEDataModel:
             return np_uint32
         else:
             return np_uint8
+
+    @property
+    def pixel_ct_type(self):
+        depth = self.depth
+        if depth > 0 and depth <= 8:
+            return c_uint8
+        elif depth > 8 and depth <= 16:
+            return c_uint16
+        elif depth > 16 and depth <= 32:
+            return c_uint32
+        else:
+            return c_uint8
 
     @staticmethod
     def get_depth_from_pixel_type(type_label: str):

--- a/studio/app/optinist/microscopes/tests/test_ND2Reader.py
+++ b/studio/app/optinist/microscopes/tests/test_ND2Reader.py
@@ -46,23 +46,16 @@ def test_nd2_reader(dump_metadata=True, dump_stack=True):
         channels_stacks = data_reader.get_image_stacks()
 
         # save tiff image (multi page) test
-        if (len(channels_stacks) > 0) and (len(channels_stacks[0]) > 0):
-            from PIL import Image
+        if (channels_stacks.shape[0] > 0) and (channels_stacks.shape[1] > 0):
+            import tifffile
 
-            # save stacks for all channels
             for channel_idx, image_stack in enumerate(channels_stacks):
-                save_stack = [Image.fromarray(frame) for frame in image_stack]
                 save_path = "{}/{}.out.ch{}.tiff".format(
                     TEST_DIR_PATH, os.path.basename(TEST_DATA_PATH), channel_idx + 1
                 )
                 print(f"save image: {save_path}")
 
-                save_stack[0].save(
-                    save_path,
-                    compression="tiff_deflate",
-                    save_all=True,
-                    append_images=save_stack[1:],
-                )
+                tifffile.imwrite(save_path, image_stack)
 
     # asserts
     assert data_reader.original_metadata["attributes"]["widthPx"] > 0


### PR DESCRIPTION
### 対応内容

- 4D data (XYZTC) support
  - for ND2, OIR
- Unify reader response format with numpy.ndarray