### PR TITLE
fixed a bug in the rename of exepriment name

### DIFF
--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -128,10 +128,12 @@ class ExptDataWriter:
             ]
         )
 
-        with open(filepath, "r+") as f:
+        # Note: "r+" option is not used here because it requires file pointer control.
+        with open(filepath, "r") as f:
             config = yaml.safe_load(f)
             config["name"] = new_name
-            f.seek(0)  # requires seek(0) before write.
+
+        with open(filepath, "w") as f:
             yaml.dump(config, f, sort_keys=False)
 
         return ExptConfig(


### PR DESCRIPTION
- Content
  - Bug
    - “r+” was used to open a file to be written, but the file truncation process was insufficient, and in some cases garbage remained at the end of the file.
  - Solution
    - Stopped using "r+" mode and simply used "r" -> "w" processing order.

- Related
  - #366
  - #369