### PR TITLE
Implement downloading of config yaml from remote when singin

### DIFF
--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -122,9 +122,9 @@ class BaseRemoteStorageController(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def download_experiment_metas(self, workspace_id: str, unique_id: str) -> bool:
+    def download_all_experiments_metas(self) -> bool:
         """
-        download experiment metadata from remote storage.
+        download all experiment metadata from remote storage.
         """
 
     @abstractmethod
@@ -177,8 +177,8 @@ class RemoteStorageController(BaseRemoteStorageController):
     def make_experiment_remote_path(self, workspace_id: str, unique_id: str) -> str:
         return self.__controller.make_experiment_remote_path(workspace_id, unique_id)
 
-    def download_experiment_metas(self, workspace_id: str, unique_id: str) -> bool:
-        return self.__controller.download_experiment_metas(workspace_id, unique_id)
+    def download_all_experiments_metas(self) -> bool:
+        return self.__controller.download_all_experiments_metas()
 
     def download_experiment(self, workspace_id: str, unique_id: str) -> bool:
         return self.__controller.download_experiment(workspace_id, unique_id)


### PR DESCRIPTION
### 対応内容

- SingIn時処理 クラウドストレージ対応
  - 主な改修ポイント
    - SingIn時のExperiments Metadata (*.yaml) のダウンロード処理
  - 詳細仕様
    - https://docs.google.com/presentation/d/1Qvwfhk49bweP6uaqC-PCoCQUGGqZC78a/edit#slide=id.p8
    - https://drive.google.com/file/d/1ssqWHzO5P42vIFy5WCziV2g6dM_YN89a/view?usp=drive_link

### Review観点補足

- [ ] S3上のMetadata の検索方式について
  - s3_storage_controller.py 内の S3StorageController.download_all_experiments_metas() では、データのダウンロードに aws cli （外部コマンド）を利用しているが、妥当であるか
    - pip module利用版（boto3）よりもプログラムードは簡潔となるが、外部コマンドへの依存が生じる

### テストケース

※別途準備想定