### PR TITLE
fix roi select not working on linked plots

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
@@ -455,7 +455,6 @@ const ImagePlotChart = memo(function ImagePlotChart({
   }
 
   const onChartClick = (event: PlotMouseEvent) => {
-    if (![MERGE_ROI, DELETE_ROI].includes(action)) return
     // use as unknown because original PlotDatum does not have z property
     const point: PlotDatum = event.points[0] as unknown as PlotDatum
     if (point.curveNumber >= 1 && outputKey === "cell_roi") {


### PR DESCRIPTION
- ROIをclickした際にリンクしているfluorescenceのplotに反映されない問題を修正