### PR TITLE
update cleaning of conda cache in dockerfile

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /opt/miniforge && \
     export PATH="$PATH:/opt/miniforge/bin" && \
     conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
-    conda clean -y --tarballs
+    conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin
 
 # setup user profile

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN mkdir -p /opt/miniforge && \
     export PATH="$PATH:/opt/miniforge/bin" && \
     conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
-    conda clean -y --tarballs
+    conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin
 
 # setup user profile

--- a/studio/config/docker/Dockerfile.test
+++ b/studio/config/docker/Dockerfile.test
@@ -16,7 +16,7 @@ RUN mkdir -p /opt/miniforge && \
     export PATH="$PATH:/opt/miniforge/bin" && \
     conda upgrade -y --all && \
     conda config --set channel_priority flexible && \
-    conda clean -y --tarballs
+    conda clean -y --all
 ENV PATH $PATH:/opt/miniforge/bin
 
 # setup optinist


### PR DESCRIPTION
### Contents

- Applied the same improvements as those made for the following issue (docker image size reduction)
  - arayabrain/optinist-for-server#358

### Result

- The size of the Docker image was reduced by about 0.5GB (4GB → 3.5GB).

#### Test Case

- [x] Run workflow to create new conda env
  - confirm operation with `lccd`