### PR TITLE
Refactor logic of creating workflow unique_id

### DIFF
--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import asdict
 from typing import Dict, List
 
@@ -38,6 +39,11 @@ class WorkflowRunner:
             nwbfile=get_typecheck_params(self.runItem.nwbParam, "nwb"),
             snakemake=get_typecheck_params(self.runItem.snakemakeParam, "snakemake"),
         ).write()
+
+    @staticmethod
+    def create_workflow_unique_id() -> str:
+        new_unique_id = str(uuid.uuid4())[:8]
+        return new_unique_id
 
     def run_workflow(self, background_tasks):
         self.set_smk_config()

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Dict
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
@@ -24,7 +23,7 @@ logger = AppLogger.get_logger()
 )
 async def run(workspace_id: str, runItem: RunItem, background_tasks: BackgroundTasks):
     try:
-        unique_id = str(uuid.uuid4())[:8]
+        unique_id = WorkflowRunner.create_workflow_unique_id()
         WorkflowRunner(workspace_id, unique_id, runItem).run_workflow(background_tasks)
 
         logger.info("run snakemake")


### PR DESCRIPTION
### Contents

- Refactor logic of creating workflow unique_id
  - Since the logic for creating workflow unique_id was written inline adhoc, it was explicitly made into a function.