### PR TITLE
Support input data uploading to remote storage

### DIFF
--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -1,5 +1,7 @@
 import os
 
+import yaml
+
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil, ProcessType
@@ -45,6 +47,35 @@ class SmkUtils:
                 return find_condaenv_filepath(conda_name)
 
         return None
+
+    @classmethod
+    def get_datatypes_inputs(
+        cls, workspace_id: str, unique_id: str, apply_basename: bool = False
+    ) -> list:
+        smk_config_yml_path = join_filepath(
+            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.SNAKEMAKE_CONFIG_YML]
+        )
+        with open(smk_config_yml_path, "r") as f:
+            smk_config = yaml.safe_load(f)
+
+        input_paths = []
+
+        for node in smk_config["rules"].values():
+            if NodeTypeUtil.check_nodetype_from_filetype(node["type"]) == NodeType.DATA:
+                if node["type"] in [FILETYPE.IMAGE]:
+                    if apply_basename:
+                        tmp_input_paths = [os.path.basename(x) for x in node["input"]]
+                    else:
+                        tmp_input_paths = node["input"]
+                    input_paths.extend(tmp_input_paths)
+                else:
+                    if apply_basename:
+                        tmp_input_path = os.path.basename(node["input"])
+                    else:
+                        tmp_input_path = node["input"]
+                    input_paths.append(tmp_input_path)
+
+        return input_paths
 
     @classmethod
     def dict2leaf(cls, root_dict: dict, path_list):

--- a/studio/app/common/core/storage/remote_storage_controller.py
+++ b/studio/app/common/core/storage/remote_storage_controller.py
@@ -6,6 +6,7 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum
 
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.snakemake.smk_utils import SmkUtils
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.dir_path import DIRPATH
 
@@ -536,6 +537,14 @@ class RemoteStorageController(BaseRemoteStorageController):
             result = await self.__controller.download_experiment(
                 workspace_id, unique_id
             )
+
+            # download input data
+            # *Download the input data related to the experiment data as well.
+            input_filenames = SmkUtils.get_datatypes_inputs(
+                workspace_id, unique_id, apply_basename=True
+            )
+            for input_filename in input_filenames:
+                await self.download_input_data(workspace_id, input_filename)
 
             # update sync status file
             RemoteSyncStatusFileUtil.create_sync_status_file_for_success(

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -223,8 +223,9 @@ async def sync_remote_experiment(
             )
 
         if not result:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="record not found"
+            )
         return result
 
     except HTTPException as e:

--- a/studio/tests/app/common/core/storage/test_remote_storage_controller.py
+++ b/studio/tests/app/common/core/storage/test_remote_storage_controller.py
@@ -34,17 +34,23 @@ def test_initialize():
         print("RemoteStorageController is available, skip this test.")
         return
 
-    test_data_src_path = f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}"
-    test_data_output_path = f"{DIRPATH.DATA_DIR}/output/{workspace_id}/{unique_id}"
+    # ----------------------------------------
+    # copy output test data
+    # ----------------------------------------
+
+    test_data_output_src_path = (
+        f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}"
+    )
+    test_data_output_dst_path = f"{DIRPATH.DATA_DIR}/output/{workspace_id}/{unique_id}"
 
     # cleaning local storage
-    if os.path.exists(test_data_output_path):
-        shutil.rmtree(test_data_output_path)
+    if os.path.exists(test_data_output_dst_path):
+        shutil.rmtree(test_data_output_dst_path)
 
     # copy test data
     shutil.copytree(
-        test_data_src_path,
-        test_data_output_path,
+        test_data_output_src_path,
+        test_data_output_dst_path,
         dirs_exist_ok=True,
     )
 
@@ -125,7 +131,45 @@ async def test_RemoteStorageController_crud_bucket():
 
 
 @pytest.mark.asyncio
-async def test_RemoteStorageController_upload():
+async def test_RemoteStorageController_operate_input_data():
+    input_file_name = "mouse2p_short_image.tiff"
+
+    # upload input data
+    async with RemoteStorageSimpleWriter(
+        remote_bucket_name
+    ) as remote_storage_controller:
+        result = await remote_storage_controller.upload_input_data(
+            workspace_id, input_file_name
+        )
+    assert result, "upload_input_data failed.."
+
+    # cleaning local storage
+    test_input_data_local_path = (
+        f"{DIRPATH.DATA_DIR}/input/{workspace_id}/{input_file_name}"
+    )
+    os.remove(test_input_data_local_path)
+
+    # download input data
+    async with RemoteStorageSimpleReader(
+        remote_bucket_name
+    ) as remote_storage_controller:
+        result = await remote_storage_controller.download_input_data(
+            workspace_id, input_file_name
+        )
+    assert result, "download_input_data failed.."
+
+    # delete input data
+    async with RemoteStorageSimpleWriter(
+        remote_bucket_name
+    ) as remote_storage_controller:
+        result = await remote_storage_controller.delete_input_data(
+            workspace_id, input_file_name
+        )
+    assert result, "delete_input_data failed.."
+
+
+@pytest.mark.asyncio
+async def test_RemoteStorageController_upload_experiment():
     if not RemoteStorageController.is_available():
         print("RemoteStorageController is available, skip this test.")
         return
@@ -153,7 +197,7 @@ async def test_RemoteStorageController_upload():
 
 
 @pytest.mark.asyncio
-async def test_RemoteStorageController_download():
+async def test_RemoteStorageController_download_experiment():
     if not RemoteStorageController.is_available():
         print("RemoteStorageController is available, skip this test.")
         return


### PR DESCRIPTION
In previous versions, input data uploaded by users was not synchronized to remote storage (S3).
In response to the above, we have added support for synchronizing input data to remote storage.

#### Specifications

- Input data synchronization (upload) timing
  - When a user uploads data to an input node
- Input data synchronization (download) timing
  - When synchronizing (downloading) experiment data, input data is also downloaded

### Testcase

1. upload any input data
    - -> confirm successful data upload to S3
2. execute workflow
    - -> confirm successful processing and successful upload of data to S3
3. manually delete 1.(input data) and 2.(experiment data) data in local
4. synchronize (download) the record of 2. on the Record screen
    - -> confirm success of synchronization (download) of 1.(input data) and 2.(experiment data)