### PR TITLE
Update docs about x86_64 installation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,4 +36,5 @@ Main Features
   gui/index
   host_for_multiuser/index
   utils/index
+  utils/nwb_file
   for_developers/index

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -21,15 +21,44 @@ Please follow instructions below.
 
 #### Install Anaconda
 
-- Download and install package.
-  - https://repo.anaconda.com/archive/
-    - Anaconda3-\*.\*-MacOSX-x86_64.pkg
-      - *The latest version of the module is ok.
+- Download and install the package:
+  - [Anaconda Archive](https://repo.anaconda.com/archive/)
+    - Download the latest version: `Anaconda3-*.MacOSX-x86_64.pkg`
+      - *The latest version of the module is fine.*
 
 ```{eval-rst}
 .. caution::
-   Even if you're using arm64 (Apple Sillicon, M1, M2...) architecture's Mac, x86_64 version is required.
-   Some modules cannot be installed by conda install or pip install in arm64 version.
+   Even if you're using arm64 (Apple Silicon, M1, M2...) architecture's Mac, the x86_64 version is required.
+   Some modules cannot be installed by conda install or pip install in the arm64 version.
+   Installing the x86_64 version of conda can be done using `rosetta`.
+
+   1. Install Rosetta using the terminal:
+
+        .. code-block:: bash
+
+          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+
+   2. Open a Terminal Session in Rosetta:
+      - Open your existing Terminal (which is running natively on ARM).
+      - Start a new Terminal session that emulates the x86_64 architecture using the following command:
+
+        .. code-block:: bash
+
+           arch -x86_64 /usr/bin/env bash
+
+   3. Download and install Miniconda:
+
+        .. code-block:: bash
+
+           curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+
+           bash Miniconda3-latest-MacOSX-x86_64.sh
+
+           /Users/MYUSERNAME/miniconda3/bin/conda init
+
+           conda activate
+
+   Now continue creating the optinist environment using conda
 ```
 
 ### Create anaconda environment


### PR DESCRIPTION
Add further explanation to documentation for running Optimist on Apple Silicon chips
Problem:
conda installations on M chips do not run correctly

Solution:
Install Intel-based conda (x86_64) using Rosetta2. 