### PR TITLE
Fixed a bug in the checking logic of window.location.port

### DIFF
--- a/frontend/src/const/API.ts
+++ b/frontend/src/const/API.ts
@@ -7,7 +7,7 @@ const PROTO =
 const PORT =
   process.env.REACT_APP_SERVER_PORT ||
   window.location.port ||
-  (PROTO == "https" ? 443 : 8000)
+  (PROTO == "https" ? 443 : 80)
 
 export const BASE_URL =
   PORT == null ? `${PROTO}://${HOST}` : `${PROTO}://${HOST}:${PORT}`


### PR DESCRIPTION
*window.location.port was supposed to be empty for the default port.

- related
  - #458