### PR TITLE
Merge bugfix/fix-frontend-dotenv-bug into develop-cloud

### DIFF
--- a/frontend/src/const/API.ts
+++ b/frontend/src/const/API.ts
@@ -7,7 +7,7 @@ const PROTO =
 const PORT =
   process.env.REACT_APP_SERVER_PORT ||
   window.location.port ||
-  (PROTO == "https" ? 443 : 8000)
+  (PROTO == "https" ? 443 : 80)
 
 export const BASE_URL =
   PORT == null ? `${PROTO}://${HOST}` : `${PROTO}://${HOST}:${PORT}`


### PR DESCRIPTION
*window.location.port was supposed to be empty for the default port.

Same as https://github.com/arayabrain/barebone-studio/pull/502