### PR TITLE
Added a header section to wrapper conda env package yamls

### DIFF
--- a/studio/app/common/wrappers/dummy/conda/dummy.yaml
+++ b/studio/app/common/wrappers/dummy/conda/dummy.yaml
@@ -1,3 +1,4 @@
+# Packages in conda env for [dummy]
 dependencies:
   - python=3.9
   - pip

--- a/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
+++ b/studio/app/optinist/wrappers/caiman/conda/caiman.yaml
@@ -1,3 +1,4 @@
+# Packages in conda env for [caiman]
 channels:
   - conda-forge
   - defaults

--- a/studio/app/optinist/wrappers/lccd/conda/lccd.yaml
+++ b/studio/app/optinist/wrappers/lccd/conda/lccd.yaml
@@ -1,10 +1,11 @@
+# Packages in conda env for [lccd]
 dependencies:
   - python=3.9
   - pip
   - pip:
-#   - pandas
-#   - argparse
-#   - joblib
+    # - pandas
+    # - argparse
+    # - joblib
     - numpy==1.23.*
     - scipy==1.9.*
     - scikit-image==0.19.*

--- a/studio/app/optinist/wrappers/optinist/conda/microscope.yaml
+++ b/studio/app/optinist/wrappers/optinist/conda/microscope.yaml
@@ -1,3 +1,4 @@
+# Packages in conda env for [microscope]
 channels:
   - conda-forge
 dependencies:

--- a/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
+++ b/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
@@ -1,3 +1,4 @@
+# Packages in conda env for [optinist]
 dependencies:
   - python=3.9
   - pip

--- a/studio/app/optinist/wrappers/suite2p/conda/suite2p.yaml
+++ b/studio/app/optinist/wrappers/suite2p/conda/suite2p.yaml
@@ -1,3 +1,4 @@
+# Packages in conda env for [suite2p]
 dependencies:
   - python=3.9
   - pip


### PR DESCRIPTION
When snakemake uses conda env package yamls, the filename is hashed, as shown in the example below, making it difficult to easily identify which algo wapper a file is for from its filename.

```
.snakemake/conda/
  - 5c61f0f4dea67b8c1e7b022a58022b1d_.yaml
  - 9e28e80060a765af43d5e40f9a6f0aee_.yaml
  - a8a8a954abda0e4ca4de364deca86b7f_.yaml
  - fed0359ea0d88bd07ee86ded9ae35fae_.yaml
```

For this reason, add a header section to identify the algo in the yamls.

- Note:
  - It is also possible to specify the "name" of the conda env in the package yml, but if you specify a name, the environment will not be rebuilt (it will be fixed) even if the package definition is changed, so the "name" section cannot be used for this requirement.