### PR TITLE
improve experiment metadata download

### DIFF
--- a/studio/app/common/core/storage/mock_storage_controller.py
+++ b/studio/app/common/core/storage/mock_storage_controller.py
@@ -47,19 +47,42 @@ class MockStorageController(BaseRemoteStorageController):
         )
         return experiment_remote_path
 
-    async def download_all_experiments_metas(self) -> bool:
+    async def download_all_experiments_metas(self, workspace_ids: list = None) -> bool:
         # ----------------------------------------
         # make paths
         # ----------------------------------------
 
-        experiment_yml_search_path = (
-            f"{__class__.MOCK_OUTPUT_DIR}/**/{DIRPATH.EXPERIMENT_YML}"
-        )
-        experiment_yml_paths = glob(experiment_yml_search_path, recursive=True)
-        workflow_yml_search_path = (
-            f"{__class__.MOCK_OUTPUT_DIR}/**/{DIRPATH.WORKFLOW_YML}"
-        )
-        workflow_yml_paths = glob(workflow_yml_search_path, recursive=True)
+        if workspace_ids:  # search specified workspaces
+            # Search per workspace
+            experiment_yml_paths = []
+            workflow_yml_paths = []
+            for ws_id in workspace_ids:
+                experiment_yml_search_path = (
+                    f"{__class__.MOCK_OUTPUT_DIR}/{ws_id}/**/{DIRPATH.EXPERIMENT_YML}"
+                )
+                tmp_experiment_yml_paths = glob(
+                    experiment_yml_search_path, recursive=True
+                )
+                experiment_yml_paths.extend(tmp_experiment_yml_paths)
+                del tmp_experiment_yml_paths
+
+                workflow_yml_search_path = (
+                    f"{__class__.MOCK_OUTPUT_DIR}/{ws_id}/**/{DIRPATH.WORKFLOW_YML}"
+                )
+                tmp_workflow_yml_paths = glob(workflow_yml_search_path, recursive=True)
+                workflow_yml_paths.extend(tmp_workflow_yml_paths)
+                del tmp_workflow_yml_paths
+        else:  # search all workspaces
+            experiment_yml_search_path = (
+                f"{__class__.MOCK_OUTPUT_DIR}/**/{DIRPATH.EXPERIMENT_YML}"
+            )
+            experiment_yml_paths = glob(experiment_yml_search_path, recursive=True)
+
+            workflow_yml_search_path = (
+                f"{__class__.MOCK_OUTPUT_DIR}/**/{DIRPATH.WORKFLOW_YML}"
+            )
+            workflow_yml_paths = glob(workflow_yml_search_path, recursive=True)
+
         target_files = sorted(experiment_yml_paths + workflow_yml_paths)
 
         logger.debug(

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -290,7 +290,7 @@ class BaseRemoteStorageController(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def download_all_experiments_metas(self) -> bool:
+    def download_all_experiments_metas(self, workspace_ids: list = None) -> bool:
         """
         download all experiment metadata from remote storage.
         """
@@ -426,8 +426,13 @@ class RemoteStorageController(BaseRemoteStorageController):
 
         return True
 
-    async def download_all_experiments_metas(self) -> bool:
-        return await self.__controller.download_all_experiments_metas()
+    async def download_all_experiments_metas(self, workspace_ids: list = None) -> bool:
+        """
+        Args:
+          workspace_ids:
+            List of workspace ids to be downloaded. if none, all workspaces are targeted
+        """
+        return await self.__controller.download_all_experiments_metas(workspace_ids)
 
     async def download_experiment(self, workspace_id: str, unique_id: str) -> bool:
         return await self.__controller.download_experiment(workspace_id, unique_id)

--- a/studio/tests/app/common/core/storage/test_remote_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_remote_storage_controller.py
@@ -172,7 +172,14 @@ async def test_RemoteStorageController_download():
     async with RemoteStorageSimpleReader(
         remote_bucket_name
     ) as remote_storage_controller:
+        # download all workspaces metadata
         await remote_storage_controller.download_all_experiments_metas()
+        assert os.path.isfile(
+            test_data_output_experiment_yaml
+        ), "download_all_experiments_metas failed.."
+
+        # download specified workspaces metadata
+        await remote_storage_controller.download_all_experiments_metas([workspace_id])
         assert os.path.isfile(
             test_data_output_experiment_yaml
         ), "download_all_experiments_metas failed.."


### PR DESCRIPTION
### Contents

- Added automatic search for remote storage when there are no records in local.
  - When the “Reload” button is pressed on the Record Screen, it works.
  - A function that takes into account the case where a Docker container (AWS ECS container) is restarted and local data in the container is lost.

### Testcase

1. Prepare the state that there is a record in S3 and there is no record locally.
2. click the Reload button on the Record Screen
3. Confirm that the metadata of the records in S3 is downloaded and the list of records is displayed.
