### PR TITLE
adjust axios timeout

### DIFF
--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -61,10 +61,14 @@ export async function uploadFileApi(
   },
   formData: FormData,
 ): Promise<{ file_path: string }> {
+  const upload_config = {
+    onUploadProgress: config.onUploadProgress,
+    timeout: 1800000, // Set a long timeout for upload api (30min)
+  }
   const response = await axios.post(
     `${BASE_URL}/files/${workspaceId}/upload/${fileName}`,
     formData,
-    config,
+    upload_config,
   )
   return response.data
 }


### PR DESCRIPTION
### Issue

When uploading a large file to the AWS ECS environment, a Timeout occurred in some cases.

### Cause

The following is a verification of each point at which timeouts may occur.

```
- client (frontend)
  - browser (chrome, etc)
  - library
    - axios
- backend
  - application
    - fastapi
      - uvicorn
  - infra
    - AWS
      - ALB
      - ECS
```

Of the above, the cause was the timeout setting in axios.
- /frontend/src/utils/axios.ts
  ```
  const axios = axiosLibrary.create({
    baseURL: BASE_URL,
    timeout: 600000,
  })
  ```


### Countermeasure

Extend timeout for file upload api. (10min -> 30min)
