### PR TITLE
Change input node id in sampledata (to a non-default value)

### DIFF
--- a/sample_data/output/tutorial1/experiment.yaml
+++ b/sample_data/output/tutorial1/experiment.yaml
@@ -17,7 +17,7 @@ function:
     started_at: '2023-11-22 16:09:06'
     success: success
     unique_id: eta_jntqpbkvwv
-  input_0:
+  input_ab1mmvt2ky:
     finished_at: '2023-11-22 16:07:03'
     hasNWB: false
     message: null
@@ -25,7 +25,7 @@ function:
     outputPaths: null
     started_at: '2023-11-22 16:07:03'
     success: success
-    unique_id: input_0
+    unique_id: input_ab1mmvt2ky
   input_zdax4o54o0:
     finished_at: '2023-11-22 16:07:03'
     hasNWB: false

--- a/sample_data/output/tutorial1/snakemake.yaml
+++ b/sample_data/output/tutorial1/snakemake.yaml
@@ -23,7 +23,7 @@ rules:
       input_zdax4o54o0: behaviors_data
       iscell: iscell
     type: eta
-  input_0:
+  input_ab1mmvt2ky:
     hdf5Path: null
     input:
     - 1/sample_mouse2p_image.tiff
@@ -54,10 +54,10 @@ rules:
         emission_lambda: 500.0
         name: OpticalChannel
       session_description: optinist
-    output: 1/tutorial1/input_0/sample_mouse2p_image.pkl
+    output: 1/tutorial1/input_ab1mmvt2ky/sample_mouse2p_image.pkl
     params: {}
     path: null
-    return_arg: input_0
+    return_arg: input_ab1mmvt2ky
     type: image
   input_zdax4o54o0:
     hdf5Path: null
@@ -100,7 +100,7 @@ rules:
   suite2p_file_convert_axgpevzu10:
     hdf5Path: null
     input:
-    - 1/tutorial1/input_0/sample_mouse2p_image.pkl
+    - 1/tutorial1/input_ab1mmvt2ky/sample_mouse2p_image.pkl
     nwbfile: null
     output: 1/tutorial1/suite2p_file_convert_axgpevzu10/suite2p_file_convert.pkl
     params:
@@ -111,7 +111,7 @@ rules:
       nplanes: 1
     path: suite2p/suite2p_file_convert
     return_arg:
-      input_0: image
+      input_ab1mmvt2ky: image
     type: suite2p_file_convert
   suite2p_registration_ktrkq5sa71:
     hdf5Path: null

--- a/sample_data/output/tutorial1/workflow.yaml
+++ b/sample_data/output/tutorial1/workflow.yaml
@@ -1,9 +1,9 @@
 edgeDict:
-  ? reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_axgpevzu10suite2p_file_convert_axgpevzu10--image--ImageData
+  ? reactflow__edge-input_ab1mmvt2kyinput_ab1mmvt2ky--image--ImageData-suite2p_file_convert_axgpevzu10suite2p_file_convert_axgpevzu10--image--ImageData
   : animated: false
-    id: reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_axgpevzu10suite2p_file_convert_axgpevzu10--image--ImageData
-    source: input_0
-    sourceHandle: input_0--image--ImageData
+    id: reactflow__edge-input_ab1mmvt2kyinput_ab1mmvt2ky--image--ImageData-suite2p_file_convert_axgpevzu10suite2p_file_convert_axgpevzu10--image--ImageData
+    source: input_ab1mmvt2ky
+    sourceHandle: input_ab1mmvt2ky--image--ImageData
     style:
       border: null
       borderRadius: null
@@ -131,7 +131,7 @@ nodeDict:
       padding: 0
       width: 250
     type: AlgorithmNode
-  input_0:
+  input_ab1mmvt2ky:
     data:
       fileType: image
       hdf5Path: null
@@ -140,7 +140,7 @@ nodeDict:
       path:
       - sample_mouse2p_image.tiff
       type: input
-    id: input_0
+    id: input_ab1mmvt2ky
     position:
       x: 50
       y: 150

--- a/sample_data/output/tutorial2/experiment.yaml
+++ b/sample_data/output/tutorial2/experiment.yaml
@@ -27,8 +27,8 @@ function:
         max_index: null
     started_at: '2024-04-11 16:47:49'
     finished_at: '2024-04-11 16:48:34'
-  input_0:
-    unique_id: input_0
+  input_cdgkgmc5oq:
+    unique_id: input_cdgkgmc5oq
     name: sample_mouse2p_image.tiff
     success: success
     hasNWB: false

--- a/sample_data/output/tutorial2/snakemake.yaml
+++ b/sample_data/output/tutorial2/snakemake.yaml
@@ -1,9 +1,9 @@
 rules:
   caiman_mc_p4f6nsi9bh:
     input:
-    - 1/tutorial2/input_0/sample_mouse2p_image.pkl
+    - 1/tutorial2/input_cdgkgmc5oq/sample_mouse2p_image.pkl
     return_arg:
-      input_0: image
+      input_cdgkgmc5oq: image
     params:
       border_nan: copy
       gSig_filt: null
@@ -36,12 +36,12 @@ rules:
     hdf5Path: null
     matPath: null
     path: caiman/caiman_mc
-  input_0:
+  input_cdgkgmc5oq:
     input:
     - 1/sample_mouse2p_image.tiff
-    return_arg: input_0
+    return_arg: input_cdgkgmc5oq
     params: {}
-    output: 1/tutorial2/input_0/sample_mouse2p_image.pkl
+    output: 1/tutorial2/input_cdgkgmc5oq/sample_mouse2p_image.pkl
     type: image
     nwbfile:
       session_description: optinist

--- a/sample_data/output/tutorial2/workflow.yaml
+++ b/sample_data/output/tutorial2/workflow.yaml
@@ -101,8 +101,8 @@ nodeDict:
       padding: 0
       width: 250
       borderRadius: 0
-  input_0:
-    id: input_0
+  input_cdgkgmc5oq:
+    id: input_cdgkgmc5oq
     type: ImageFileNode
     data:
       label: sample_mouse2p_image.tiff
@@ -542,12 +542,12 @@ nodeDict:
       width: 250
       borderRadius: 0
 edgeDict:
-  reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData:
-    id: reactflow__edge-input_0input_0--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData
+  reactflow__edge-input_cdgkgmc5oq--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData:
+    id: reactflow__edge-input_cdgkgmc5oqinput_cdgkgmc5oq--image--ImageData-caiman_mc_p4f6nsi9bhcaiman_mc_p4f6nsi9bh--image--ImageData
     type: buttonedge
     animated: false
-    source: input_0
-    sourceHandle: input_0--image--ImageData
+    source: input_cdgkgmc5oq
+    sourceHandle: input_cdgkgmc5oq--image--ImageData
     target: caiman_mc_p4f6nsi9bh
     targetHandle: caiman_mc_p4f6nsi9bh--image--ImageData
     style:


### PR DESCRIPTION
### Contents

If the default value (input_0) is set for the ID of Input Node in Record, the following cases have been confirmed to cause problems.

- Cases where the problem occurs
  1. modify the initial Node Type to be displayed in Workflow in frontend (e.g. Image -> Microscope)
  2. execute the Workflow changed in 1.
  3. Reproduce a past Record (with a different Input Type) → Crash in the frontend
- Cause of the problem
  - When Reproducing a Record, there seems to be a lack of frontend validation for the case where “Nodes with the same ID but different types” exist on the Workflow screen.

As a temporary workaround, for Sample Data, apply a modification to make the Input Node ID a non-default value to avoid this case.
(Permanent measures will be considered separately as needed.)

### Testcase

- Run Workflow
  - [x] Tutorial1 (suite2p+α)
  - [x] Tutorial2 (caiman+α)