### PR TITLE
update tutorial data

### DIFF
--- a/sample_data/output/tutorial2/experiment.yaml
+++ b/sample_data/output/tutorial2/experiment.yaml
@@ -1,91 +1,95 @@
-finished_at: '2023-11-22 17:20:57'
+workspace_id: '1'
+unique_id: tutorial2
+name: Tutorial2
+started_at: '2024-04-11 16:47:34'
+finished_at: '2024-04-11 16:49:14'
+success: success
+hasNWB: true
 function:
-  caiman_cnmf_z6a16cmiwl:
-    finished_at: '2023-11-22 17:20:48'
-    hasNWB: true
-    message: caiman_cnmf success
-    name: caiman_cnmf
-    outputPaths:
-      all_roi:
-        max_index: null
-        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_z6a16cmiwl/all_roi.json
-        type: roi
-      cell_roi:
-        max_index: null
-        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_z6a16cmiwl/cell_roi.json
-        type: roi
-      fluorescence:
-        max_index: 6
-        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_z6a16cmiwl/fluorescence
-        type: timeseries
-      images:
-        max_index: 1
-        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_z6a16cmiwl/images.json
-        type: images
-      non_cell_roi:
-        max_index: null
-        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_z6a16cmiwl/non_cell_roi.json
-        type: roi
-    started_at: null
-    success: success
-    unique_id: caiman_cnmf_z6a16cmiwl
   caiman_mc_p4f6nsi9bh:
-    finished_at: '2023-11-22 17:20:50'
+    unique_id: caiman_mc_p4f6nsi9bh
+    name: caiman_mc
+    success: success
     hasNWB: true
     message: caiman_mc success
-    name: caiman_mc
     outputPaths:
       mc_images:
-        max_index: 2000
-        path: /tmp/studio/output/1/tutorial2/caiman_mc_p4f6nsi9bh/mc_images.json
+        path: /tmp/studio/output/1/tutorial2/caiman_mc_p4f6nsi9bh/tiff/mc_images/mc_images.tif
         type: images
+        max_index: 2000
       meanImg:
-        max_index: 1
         path: /tmp/studio/output/1/tutorial2/caiman_mc_p4f6nsi9bh/meanImg.json
         type: images
+        max_index: 1
       rois:
-        max_index: null
         path: /tmp/studio/output/1/tutorial2/caiman_mc_p4f6nsi9bh/rois.json
         type: roi
-    started_at: null
-    success: success
-    unique_id: caiman_mc_p4f6nsi9bh
+        max_index: null
+    started_at: '2024-04-11 16:47:49'
+    finished_at: '2024-04-11 16:48:34'
   input_0:
-    finished_at: '2023-11-22 17:20:42'
+    unique_id: input_0
+    name: sample_mouse2p_image.tiff
+    success: success
     hasNWB: false
     message: null
-    name: sample_mouse2p_image.tiff
     outputPaths: null
-    started_at: '2023-11-22 17:20:42'
-    success: success
-    unique_id: input_0
+    started_at: '2024-04-11 16:47:34'
+    finished_at: '2024-04-11 16:47:34'
   pca_xi0d87mbrk:
-    finished_at: '2023-11-22 17:20:57'
+    unique_id: pca_xi0d87mbrk
+    name: pca
+    success: success
     hasNWB: true
     message: pca success
-    name: pca
     outputPaths:
-      contribution:
-        max_index: null
-        path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/contribution.json
-        type: bar
-      cumsum_contribution:
-        max_index: null
-        path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/cumsum_contribution.json
-        type: bar
       explained_variance:
-        max_index: null
         path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/evr.json
         type: bar
-      projectedNd:
         max_index: null
+      projectedNd:
         path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/projectedNd.json
         type: scatter
-    started_at: '2023-11-22 17:20:53'
+        max_index: null
+      contribution:
+        path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/contribution.json
+        type: bar
+        max_index: null
+      cumsum_contribution:
+        path: /tmp/studio/output/1/tutorial2/pca_xi0d87mbrk/cumsum_contribution.json
+        type: bar
+        max_index: null
+    started_at: '2024-04-11 16:49:09'
+    finished_at: '2024-04-11 16:49:14'
+  caiman_cnmf_qcjcwx9uq7:
+    unique_id: caiman_cnmf_qcjcwx9uq7
+    name: caiman_cnmf
     success: success
-    unique_id: pca_xi0d87mbrk
-hasNWB: true
-name: Tutorial2
+    hasNWB: true
+    message: caiman_cnmf success
+    outputPaths:
+      images:
+        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_qcjcwx9uq7/images.json
+        type: images
+        max_index: 1
+      fluorescence:
+        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_qcjcwx9uq7/fluorescence
+        type: timeseries
+        max_index: 4
+      all_roi:
+        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_qcjcwx9uq7/all_roi.json
+        type: roi
+        max_index: null
+      cell_roi:
+        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_qcjcwx9uq7/cell_roi.json
+        type: roi
+        max_index: null
+      non_cell_roi:
+        path: /tmp/studio/output/1/tutorial2/caiman_cnmf_qcjcwx9uq7/non_cell_roi.json
+        type: roi
+        max_index: null
+    started_at: '2024-04-11 16:48:36'
+    finished_at: '2024-04-11 16:48:59'
 nwb:
   device:
     description: Microscope Information
@@ -119,7 +123,3 @@ snakemake:
   forcetargets: true
   lock: false
   use_conda: true
-started_at: '2023-11-22 17:20:42'
-success: success
-unique_id: tutorial2
-workspace_id: '1'

--- a/sample_data/output/tutorial2/snakemake.yaml
+++ b/sample_data/output/tutorial2/snakemake.yaml
@@ -1,41 +1,9 @@
-last_output:
-- 1/tutorial2/pca_xi0d87mbrk/pca.pkl
 rules:
-  caiman_cnmf_z6a16cmiwl:
-    hdf5Path: null
-    input:
-    - 1/tutorial2/caiman_mc_p4f6nsi9bh/caiman_mc.pkl
-    nwbfile: null
-    output: 1/tutorial2/caiman_cnmf_z6a16cmiwl/caiman_cnmf.pkl
-    params:
-      init_params:
-        K: 4
-        do_refit: false
-        gSig:
-        - 4
-        - 4
-        method_init: greedy_roi
-        nb: 2
-        ssub: 1
-        tsub: 1
-      merge_params:
-        merge_thr: 0.85
-        thr: 0.9
-      patch_params:
-        rf: null
-        stride: 6
-      preprocess_params:
-        p: 1
-    path: caiman/caiman_cnmf
-    return_arg:
-      mc_images: images
-    type: caiman_cnmf
   caiman_mc_p4f6nsi9bh:
-    hdf5Path: null
     input:
     - 1/tutorial2/input_0/sample_mouse2p_image.pkl
-    nwbfile: null
-    output: 1/tutorial2/caiman_mc_p4f6nsi9bh/caiman_mc.pkl
+    return_arg:
+      input_0: image
     params:
       border_nan: copy
       gSig_filt: null
@@ -62,53 +30,57 @@ rules:
       - 96
       upsample_factor_grid: 4
       use_cuda: false
-    path: caiman/caiman_mc
-    return_arg:
-      input_0: image
+    output: 1/tutorial2/caiman_mc_p4f6nsi9bh/caiman_mc.pkl
     type: caiman_mc
-  input_0:
+    nwbfile: null
     hdf5Path: null
+    matPath: null
+    path: caiman/caiman_mc
+  input_0:
     input:
     - 1/sample_mouse2p_image.tiff
+    return_arg: input_0
+    params: {}
+    output: 1/tutorial2/input_0/sample_mouse2p_image.pkl
+    type: image
     nwbfile:
+      session_description: optinist
+      identifier: optinist
+      experiment_description: None
       device:
+        name: Microscope device
         description: Microscope Information
         manufacturer: Microscope Manufacture
-        name: Microscope device
-      experiment_description: None
-      identifier: optinist
-      image_series:
-        starting_frame:
-        - 0
-        starting_time: 0
-      imaging_plane:
-        description: standard
-        excitation_lambda: 900.0
-        imaging_rate: 30.0
-        indicator: GCaMP
-        location: V1
-        name: ImagingPlane
-      ophys:
-        plane_segmentation:
-          description: ''
-          name: PlaneSegmentation
       optical_channel:
+        name: OpticalChannel
         description: optical channel
         emission_lambda: 500.0
-        name: OpticalChannel
-      session_description: optinist
-    output: 1/tutorial2/input_0/sample_mouse2p_image.pkl
-    params: {}
-    path: null
-    return_arg: input_0
-    type: image
-  pca_xi0d87mbrk:
+      imaging_plane:
+        name: ImagingPlane
+        description: standard
+        imaging_rate: 30.0
+        excitation_lambda: 900.0
+        indicator: GCaMP
+        location: V1
+      image_series:
+        starting_time: 0
+        starting_frame:
+        - 0
+        save_raw_image_to_nwb: false
+      ophys:
+        plane_segmentation:
+          name: PlaneSegmentation
+          description: ''
     hdf5Path: null
+    matPath: null
+    path: null
+  pca_xi0d87mbrk:
     input:
-    - 1/tutorial2/caiman_cnmf_z6a16cmiwl/caiman_cnmf.pkl
-    - 1/tutorial2/caiman_cnmf_z6a16cmiwl/caiman_cnmf.pkl
-    nwbfile: null
-    output: 1/tutorial2/pca_xi0d87mbrk/pca.pkl
+    - 1/tutorial2/caiman_cnmf_qcjcwx9uq7/caiman_cnmf.pkl
+    - 1/tutorial2/caiman_cnmf_qcjcwx9uq7/caiman_cnmf.pkl
+    return_arg:
+      fluorescence: neural_data
+      iscell: iscell
     params:
       PCA:
         copy: true
@@ -120,8 +92,116 @@ rules:
       standard_mean: true
       standard_std: true
       transpose: true
-    path: optinist/dimension_reduction/pca
-    return_arg:
-      fluorescence: neural_data
-      iscell: iscell
+    output: 1/tutorial2/pca_xi0d87mbrk/pca.pkl
     type: pca
+    nwbfile: null
+    hdf5Path: null
+    matPath: null
+    path: optinist/dimension_reduction/pca
+  caiman_cnmf_qcjcwx9uq7:
+    input:
+    - 1/tutorial2/caiman_mc_p4f6nsi9bh/caiman_mc.pkl
+    return_arg:
+      mc_images: images
+    params:
+      data_params:
+        decay_time: 0.4
+      init_params:
+        do_refit: false
+        K: 4
+        gSig:
+        - 4
+        - 4
+        ssub: 1
+        tsub: 1
+        nb: 2
+        method_init: greedy_roi
+        roi_thr: 0.9
+      preprocess_params:
+        p: 1
+      patch_params:
+        rf: null
+        stride: 6
+      merge_params:
+        merge_thr: 0.85
+      advanced:
+        init_params:
+          SC_kernel: heat
+          SC_sigma: 1
+          SC_thr: 0
+          SC_normalize: true
+          SC_use_NN: false
+          SC_nnn: 20
+          gSiz: null
+          center_psf: false
+          lambda_gnmf: 1
+          maxIter: 5
+          min_corr: 0.85
+          min_pnr: 20
+          seed_method: auto
+          ring_size_factor: 1.5
+          ssub_B: 2
+          init_iter: 2
+          nIter: 5
+          rolling_sum: true
+          rolling_length: 100
+          kernel: null
+          max_iter_snmf: 500
+          alpha_snmf: 0.5
+          sigma_smooth_snmf:
+          - 0.5
+          - 0.5
+          - 0.5
+          perc_baseline_snmf: 20
+          normalize_init: true
+          options_local_NMF: null
+        preprocess_params:
+          sn: null
+          noise_range:
+          - 0.25
+          - 0.5
+          noise_method: mean
+          max_num_samples_fft: 3072
+          n_pixels_per_process: null
+          compute_g: false
+          lags: 5
+          include_noise: false
+          pixels: null
+          check_nan: true
+        patch_params:
+          nb_patch: 1
+          border_pix: 0
+          low_rank_background: true
+          del_duplicates: false
+          only_init: true
+          p_patch: 0
+          skip_refinement: false
+          remove_very_bad_comps: false
+          p_ssub: 2
+          p_tsub: 2
+          memory_fact: 1
+          n_processes: 1
+          in_memory: true
+        merge_params:
+          do_merge: true
+          merge_parallel: false
+          max_merge_area: null
+        quality_evaluation_params:
+          SNR_lowest: 0.5
+          cnn_lowest: 0.1
+          gSig_range: null
+          min_SNR: 2.5
+          min_cnn_thr: 0.9
+          rval_lowest: -1
+          rval_thr: 0.8
+          use_cnn: true
+          use_ecc: false
+          max_ecc: 3
+    output: 1/tutorial2/caiman_cnmf_qcjcwx9uq7/caiman_cnmf.pkl
+    type: caiman_cnmf
+    nwbfile: null
+    hdf5Path: null
+    matPath: null
+    path: caiman/caiman_cnmf
+last_output:
+- 1/tutorial2/pca_xi0d87mbrk/pca.pkl

--- a/sample_data/output/tutorial2/workflow.yaml
+++ b/sample_data/output/tutorial2/workflow.yaml
@@ -1,146 +1,8 @@
-edgeDict:
-  ? reactflow__edge-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--fluorescence--FluoData-pca_xi0d87mbrkpca_xi0d87mbrk--neural_data--FluoData
-  : animated: false
-    id: reactflow__edge-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--fluorescence--FluoData-pca_xi0d87mbrkpca_xi0d87mbrk--neural_data--FluoData
-    source: caiman_cnmf_z6a16cmiwl
-    sourceHandle: caiman_cnmf_z6a16cmiwl--fluorescence--FluoData
-    style:
-      border: null
-      borderRadius: null
-      height: null
-      padding: null
-      width: 5
-    target: pca_xi0d87mbrk
-    targetHandle: pca_xi0d87mbrk--neural_data--FluoData
-    type: buttonedge
-  ? reactflow__edge-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--iscell--IscellData-pca_xi0d87mbrkpca_xi0d87mbrk--iscell--IscellData
-  : animated: false
-    id: reactflow__edge-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--iscell--IscellData-pca_xi0d87mbrkpca_xi0d87mbrk--iscell--IscellData
-    source: caiman_cnmf_z6a16cmiwl
-    sourceHandle: caiman_cnmf_z6a16cmiwl--iscell--IscellData
-    style:
-      border: null
-      borderRadius: null
-      height: null
-      padding: null
-      width: 5
-    target: pca_xi0d87mbrk
-    targetHandle: pca_xi0d87mbrk--iscell--IscellData
-    type: buttonedge
-  ? reactflow__edge-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--mc_images--ImageData-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--images--ImageData
-  : animated: false
-    id: reactflow__edge-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--mc_images--ImageData-caiman_cnmf_z6a16cmiwlcaiman_cnmf_z6a16cmiwl--images--ImageData
-    source: caiman_mc_p4f6nsi9bh
-    sourceHandle: caiman_mc_p4f6nsi9bh--mc_images--ImageData
-    style:
-      border: null
-      borderRadius: null
-      height: null
-      padding: null
-      width: 5
-    target: caiman_cnmf_z6a16cmiwl
-    targetHandle: caiman_cnmf_z6a16cmiwl--images--ImageData
-    type: buttonedge
-  reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData:
-    animated: false
-    id: reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData
-    source: input_0
-    sourceHandle: input_0--image--ImageData
-    style:
-      border: null
-      borderRadius: null
-      height: null
-      padding: null
-      width: 5
-    target: caiman_mc_p4f6nsi9bh
-    targetHandle: caiman_mc_p4f6nsi9bh--image--ImageData
-    type: buttonedge
 nodeDict:
-  caiman_cnmf_z6a16cmiwl:
-    data:
-      fileType: null
-      hdf5Path: null
-      label: caiman_cnmf
-      param:
-        init_params:
-          children:
-            K:
-              path: init_params/K
-              type: child
-              value: 4
-            do_refit:
-              path: init_params/do_refit
-              type: child
-              value: false
-            gSig:
-              path: init_params/gSig
-              type: child
-              value:
-              - 4
-              - 4
-            method_init:
-              path: init_params/method_init
-              type: child
-              value: greedy_roi
-            nb:
-              path: init_params/nb
-              type: child
-              value: 2
-            ssub:
-              path: init_params/ssub
-              type: child
-              value: 1
-            tsub:
-              path: init_params/tsub
-              type: child
-              value: 1
-          type: parent
-        merge_params:
-          children:
-            merge_thr:
-              path: merge_params/merge_thr
-              type: child
-              value: 0.85
-            thr:
-              path: merge_params/thr
-              type: child
-              value: 0.9
-          type: parent
-        patch_params:
-          children:
-            rf:
-              path: patch_params/rf
-              type: child
-              value: null
-            stride:
-              path: patch_params/stride
-              type: child
-              value: 6
-          type: parent
-        preprocess_params:
-          children:
-            p:
-              path: preprocess_params/p
-              type: child
-              value: 1
-          type: parent
-      path: caiman/caiman_cnmf
-      type: algorithm
-    id: caiman_cnmf_z6a16cmiwl
-    position:
-      x: 600
-      y: 146
-    style:
-      border: '1px solid #777'
-      borderRadius: 0
-      height: 125
-      padding: 0
-      width: 250
-    type: AlgorithmNode
   caiman_mc_p4f6nsi9bh:
+    id: caiman_mc_p4f6nsi9bh
+    type: AlgorithmNode
     data:
-      fileType: null
-      hdf5Path: null
       label: caiman_mc
       param:
         border_nan:
@@ -227,41 +89,43 @@ nodeDict:
           value: false
       path: caiman/caiman_mc
       type: algorithm
-    id: caiman_mc_p4f6nsi9bh
+      fileType: null
+      hdf5Path: null
+      matPath: null
     position:
       x: 324
       y: 147
     style:
       border: '1px solid #777'
-      borderRadius: 0
-      height: 125
+      height: 140
       padding: 0
       width: 250
-    type: AlgorithmNode
+      borderRadius: 0
   input_0:
+    id: input_0
+    type: ImageFileNode
     data:
-      fileType: image
-      hdf5Path: null
       label: sample_mouse2p_image.tiff
       param: {}
       path:
       - sample_mouse2p_image.tiff
       type: input
-    id: input_0
+      fileType: image
+      hdf5Path: null
+      matPath: null
     position:
       x: 50
       y: 150
     style:
       border: '1px solid #777'
-      borderRadius: null
-      height: 125
+      height: 140
       padding: null
       width: 250
-    type: ImageFileNode
+      borderRadius: null
   pca_xi0d87mbrk:
+    id: pca_xi0d87mbrk
+    type: AlgorithmNode
     data:
-      fileType: null
-      hdf5Path: null
       label: pca
       param:
         PCA:
@@ -305,14 +169,432 @@ nodeDict:
           value: true
       path: optinist/dimension_reduction/pca
       type: algorithm
-    id: pca_xi0d87mbrk
+      fileType: null
+      hdf5Path: null
+      matPath: null
     position:
-      x: 905.7142857142858
-      y: 146.77784847116664
+      x: 905
+      y: 146
     style:
       border: '1px solid #777'
-      borderRadius: 0
-      height: 125
+      height: 140
       padding: 0
       width: 250
+      borderRadius: 0
+  caiman_cnmf_qcjcwx9uq7:
+    id: caiman_cnmf_qcjcwx9uq7
     type: AlgorithmNode
+    data:
+      label: caiman_cnmf
+      param:
+        data_params:
+          type: parent
+          children:
+            decay_time:
+              type: child
+              value: 0.4
+              path: data_params/decay_time
+        init_params:
+          type: parent
+          children:
+            do_refit:
+              type: child
+              value: false
+              path: init_params/do_refit
+            K:
+              type: child
+              value: 4
+              path: init_params/K
+            gSig:
+              type: child
+              value:
+              - 4
+              - 4
+              path: init_params/gSig
+            ssub:
+              type: child
+              value: 1
+              path: init_params/ssub
+            tsub:
+              type: child
+              value: 1
+              path: init_params/tsub
+            nb:
+              type: child
+              value: 2
+              path: init_params/nb
+            method_init:
+              type: child
+              value: greedy_roi
+              path: init_params/method_init
+            roi_thr:
+              type: child
+              value: 0.9
+              path: init_params/roi_thr
+        preprocess_params:
+          type: parent
+          children:
+            p:
+              type: child
+              value: 1
+              path: preprocess_params/p
+        patch_params:
+          type: parent
+          children:
+            rf:
+              type: child
+              value: null
+              path: patch_params/rf
+            stride:
+              type: child
+              value: 6
+              path: patch_params/stride
+        merge_params:
+          type: parent
+          children:
+            merge_thr:
+              type: child
+              value: 0.85
+              path: merge_params/merge_thr
+        advanced:
+          type: parent
+          children:
+            init_params:
+              type: parent
+              children:
+                SC_kernel:
+                  type: child
+                  value: heat
+                  path: advanced/init_params/SC_kernel
+                SC_sigma:
+                  type: child
+                  value: 1
+                  path: advanced/init_params/SC_sigma
+                SC_thr:
+                  type: child
+                  value: 0
+                  path: advanced/init_params/SC_thr
+                SC_normalize:
+                  type: child
+                  value: true
+                  path: advanced/init_params/SC_normalize
+                SC_use_NN:
+                  type: child
+                  value: false
+                  path: advanced/init_params/SC_use_NN
+                SC_nnn:
+                  type: child
+                  value: 20
+                  path: advanced/init_params/SC_nnn
+                gSiz:
+                  type: child
+                  value: null
+                  path: advanced/init_params/gSiz
+                center_psf:
+                  type: child
+                  value: false
+                  path: advanced/init_params/center_psf
+                lambda_gnmf:
+                  type: child
+                  value: 1
+                  path: advanced/init_params/lambda_gnmf
+                maxIter:
+                  type: child
+                  value: 5
+                  path: advanced/init_params/maxIter
+                min_corr:
+                  type: child
+                  value: 0.85
+                  path: advanced/init_params/min_corr
+                min_pnr:
+                  type: child
+                  value: 20
+                  path: advanced/init_params/min_pnr
+                seed_method:
+                  type: child
+                  value: auto
+                  path: advanced/init_params/seed_method
+                ring_size_factor:
+                  type: child
+                  value: 1.5
+                  path: advanced/init_params/ring_size_factor
+                ssub_B:
+                  type: child
+                  value: 2
+                  path: advanced/init_params/ssub_B
+                init_iter:
+                  type: child
+                  value: 2
+                  path: advanced/init_params/init_iter
+                nIter:
+                  type: child
+                  value: 5
+                  path: advanced/init_params/nIter
+                rolling_sum:
+                  type: child
+                  value: true
+                  path: advanced/init_params/rolling_sum
+                rolling_length:
+                  type: child
+                  value: 100
+                  path: advanced/init_params/rolling_length
+                kernel:
+                  type: child
+                  value: null
+                  path: advanced/init_params/kernel
+                max_iter_snmf:
+                  type: child
+                  value: 500
+                  path: advanced/init_params/max_iter_snmf
+                alpha_snmf:
+                  type: child
+                  value: 0.5
+                  path: advanced/init_params/alpha_snmf
+                sigma_smooth_snmf:
+                  type: child
+                  value:
+                  - 0.5
+                  - 0.5
+                  - 0.5
+                  path: advanced/init_params/sigma_smooth_snmf
+                perc_baseline_snmf:
+                  type: child
+                  value: 20
+                  path: advanced/init_params/perc_baseline_snmf
+                normalize_init:
+                  type: child
+                  value: true
+                  path: advanced/init_params/normalize_init
+                options_local_NMF:
+                  type: child
+                  value: null
+                  path: advanced/init_params/options_local_NMF
+            preprocess_params:
+              type: parent
+              children:
+                sn:
+                  type: child
+                  value: null
+                  path: advanced/init_params/preprocess_params/sn
+                noise_range:
+                  type: child
+                  value:
+                  - 0.25
+                  - 0.5
+                  path: advanced/init_params/preprocess_params/noise_range
+                noise_method:
+                  type: child
+                  value: mean
+                  path: advanced/init_params/preprocess_params/noise_method
+                max_num_samples_fft:
+                  type: child
+                  value: 3072
+                  path: advanced/init_params/preprocess_params/max_num_samples_fft
+                n_pixels_per_process:
+                  type: child
+                  value: null
+                  path: advanced/init_params/preprocess_params/n_pixels_per_process
+                compute_g:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/compute_g
+                lags:
+                  type: child
+                  value: 5
+                  path: advanced/init_params/preprocess_params/lags
+                include_noise:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/include_noise
+                pixels:
+                  type: child
+                  value: null
+                  path: advanced/init_params/preprocess_params/pixels
+                check_nan:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/check_nan
+            patch_params:
+              type: parent
+              children:
+                nb_patch:
+                  type: child
+                  value: 1
+                  path: advanced/init_params/preprocess_params/patch_params/nb_patch
+                border_pix:
+                  type: child
+                  value: 0
+                  path: advanced/init_params/preprocess_params/patch_params/border_pix
+                low_rank_background:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/patch_params/low_rank_background
+                del_duplicates:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/patch_params/del_duplicates
+                only_init:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/patch_params/only_init
+                p_patch:
+                  type: child
+                  value: 0
+                  path: advanced/init_params/preprocess_params/patch_params/p_patch
+                skip_refinement:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/patch_params/skip_refinement
+                remove_very_bad_comps:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/patch_params/remove_very_bad_comps
+                p_ssub:
+                  type: child
+                  value: 2
+                  path: advanced/init_params/preprocess_params/patch_params/p_ssub
+                p_tsub:
+                  type: child
+                  value: 2
+                  path: advanced/init_params/preprocess_params/patch_params/p_tsub
+                memory_fact:
+                  type: child
+                  value: 1
+                  path: advanced/init_params/preprocess_params/patch_params/memory_fact
+                n_processes:
+                  type: child
+                  value: 1
+                  path: advanced/init_params/preprocess_params/patch_params/n_processes
+                in_memory:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/patch_params/in_memory
+            merge_params:
+              type: parent
+              children:
+                do_merge:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/do_merge
+                merge_parallel:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/merge_parallel
+                max_merge_area:
+                  type: child
+                  value: null
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/max_merge_area
+            quality_evaluation_params:
+              type: parent
+              children:
+                SNR_lowest:
+                  type: child
+                  value: 0.5
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/SNR_lowest
+                cnn_lowest:
+                  type: child
+                  value: 0.1
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/cnn_lowest
+                gSig_range:
+                  type: child
+                  value: null
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/gSig_range
+                min_SNR:
+                  type: child
+                  value: 2.5
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/min_SNR
+                min_cnn_thr:
+                  type: child
+                  value: 0.9
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/min_cnn_thr
+                rval_lowest:
+                  type: child
+                  value: -1
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/rval_lowest
+                rval_thr:
+                  type: child
+                  value: 0.8
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/rval_thr
+                use_cnn:
+                  type: child
+                  value: true
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/use_cnn
+                use_ecc:
+                  type: child
+                  value: false
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/use_ecc
+                max_ecc:
+                  type: child
+                  value: 3
+                  path: advanced/init_params/preprocess_params/patch_params/merge_params/quality_evaluation_params/max_ecc
+      path: caiman/caiman_cnmf
+      type: algorithm
+      fileType: null
+      hdf5Path: null
+      matPath: null
+    position:
+      x: 614.2857142857143
+      y: 146.23411008263156
+    style:
+      border: '1px solid #777'
+      height: 140
+      padding: 0
+      width: 250
+      borderRadius: 0
+edgeDict:
+  reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData:
+    id: reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData
+    type: buttonedge
+    animated: false
+    source: input_0
+    sourceHandle: input_0--image--ImageData
+    target: caiman_mc_p4f6nsi9bh
+    targetHandle: caiman_mc_p4f6nsi9bh--image--ImageData
+    style:
+      border: null
+      height: null
+      padding: null
+      width: 5
+      borderRadius: null
+  ? reactflow__edge-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--mc_images--ImageData-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--images--ImageData
+  : id: reactflow__edge-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--mc_images--ImageData-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--images--ImageData
+    type: buttonedge
+    animated: false
+    source: caiman_mc_p4f6nsi9bh
+    sourceHandle: caiman_mc_p4f6nsi9bh--mc_images--ImageData
+    target: caiman_cnmf_qcjcwx9uq7
+    targetHandle: caiman_cnmf_qcjcwx9uq7--images--ImageData
+    style:
+      border: null
+      height: null
+      padding: null
+      width: 5
+      borderRadius: null
+  ? reactflow__edge-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--fluorescence--FluoData-pca_xi0d87mbrkpca_xi0d87mbrk--neural_data--FluoData
+  : id: reactflow__edge-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--fluorescence--FluoData-pca_xi0d87mbrkpca_xi0d87mbrk--neural_data--FluoData
+    type: buttonedge
+    animated: false
+    source: caiman_cnmf_qcjcwx9uq7
+    sourceHandle: caiman_cnmf_qcjcwx9uq7--fluorescence--FluoData
+    target: pca_xi0d87mbrk
+    targetHandle: pca_xi0d87mbrk--neural_data--FluoData
+    style:
+      border: null
+      height: null
+      padding: null
+      width: 5
+      borderRadius: null
+  ? reactflow__edge-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--iscell--IscellData-pca_xi0d87mbrkpca_xi0d87mbrk--iscell--IscellData
+  : id: reactflow__edge-caiman_cnmf_qcjcwx9uq7caiman_cnmf_qcjcwx9uq7--iscell--IscellData-pca_xi0d87mbrkpca_xi0d87mbrk--iscell--IscellData
+    type: buttonedge
+    animated: false
+    source: caiman_cnmf_qcjcwx9uq7
+    sourceHandle: caiman_cnmf_qcjcwx9uq7--iscell--IscellData
+    target: pca_xi0d87mbrk
+    targetHandle: pca_xi0d87mbrk--iscell--IscellData
+    style:
+      border: null
+      height: null
+      padding: null
+      width: 5
+      borderRadius: null


### PR DESCRIPTION
## 概要
- Tutorial2を実行する際に`check_types`でKeyErrorが発生する問題を修正

## 原因
- caiman_cnmfに #300 などでパラメータが追加されたことに伴い、チュートリアルで使用しているyamlファイルのパラメータと不一致になっており、バリデーションで弾かれてしまった

## 対応
- 最新版のcnmfノードに置き換えて実行した結果でTutorialファイルを差し替え