### PR TITLE
Feature/fluo_to_hdf5 transpose

### DIFF
--- a/studio/app/optinist/wrappers/optinist/visualize_utils/fluo_from_hdf5.py
+++ b/studio/app/optinist/wrappers/optinist/visualize_utils/fluo_from_hdf5.py
@@ -4,8 +4,13 @@ from studio.app.optinist.dataclass.fluo import FluoData
 def fluo_from_hdf5(
     fluo: FluoData, output_dir: str, params: dict = None, **kwargs
 ) -> dict(fluorescence=FluoData):
-    import numpy as np
+    if params["transpose"]:
+        import numpy as np
 
-    return {
-        "fluorescence": FluoData(np.transpose(fluo.data), file_name="fluorescence"),
-    }
+        return {
+            "fluorescence": FluoData(np.transpose(fluo.data), file_name="fluorescence"),
+        }
+    else:
+        return {
+            "fluorescence": FluoData(fluo.data, file_name="fluorescence"),
+        }

--- a/studio/app/optinist/wrappers/optinist/visualize_utils/params/fluo_from_hdf5.yaml
+++ b/studio/app/optinist/wrappers/optinist/visualize_utils/params/fluo_from_hdf5.yaml
@@ -1,1 +1,4 @@
+# This is a temporary measure. Generally, Transpose should be set to True.
+# However, when Transpose is set to True, the data coordinates may sometimes be reversed.
+# Therefore, it may be switched to False on the screen.
 transpose: True

--- a/studio/app/optinist/wrappers/optinist/visualize_utils/params/fluo_from_hdf5.yaml
+++ b/studio/app/optinist/wrappers/optinist/visualize_utils/params/fluo_from_hdf5.yaml
@@ -1,1 +1,1 @@
-""
+transpose: True


### PR DESCRIPTION
We found a case where time and ROI were transposed after using hdf5_to_fluo. However, upon checking, this function worked correctly. therefore, it may be that sometimes the data is saved in one orientation, and other times in another orientation, or maybe there was a bug with the React-plus code. 
In any case, it is a useful feature for users to be able to transpose their data. 

<img width="1072" alt="Screenshot 2025-02-05 at 16 11 04" src="https://github.com/user-attachments/assets/9f597ac2-4eae-422c-a4aa-5e25ef8d477e" />


<img width="1038" alt="Screenshot 2025-02-05 at 16 11 37" src="https://github.com/user-attachments/assets/39e6d7a9-7aae-405b-bde4-6fa8fdf0c815" />
