### PR TITLE
adjust caiman dependencies

### DIFF
--- a/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
+++ b/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
@@ -6,3 +6,4 @@ dependencies:
   - cython
   - numpy=1.22.*
   - caiman>=1.9.9, <=1.9.12
+  - scikit-image=0.19.*


### PR DESCRIPTION
現在の dependencies の構成で、caimanの処理でエラー（deprecatedのため）となるモジュールバージョン（scikit-image 0.20）がインストールされるケースがあるため、バージョンを明記する。
※今後、他のモジュールでも deprecated が生じた場合は、同様の対応を行う形を想定。