### PR TITLE
implement online cnmf and register_multisession

### DIFF
--- a/studio/app/const.py
+++ b/studio/app/const.py
@@ -20,3 +20,5 @@ ACCEPT_MICROSCOPE_EXT = [".nd2", ".oir", ".isxd", ".thor.zip"]
 NOT_DISPLAY_ARGS_LIST = ["params", "output_dir", "nwbfile", "kwargs"]
 
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+MAX_IMAGE_DATA_PART_SIZE = 1_000_000_000  # 1GB

--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -222,14 +222,19 @@ class NWBCreater:
                 roi["table_name"], region=roi["region"]
             )
 
-            roi_resp_series = RoiResponseSeries(
-                name=roi["name"],
-                data=roi["data"],
-                rois=region_roi,
-                unit=roi["unit"],
-                timestamps=roi.get("timestamps"),
-                rate=float(roi.get("rate", 0.0)),
-            )
+            roi_resp_dict = {
+                "name": roi["name"],
+                "data": roi["data"],
+                "rois": region_roi,
+                "unit": roi["unit"],
+                "timestamps": roi.get("timestamps"),
+                "rate": float(roi.get("rate", 0.0)),
+            }
+            if "comments" in roi:
+                roi_resp_dict["comments"] = roi["comments"]
+
+            roi_resp_series = RoiResponseSeries(**roi_resp_dict)
+
             fluo.add_roi_response_series(roi_resp_series)
 
         nwbfile.processing["ophys"].add(fluo)

--- a/studio/app/optinist/wrappers/caiman/__init__.py
+++ b/studio/app/optinist/wrappers/caiman/__init__.py
@@ -1,4 +1,7 @@
 from studio.app.optinist.wrappers.caiman.cnmf import caiman_cnmf
+from studio.app.optinist.wrappers.caiman.cnmf_multisession import (
+    caiman_cnmf_multisession,
+)
 from studio.app.optinist.wrappers.caiman.cnmfe import caiman_cnmfe
 from studio.app.optinist.wrappers.caiman.motion_correction import caiman_mc
 
@@ -14,6 +17,10 @@ caiman_wrapper_dict = {
         },
         "caiman_cnmfe": {
             "function": caiman_cnmfe,
+            "conda_name": "caiman",
+        },
+        "cnmf_multisession": {
+            "function": caiman_cnmf_multisession,
             "conda_name": "caiman",
         },
     }

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -91,7 +91,7 @@ def caiman_cnmf(
     from caiman.cluster import setup_cluster
     from caiman.mmapping import prepare_shape
     from caiman.paths import memmap_frames_filename
-    from caiman.source_extraction.cnmf import cnmf
+    from caiman.source_extraction.cnmf import cnmf, online_cnmf
     from caiman.source_extraction.cnmf.params import CNMFParams
 
     function_id = output_dir.split("/")[-1]
@@ -111,6 +111,7 @@ def caiman_cnmf(
     Ain = reshaped_params.pop("Ain", None)
     do_refit = reshaped_params.pop("do_refit", None)
     roi_thr = reshaped_params.pop("roi_thr", None)
+    use_online = reshaped_params.pop("use_online", False)
 
     file_path = images.path
     if isinstance(file_path, list):
@@ -157,11 +158,25 @@ def caiman_cnmf(
         backend="local", n_processes=None, single_thread=True
     )
 
-    cnm = cnmf.CNMF(n_processes=n_processes, dview=dview, Ain=Ain, params=ops)
-    cnm = cnm.fit(mmap_images)
+    if use_online:
+        ops.change_params(
+            {
+                "fnames": [join_filepath([dir_path, fname_tot])],
+                # NOTE: These params uses np.inf as default in CaImAn.
+                # Yaml cannot serialize np.inf, so default value in yaml is None.
+                "max_comp_update_shape": reshaped_params["max_comp_update_shape"]
+                or np.inf,
+                "num_times_comp_updated": reshaped_params["update_num_comps"] or np.inf,
+            }
+        )
+        cnm = online_cnmf.OnACID(dview=dview, Ain=Ain, params=ops)
+        cnm.fit_online()
+    else:
+        cnm = cnmf.CNMF(n_processes=n_processes, dview=dview, Ain=Ain, params=ops)
+        cnm = cnm.fit(mmap_images)
 
-    if do_refit:
-        cnm = cnm.refit(mmap_images, dview=dview)
+        if do_refit:
+            cnm = cnm.refit(mmap_images, dview=dview)
 
     cnm.estimates.evaluate_components(mmap_images, cnm.params, dview=dview)
 

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -1,0 +1,201 @@
+import gc
+import os
+import shutil
+
+import imageio
+import numpy as np
+
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.dataclass import ImageData
+from studio.app.dir_path import DIRPATH
+from studio.app.optinist.core.nwb.nwb import NWBDATASET
+from studio.app.optinist.dataclass import EditRoiData, FluoData, IscellData, RoiData
+from studio.app.optinist.wrappers.caiman.cnmf import (
+    get_roi,
+    util_get_memmap,
+    util_recursive_flatten_params,
+)
+
+logger = AppLogger.get_logger()
+
+
+def caiman_cnmf_multisession(
+    images: ImageData, output_dir: str, params: dict = None, **kwargs
+) -> dict(fluorescence=FluoData, iscell=IscellData):
+    from caiman import load, local_correlations, stop_server
+    from caiman.base.rois import register_multisession
+    from caiman.cluster import setup_cluster
+    from caiman.source_extraction.cnmf import cnmf
+    from caiman.source_extraction.cnmf.params import CNMFParams
+
+    function_id = output_dir.split("/")[-1]
+    logger.info(f"start caiman_cnmf_multisession: {function_id}")
+
+    # NOTE: evaluate_components requires cnn_model files in caiman_data directory.
+    caiman_data_dir = os.path.join(os.path.expanduser("~"), "caiman_data")
+    if not os.path.exists(caiman_data_dir):
+        shutil.copytree(
+            f"{DIRPATH.APP_DIR}/optinist/wrappers/caiman/caiman_data", caiman_data_dir
+        )
+
+    # flatten cmnf params segments.
+    reshaped_params = {}
+    util_recursive_flatten_params(params, reshaped_params)
+
+    Ain = reshaped_params.pop("Ain", None)
+    roi_thr = reshaped_params.pop("roi_thr", None)
+    reg_file_rate = reshaped_params.pop("reg_file_rate", 1.0)
+    if reg_file_rate > 1.0:
+        logger.warn(
+            f"reg_file_rate {reg_file_rate}, should be lte 1. Using 1.0 instead."
+        )
+        reg_file_rate = 1.0
+
+    split_image_paths = images.split_image(output_dir)
+    n_split_images = len(split_image_paths)
+
+    logger.info(f"image was split into {n_split_images} parts.")
+
+    nwbfile = kwargs.get("nwbfile", {})
+    fr = nwbfile.get("imaging_plane", {}).get("imaging_rate", 30)
+
+    if reshaped_params is None:
+        ops = CNMFParams()
+    else:
+        ops = CNMFParams(params_dict={**reshaped_params, "fr": fr})
+
+    if "dview" in locals():
+        stop_server(dview=dview)  # noqa: F821
+
+    c, dview, n_processes = setup_cluster(
+        backend="local", n_processes=None, single_thread=True
+    )
+
+    cnm_list = []
+    templates = []
+    for split_image_path in split_image_paths:
+        split_image = imageio.volread(split_image_path)
+        split_image_mmap, _, _ = util_get_memmap(split_image, split_image_path)
+        del split_image
+        gc.collect()
+
+        # ops.change_params("fnames", [image_path])
+        cnm = cnmf.CNMF(n_processes=n_processes, dview=dview, Ain=Ain, params=ops)
+        cnm = cnm.fit(split_image_mmap)
+        cnm_list.append(cnm)
+        templates.append(load(split_image_path).mean(0))
+
+        del split_image_mmap
+        gc.collect()
+
+    stop_server(dview=dview)
+
+    spatial = [cnm.estimates.A for cnm in cnm_list]
+    dims = templates[0].shape
+
+    spatial_union, assignments, matchings = register_multisession(
+        A=spatial, dims=dims, templates=templates
+    )
+
+    reg_files = int(len(split_image_paths) * reg_file_rate)
+    assignments_filtered = np.array(
+        np.nan_to_num(
+            assignments[np.sum(~np.isnan(assignments), axis=1) >= reg_files],
+        ),
+        dtype=int,
+    )
+    if assignments_filtered.shape[0] == 0:
+        raise Exception(
+            f"No same cells found in {reg_files} or more "
+            + f"out of {n_split_images} files. "
+            + "Try to set lower reg_file_rate.",
+        )
+
+    spatial_filtered = spatial[0][:, assignments_filtered[:, 0]]
+
+    fluorescence = np.array(
+        [
+            np.concatenate(
+                [
+                    cnm_list[j].estimates.C[int(assignments_filtered[i, j])]
+                    for j in range(assignments_filtered.shape[1])
+                ]
+            )
+            for i in range(assignments_filtered.shape[0])
+        ]
+    )
+
+    # contours plot
+    thr_method = "nrg"
+    swap_dim = False
+
+    iscell = np.concatenate([np.ones(assignments_filtered.shape[0], dtype=int)])
+
+    cell_ims = get_roi(spatial_filtered, roi_thr, thr_method, swap_dim, dims)
+    cell_ims = np.stack(cell_ims).astype(float)
+    cell_ims[cell_ims == 0] = np.nan
+    cell_ims -= 1
+    n_rois = len(cell_ims)
+
+    # NWBの追加
+    nwbfile = {}
+    # NWBにROIを追加
+    roi_list = []
+    n_cells = spatial_filtered.shape[-1]
+    for i in range(n_cells):
+        kargs = {}
+        kargs["image_mask"] = spatial_filtered.T[i].T.toarray().reshape(dims)
+        roi_list.append(kargs)
+
+    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": cell_ims}}
+
+    # iscellを追加
+    nwbfile[NWBDATASET.COLUMN] = {
+        function_id: {
+            "name": "iscell",
+            "description": "iscell",
+            "data": iscell,
+        }
+    }
+
+    nwbfile[NWBDATASET.FLUORESCENCE] = {
+        function_id: {
+            "Fluorescence": {
+                "table_name": "ROIs",
+                "region": list(range(n_rois)),
+                "name": "Fluorescence",
+                "data": fluorescence.T,
+                "unit": "lumens",
+            }
+        }
+    }
+
+    # get mean image
+    file_path = images.path
+    if isinstance(file_path, list):
+        file_path = file_path[0]
+    images = images.data
+    mmap_images, dims, _ = util_get_memmap(images.data, file_path)
+
+    Cn = local_correlations(mmap_images.transpose(1, 2, 0))
+    Cn[np.isnan(Cn)] = 0
+
+    info = {
+        "images": ImageData(
+            np.array(Cn * 255, dtype=np.uint8),
+            output_dir=output_dir,
+            file_name="images",
+        ),
+        "fluorescence": FluoData(fluorescence, file_name="fluorescence"),
+        "iscell": IscellData(iscell, file_name="iscell"),
+        "cell_roi": RoiData(
+            np.nanmax(cell_ims[iscell != 0], axis=0),
+            output_dir=output_dir,
+            file_name="cell_roi",
+        ),
+        "edit_roi_data": EditRoiData(mmap_images, cell_ims),
+        "nwbfile": nwbfile,
+    }
+
+    return info

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -167,6 +167,8 @@ def caiman_cnmf_multisession(
                 "name": "Fluorescence",
                 "data": fluorescence.T,
                 "unit": "lumens",
+                "comments": f"ROIs were detected in {reg_files} out of "
+                + f"{n_split_images} sessions ({reg_file_rate} overall).",
             }
         }
     }

--- a/studio/app/optinist/wrappers/caiman/params/caiman_cnmf.yaml
+++ b/studio/app/optinist/wrappers/caiman/params/caiman_cnmf.yaml
@@ -11,7 +11,7 @@ data_params:
 
 init_params:
   # Ain: null  # TBD: need to support 2D array type.
-
+  use_online: False  # If True, use CNMF Online instead of CNMF.
   do_refit: False
 
   K: 4
@@ -122,3 +122,46 @@ advanced:
     use_cnn: True
     use_ecc: False
     max_ecc: 3
+
+  online_params:
+    N_samples_exceptionality: null  # timesteps to compute SNR
+    batch_update_suff_stat: False
+    dist_shape_update: False        # update shapes in a distributed way
+    ds_factor: 1                    # spatial downsampling for faster processing
+    epochs: 1                       # number of epochs
+    expected_comps: 500             # number of expected components
+    full_XXt: False                 # store entire XXt matrix (as opposed to a list of sub-matrices)
+    init_batch: 200                 # length of mini batch for initialization
+    init_method: bare               # initialization method for first batch
+    iters_shape: 5                  # number of block-CD iterations
+    max_comp_update_shape: null     # maximum number of spatial components to be updated at each time
+                                    # Set int value. If left None, np.inf (CaImAn default) is used.
+    max_num_added: 5                # maximum number of new components for each frame
+    max_shifts_online: 10           # maximum shifts during motion correction
+    min_num_trial: 5                # number of mew possible components for each frame
+    minibatch_shape: 100            # number of frames in each minibatch
+    minibatch_suff_stat: 5
+    motion_correct: False           # flag for motion correction
+    movie_name_online: 'online_movie.mp4'  # filename of saved movie (appended to directory where data is located)
+    normalize: False                # normalize frame
+    n_refit: 0                      # Additional iterations to simultaneously refit
+    num_times_comp_updated: null    # number of times each component is updated
+                                    # Set int value. If left None, np.inf (CaImAn default) is used.
+    opencv_codec: H264              # FourCC video codec for saving movie. Check http://www.fourcc.org/codecs.php
+    ring_CNN: False                 # flag for using a ring CNN background model
+    save_online_movie: False        # flag for saving online movie
+    show_movie: False               # display movie online
+    simultaneously: False           # demix and deconvolve simultaneously
+    sniper_mode: False              # flag for using CNN
+    stop_detection: False           # flag for stop detecting new neurons at the last epoch
+    test_both: False                # flag for using both CNN and space correlation
+    thresh_CNN_noisy: 0.5           # threshold for online CNN classifier
+    thresh_fitness_delta: -50
+    thresh_fitness_raw: null        # threshold for trace SNR (computed below)
+    thresh_overlap: 0.5
+    update_freq: 200                # update every shape at least once every update_freq steps
+    update_num_comps: False         # flag for searching for new components
+    use_corr_img: False             # flag for using correlation image to detect new components
+    use_dense: True                 # flag for representation and storing of A and b
+    use_peak_max: True              # flag for finding candidate centroids
+    W_update_factor: 1              # update W less often than shapes by a given factor

--- a/studio/app/optinist/wrappers/caiman/params/cnmf_multisession.yaml
+++ b/studio/app/optinist/wrappers/caiman/params/cnmf_multisession.yaml
@@ -1,0 +1,122 @@
+# - CaImAn parameters reference page
+#   - https://caiman.readthedocs.io/en/dev/Getting_Started.html#parameters
+#   - https://caiman.readthedocs.io/en/dev/core_functions.html#caiman.source_extraction.cnmf.params.CNMFParams
+
+# ----------------------------------------
+# Basic Parameters
+# ----------------------------------------
+
+data_params:
+  decay_time: 0.4
+
+init_params:
+  # Ain: null  # TBD: need to support 2D array type.
+  reg_file_rate: 1.0  # threshold for the cell is detected in how many files
+  K: 4
+  gSig: [4, 4]
+  ssub: 1
+  tsub: 1
+  nb: 2
+  method_init: "greedy_roi"
+
+  roi_thr: 0.9  # Note: Extended param for ROI
+
+preprocess_params:
+  p: 1
+
+patch_params:
+  rf: null
+  stride: 6
+
+merge_params:
+  merge_thr: 0.85
+
+
+# ----------------------------------------
+# Advanced Parameters
+# ----------------------------------------
+
+advanced:
+  # Note: Other data params are undefined because they are less necessary.
+  # data_params:
+  #   fnames: null
+  #   dims: null
+  #   fr: 30
+  #   dxy: [1, 1]
+  #   var_name_hdf5: 'mov'
+  #   caiman_version: null
+  #   last_commit: null
+  #   mmap_F: null
+  #   mmap_C: null
+
+  init_params:
+    SC_kernel: "heat"
+    SC_sigma: 1
+    SC_thr: 0
+    SC_normalize: True
+    SC_use_NN: False
+    SC_nnn: 20
+    gSiz: null
+    center_psf: False
+    lambda_gnmf: 1
+    maxIter: 5
+    min_corr: 0.85
+    min_pnr: 20
+    seed_method: "auto"
+    ring_size_factor: 1.5
+    ssub_B: 2
+    init_iter: 2
+    nIter: 5
+    rolling_sum: True
+    rolling_length: 100
+    kernel: null
+    max_iter_snmf: 500
+    alpha_snmf: 0.5
+    sigma_smooth_snmf: [0.5, 0.5, 0.5]
+    perc_baseline_snmf: 20
+    normalize_init: True
+    options_local_NMF: null
+
+  preprocess_params:
+    sn: null
+    noise_range: [0.25, 0.5]
+    noise_method: "mean"
+    max_num_samples_fft: 3072
+    n_pixels_per_process: null
+    compute_g: False
+    lags: 5
+    include_noise: False
+    pixels: null
+    check_nan: True
+
+  patch_params:
+    nb_patch: 1
+    border_pix: 0
+    low_rank_background: True
+    del_duplicates: False
+    only_init: True
+    p_patch: 0
+    skip_refinement: False
+    remove_very_bad_comps: False
+    p_ssub: 2
+    p_tsub: 2
+    memory_fact: 1
+    n_processes: 1
+    in_memory: True
+
+  merge_params:
+    do_merge: True
+    merge_parallel: False
+    max_merge_area: null
+
+  quality_evaluation_params:
+    SNR_lowest: 0.5
+    cnn_lowest: 0.1
+    gSig_range: null
+    min_SNR: 2.5
+    min_cnn_thr: 0.9
+    rval_lowest: -1
+    rval_thr: 0.8
+    use_cnn: True
+    use_ecc: False
+    max_ecc: 3


### PR DESCRIPTION
メモリ消費が大きい場合の対策として、以下の実装を追加
- cnmf online
  - 通常のcnmfのオプションとして実装
  - `use_online`パラメータで切り替え
  - online版のパラメータはadvancedに格納
- 分割した画像それぞれでcnmfを実行し、結果をregister multisessionで統合
  - 画像の分割は画像サイズ(GB)を端数切り上げした値で行う
    - 例:) 3.8GBの場合4ファイルに分割
  - 1GB未満のファイルの場合、強制的に2分割する(register_multisessionでは2つ以上のsessionがないとエラーとなるため)
  - 分割されたファイルの内、何割のファイルで共通して検出されたかによってregister_multisessionの結果をフィルタリングする
    - reg_file_rateで割合を0.0 ~ 1.0の値で設定
    - フィルタリングの結果ROI数が0の場合は後続の計算等ができないため、Exceptionとしている

## ToDo
- [x] reg_file_rateの情報をNWBに保存

(追記)
- Fluorescenceのcomments欄に以下の形式でreg_file_rateの情報を記載する形で対応

![Screenshot 2024-04-11 at 13 54 02](https://github.com/arayabrain/barebone-studio/assets/42664619/e5114bab-c472-41d6-bbfc-7b160fbaa9ec)

