### PR TITLE
Edit ROI UI improve bugfix

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
@@ -659,11 +659,18 @@ const ImagePlotChart = memo(function ImagePlotChart({
   const onCommitRoi = async () => {
     if (!roiFilePath || workspaceId === undefined) return
     try {
-      await dispatch(commitRoi({ path: roiFilePath, workspaceId }))
+      await dispatch(commitRoi({ path: roiFilePath, workspaceId })).unwrap()
       workspaceId &&
-        (await dispatch(getRoiData({ path: roiFilePath, workspaceId })))
-      enqueueSnackbar("Finished", { variant: "success" })
+        (await dispatch(
+          getRoiData({ path: roiFilePath, workspaceId }),
+        ).unwrap())
+
+      enqueueSnackbar("Successfully committed to Edit ROI.", {
+        variant: "success",
+      })
       resetTimeSeries()
+    } catch (error) {
+      enqueueSnackbar("Failed to commit Edit ROI.", { variant: "error" })
     } finally {
       setEdit(false)
       setAction("")

--- a/frontend/src/components/Workspace/Visualize/VisualizeItem.tsx
+++ b/frontend/src/components/Workspace/Visualize/VisualizeItem.tsx
@@ -14,7 +14,10 @@ import Loading from "components/common/Loading"
 import { useMouseDragHandler } from "components/utils/MouseDragUtil"
 import { DisplayDataItem } from "components/Workspace/Visualize/DisplayDataItem"
 import { FilePathSelect } from "components/Workspace/Visualize/FilePathSelect"
-import { selectLoading } from "store/slice/DisplayData/DisplayDataSelectors"
+import {
+  selectLoading,
+  selectIsEditRoiCommitting,
+} from "store/slice/DisplayData/DisplayDataSelectors"
 import {
   DATA_TYPE,
   DATA_TYPE_SET,
@@ -65,13 +68,18 @@ export const VisualizeItem = memo(function VisualizeItem({
   const { size, onMouseDownX, onMouseDownY, onMouseDownXY } =
     useItemDragResize(itemId)
   const loading = useSelector(selectLoading)
+  const isEditRoiCommitting = useSelector(selectIsEditRoiCommitting)
+
   const [roiFilePath, setRoiFilePath] = useState("")
   return (
     <Box
       sx={{ m: 1, display: "flex", flexDirection: "row", position: "relative" }}
     >
       {loading && roiFilePath.includes("_roi.json") && (
-        <Loading loading={true} position={"absolute"} />
+        <Loading
+          loading={loading}
+          position={isEditRoiCommitting ? "fixed" : "absolute"}
+        />
       )}
       <Box
         sx={{

--- a/frontend/src/store/slice/DisplayData/DisplayDataSelectors.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataSelectors.ts
@@ -1,7 +1,11 @@
 import { RootState } from "store/store"
 
 const selectDisplayData = (state: RootState) => state.displayData
+
 export const selectLoading = (state: RootState) => state.displayData.loading
+
+export const selectIsEditRoiCommitting = (state: RootState) =>
+  state.displayData.isEditRoiCommitting
 
 export const selectTimeSeriesData = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).timeSeries[filePath].data

--- a/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
@@ -50,6 +50,7 @@ const initialState: DisplayData = {
   loading: false,
   loadingStack: [],
   statusRoi: { temp_add_roi: [], temp_delete_roi: [], temp_merge_roi: [] },
+  isEditRoiCommitting: false,
 }
 
 export const displayDataSlice = createSlice({
@@ -605,13 +606,17 @@ export const displayDataSlice = createSlice({
         state.loadingStack.pop()
         state.loading = state.loadingStack.length > 0
       })
+      .addCase(commitRoi.pending, (state) => {
+        state.isEditRoiCommitting = true
+
+        state.loadingStack.push((state.loading = true))
+      })
       .addMatcher(
         isAnyOf(
           cancelRoi.pending,
           mergeRoi.pending,
           deleteRoi.pending,
           addRoi.pending,
-          commitRoi.pending,
           getStatus.pending,
         ),
         (state) => {
@@ -627,8 +632,6 @@ export const displayDataSlice = createSlice({
           addRoi.fulfilled,
           deleteRoi.rejected,
           deleteRoi.fulfilled,
-          commitRoi.rejected,
-          commitRoi.fulfilled,
           getStatus.rejected,
         ),
         (state) => {
@@ -636,6 +639,12 @@ export const displayDataSlice = createSlice({
           state.loading = state.loadingStack.length > 0
         },
       )
+      .addMatcher(isAnyOf(commitRoi.rejected, commitRoi.fulfilled), (state) => {
+        state.isEditRoiCommitting = false
+
+        state.loadingStack.pop()
+        state.loading = state.loadingStack.length > 0
+      })
       .addMatcher(
         isAnyOf(run.fulfilled, runByCurrentUid.fulfilled),
         () => initialState,

--- a/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
@@ -48,6 +48,7 @@ const initialState: DisplayData = {
   pie: {},
   polar: {},
   loading: false,
+  loadingStack: [],
   statusRoi: { temp_add_roi: [], temp_delete_roi: [], temp_merge_roi: [] },
 }
 
@@ -435,7 +436,9 @@ export const displayDataSlice = createSlice({
       })
       .addCase(getRoiData.pending, (state, action) => {
         const { path } = action.meta.arg
-        state.loading = true
+
+        state.loadingStack.push((state.loading = true))
+
         state.roi[path] = {
           type: "roi",
           data: [],
@@ -448,7 +451,9 @@ export const displayDataSlice = createSlice({
       .addCase(getRoiData.fulfilled, (state, action) => {
         const { path } = action.meta.arg
         const { data } = action.payload
-        state.loading = false
+
+        state.loadingStack.pop()
+        state.loading = state.loadingStack.length > 0
 
         // 計算
         const roi1Ddata: number[] = data[0]
@@ -472,7 +477,10 @@ export const displayDataSlice = createSlice({
       })
       .addCase(getRoiData.rejected, (state, action) => {
         const { path } = action.meta.arg
-        state.loading = false
+
+        state.loadingStack.pop()
+        state.loading = state.loadingStack.length > 0
+
         state.roi[path] = {
           type: "roi",
           data: [],
@@ -583,7 +591,9 @@ export const displayDataSlice = createSlice({
       })
       .addCase(getStatus.fulfilled, (state, action) => {
         state.statusRoi = action.payload
-        state.loading = false
+
+        state.loadingStack.pop()
+        state.loading = state.loadingStack.length > 0
       })
       .addCase(cancelRoi.fulfilled, (state) => {
         state.statusRoi = {
@@ -591,7 +601,9 @@ export const displayDataSlice = createSlice({
           temp_delete_roi: [],
           temp_merge_roi: [],
         }
-        state.loading = false
+
+        state.loadingStack.pop()
+        state.loading = state.loadingStack.length > 0
       })
       .addMatcher(
         isAnyOf(
@@ -603,7 +615,7 @@ export const displayDataSlice = createSlice({
           getStatus.pending,
         ),
         (state) => {
-          state.loading = true
+          state.loadingStack.push((state.loading = true))
         },
       )
       .addMatcher(
@@ -620,7 +632,8 @@ export const displayDataSlice = createSlice({
           getStatus.rejected,
         ),
         (state) => {
-          state.loading = false
+          state.loadingStack.pop()
+          state.loading = state.loadingStack.length > 0
         },
       )
       .addMatcher(

--- a/frontend/src/store/slice/DisplayData/DisplayDataType.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataType.ts
@@ -58,6 +58,7 @@ export type DisplayData = {
     [filePath: string]: PolarDisplayData
   }
   loading: boolean
+  loadingStack: boolean[]
   statusRoi: StatusROI
 }
 

--- a/frontend/src/store/slice/DisplayData/DisplayDataType.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataType.ts
@@ -60,6 +60,7 @@ export type DisplayData = {
   loading: boolean
   loadingStack: boolean[]
   statusRoi: StatusROI
+  isEditRoiCommitting: boolean
 }
 
 export const DATA_TYPE_SET = {

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -74,6 +74,7 @@ class EditRoiUtils:
 class EditROI:
     def __init__(self, file_path):
         self.node_dirpath = os.path.dirname(file_path)
+        self.workflow_dirpath = os.path.dirname(self.node_dirpath)
         self.function_id = ExptOutputPathIds(self.node_dirpath).function_id
 
         self.output_info: Dict = PickleReader.read(self.pickle_file_path)
@@ -230,6 +231,7 @@ class EditROI:
         self.__update_pickle_for_roi_edition(self.pickle_file_path, info)
         self.__save_json(info)
         self.__update_whole_nwb(info)
+
         (
             os.remove(self.tmp_pickle_file_path)
             if os.path.exists(self.tmp_pickle_file_path)
@@ -259,9 +261,8 @@ class EditROI:
         )
 
     def __update_whole_nwb(self, output_info):
-        workflow_dirpath = os.path.dirname(self.node_dirpath)
         smk_config_file = join_filepath(
-            [workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
+            [self.workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
         )
         smk_config = ConfigReader.read(smk_config_file)
         last_outputs = smk_config.get("last_output")
@@ -271,7 +272,7 @@ class EditROI:
             last_output_info = self.__update_pickle_for_roi_edition(
                 last_output_path, output_info
             )
-            whole_nwb_path = join_filepath([workflow_dirpath, "whole.nwb"])
+            whole_nwb_path = join_filepath([self.workflow_dirpath, "whole.nwb"])
 
             Runner.save_all_nwb(whole_nwb_path, last_output_info["nwbfile"])
 

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -54,7 +54,7 @@ class EditRoiUtils:
 
     @classmethod
     def execute(cls, filepath):
-        snakemake(
+        result = snakemake(
             DIRPATH.SNAKEMAKE_FILEPATH,
             use_conda=True,
             cores=2,
@@ -65,6 +65,10 @@ class EditRoiUtils:
                 "file_path": filepath,
             },
         )
+
+        if not result:
+            logger.error("edit_ROI snakemake run failed.")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class EditROI:


### PR DESCRIPTION
## Contents

### Bufgix

- Optimize loading display
  - Loading icon is not properly displayed in the ROI initial view.
  - In cases where multiple APIs are executed concurrently, there was insufficient consideration for state management of loading icons, so this has been improved.

- Inadequate API error handling
  - Improper error handling in commit_edit API (success is displayed even if 500 error, etc.)

### Improvements

- Control of the UI during "edit ROI" runs
  - Workflow RUN should not be executed when “edit ROI” is committed (snakemake is run by backend).
  - This was handled by displaying the loading icon in full screen when committing “edit ROI”.
