### PR TITLE
add remote storage upload on edit roi

### DIFF
--- a/studio/app/common/core/utils/filepath_finder.py
+++ b/studio/app/common/core/utils/filepath_finder.py
@@ -1,4 +1,6 @@
+import datetime
 import os
+import re
 from glob import glob
 from typing import Optional
 
@@ -27,3 +29,47 @@ def find_param_filepath(name: str):
 
 def find_condaenv_filepath(name: str):
     return find_filepath(name, "conda")
+
+
+def find_recent_updated_files(
+    find_root_dir: str,
+    threshold_minutes: int,
+    exclude_files: list = [],
+    do_relative_path: bool = False,
+):
+    """
+    Search for files that have been updated since the specified time.
+    """
+    time_threshold = datetime.datetime.now() - datetime.timedelta(
+        minutes=threshold_minutes
+    )
+    recent_files = []
+
+    # search under directories
+    for root, dirs, files in os.walk(find_root_dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+
+            # check exclude file
+            is_exclude = False
+            for exclude_file in exclude_files:
+                if exclude_file in file_path:
+                    is_exclude = True
+                    break
+            if is_exclude:
+                continue
+
+            # get mtime
+            file_mtime = os.path.getmtime(file_path)
+            file_mtime_dt = datetime.datetime.fromtimestamp(file_mtime)
+
+            # compare mtime
+            if file_mtime_dt > time_threshold:
+                result_file_path = (
+                    re.sub(f"^{find_root_dir}/", "", file_path)
+                    if do_relative_path
+                    else file_path
+                )
+                recent_files.append(result_file_path)
+
+    return recent_files

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -251,9 +251,7 @@ class EditROI:
 
         self.__update_pickle_for_roi_edition(self.pickle_file_path, info)
         self.__save_json(info)
-
-        # TODO: __update_whole_nwb 内でExceptionが生じているため、暫定コメントアウト 2024/09/16
-        # self.__update_whole_nwb(info)
+        self.__update_whole_nwb(info)
 
         (
             os.remove(self.tmp_pickle_file_path)

--- a/studio/app/optinist/routers/roi.py
+++ b/studio/app/optinist/routers/roi.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 
+from studio.app.common.core.auth.auth_dependencies import get_user_remote_bucket_name
 from studio.app.common.core.workspace.workspace_dependencies import is_workspace_owner
 from studio.app.optinist.core.edit_ROI import EditROI, EditRoiUtils
 from studio.app.optinist.schemas.roi import RoiList, RoiPos, RoiStatus
@@ -51,8 +52,11 @@ async def delete_roi(filepath: str, roi_list: RoiList):
     response_model=bool,
     dependencies=[Depends(is_workspace_owner)],
 )
-async def commit_edit(filepath: str):
-    EditRoiUtils.execute(filepath)
+async def commit_edit(
+    filepath: str,
+    remote_bucket_name: str = Depends(get_user_remote_bucket_name),
+):
+    EditRoiUtils.execute(filepath, remote_bucket_name)
     return True
 
 


### PR DESCRIPTION
### Contents

- Support for s3 upload of processing results
- Supplemental specifications
  - Only files that have been updated by edit roi (files that have been updated immediately before) are subject to upload.