### PR TITLE
Fixed ExptDataWriter bug

### DIFF
--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -131,6 +131,7 @@ class ExptDataWriter:
         with open(filepath, "r+") as f:
             config = yaml.safe_load(f)
             config["name"] = new_name
+            f.seek(0)  # requires seek(0) before write.
             yaml.dump(config, f, sort_keys=False)
 
         return ExptConfig(


### PR DESCRIPTION
- A seek(0) was needed before file write in rename().
  - On the surface, the problem was not visible, but an unexpected data append to experiment.yaml had occurred. 