### PR TITLE
Add S3 Bucket CRUD operation on Account Manager

### DIFF
--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -212,7 +212,7 @@ class BaseRemoteStorageController(metaclass=ABCMeta):
 
 class RemoteStorageController(BaseRemoteStorageController):
     def __init__(self, bucket_name: str):
-        remote_storage_type = os.environ.get("REMOTE_STORAGE_TYPE")
+        remote_storage_type = RemoteStorageType.get_activated_type()
 
         if remote_storage_type == RemoteStorageType.MOCK.value:
             from studio.app.common.core.storage.mock_storage_controller import (
@@ -234,6 +234,30 @@ class RemoteStorageController(BaseRemoteStorageController):
 
     def make_experiment_remote_path(self, workspace_id: str, unique_id: str) -> str:
         return self.__controller.make_experiment_remote_path(workspace_id, unique_id)
+
+    def create_bucket(self) -> bool:
+        remote_storage_type = RemoteStorageType.get_activated_type()
+        if remote_storage_type == RemoteStorageType.S3.value:
+            self.__controller.create_bucket()
+        else:
+            assert False, (
+                "This remote_storage_type "
+                f"does not support bucket: {remote_storage_type}"
+            )
+
+        return True
+
+    def delete_bucket(self, force_delete=False) -> bool:
+        remote_storage_type = RemoteStorageType.get_activated_type()
+        if remote_storage_type == RemoteStorageType.S3.value:
+            self.__controller.delete_bucket(force_delete)
+        else:
+            assert False, (
+                "This remote_storage_type "
+                f"does not support bucket: {remote_storage_type}"
+            )
+
+        return True
 
     def download_all_experiments_metas(self) -> bool:
         return self.__controller.download_all_experiments_metas()

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -235,6 +235,19 @@ class RemoteStorageController(BaseRemoteStorageController):
     def make_experiment_remote_path(self, workspace_id: str, unique_id: str) -> str:
         return self.__controller.make_experiment_remote_path(workspace_id, unique_id)
 
+    @staticmethod
+    def create_user_bucket_name(id: int, prefix: str = "optinist-user") -> str:
+        import hashlib
+        import time
+
+        current_time = time.time()
+        hash_src = f"{id}-{current_time}"
+        hash_value = hashlib.md5(hash_src.encode()).hexdigest()
+        hash_value = hash_value[0:10]
+        new_name = f"{prefix}-{id}-{hash_value}"
+
+        return new_name
+
     def create_bucket(self) -> bool:
         remote_storage_type = RemoteStorageType.get_activated_type()
         if remote_storage_type == RemoteStorageType.S3.value:

--- a/studio/app/common/core/storage/s3_storage_controller.py
+++ b/studio/app/common/core/storage/s3_storage_controller.py
@@ -141,10 +141,13 @@ class S3StorageController(BaseRemoteStorageController):
             ), f"Fail aws_s3_sync_command. {cmd_ret.stderr}"
 
             # extract target files paths from command's stdout
-            target_files_str = re.sub(
-                "^.*(s3://[^ ]*) .*$", r"\1", cmd_ret.stdout, flags=(re.MULTILINE)
-            ).strip()
-            target_files = target_files_str.split("\n")
+            if len(str(cmd_ret.stdout).strip()) > 0:
+                target_files_str = re.sub(
+                    "^.*(s3://[^ ]*) .*$", r"\1", cmd_ret.stdout, flags=(re.MULTILINE)
+                ).strip()
+                target_files = target_files_str.split("\n")
+            else:
+                target_files = []
 
             logger.debug(
                 "aws s3 sync result: [returncode:%d][len:%d]",


### PR DESCRIPTION
### Functions

- on Account Manager Screen
  - When adding an account ... create user s3 bucket
  - When deleting an account ... delete user s3 bucket

- Remarks
  - bucket name format ... `optinist-{user_id}-{unique_hash}`

### Testcase

1. create user → create bucket succeeded
2. singin → execute workflow → S3 sync succeeded
3. delete user → delete bucket succeeded