### PR TITLE
consistent colour behaviour

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/ImagePlot.tsx
@@ -236,12 +236,14 @@ const ImagePlotChart = memo(function ImagePlotChart({
   const refPageXSize = useRef(0)
   const refPageYSize = useRef(0)
 
-  const colorscaleRoi = createColormap({
-    colormap: "jet",
-    nshades: 100, //timeDataMaxIndex >= 6 ? timeDataMaxIndex : 6,
-    format: "rgba",
-    alpha: 1.0,
-  })
+  function getRoiColor(roiIndex: number): string {
+    const colors = createColormap({
+      colormap: "jet",
+      nshades: 200,
+      format: "hex",
+    })
+    return colors[(Math.abs(roiIndex) * 9) % 200]
+  }
 
   useEffect(() => {
     setRoiDataState(roiData)
@@ -306,10 +308,7 @@ const ImagePlotChart = memo(function ImagePlotChart({
         hovertemplate: action === ADD_ROI ? "none" : "ROI: %{z}",
         // hoverinfo: isAddRoi || pointClick.length ? "none" : undefined,
         colorscale: [...Array(timeDataMaxIndex + 1)].map((_, i) => {
-          const new_i = Math.floor(((i % 10) * 10 + i / 10) % 100)
           const offset: number = i / timeDataMaxIndex
-          const rgba = colorscaleRoi[new_i]
-          const hex = rgba2hex(rgba, roiAlpha)
           if (!action) {
             if (statusRoi.temp_delete_roi.includes(i))
               return [offset, "#ffffff"]
@@ -341,7 +340,7 @@ const ImagePlotChart = memo(function ImagePlotChart({
               return [offset, "#e134eb"]
             if (statusRoi.temp_add_roi.includes(i)) return [offset, "#3483eb"]
           }
-          return [offset, hex]
+          return [offset, getRoiColor(i)]
         }),
         zmin: 0,
         zmax: timeDataMaxIndex,
@@ -356,7 +355,6 @@ const ImagePlotChart = memo(function ImagePlotChart({
       zsmooth,
       showscale,
       colorscale,
-      colorscaleRoi,
       timeDataMaxIndex,
       roiAlpha,
       alpha,

--- a/frontend/src/components/Workspace/Visualize/Plot/TimeSeriesPlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/TimeSeriesPlot.tsx
@@ -129,19 +129,20 @@ const TimeSeriesPlotImple = memo(function TimeSeriesPlotImple() {
     //eslint-disable-next-line
   }, [rangeUnit, dataXrange, timeSeriesData, drawOrderList])
 
-  const colorScale = createColormap({
-    colormap: "jet",
-    nshades: 100, //maxIndex >= 6 ? maxIndex : 6,
-    format: "hex",
-    alpha: 1,
-  })
+  function getRoiColor(roiIndex: number): string {
+    const colors = createColormap({
+      colormap: "jet",
+      nshades: 200,
+      format: "hex",
+    })
+    return colors[(Math.abs(roiIndex) * 9) % 200]
+  }
 
   const data = useMemo(() => {
     return Object.fromEntries(
       dataKeys.map((key) => {
         let y = newDataXrange.map((x) => newTimeSeriesData[key]?.[x])
         const i = Number(key)
-        const new_i = Math.floor((i % 10) * 10 + i / 10) % 100
         if (drawOrderList.includes(key) && !stdBool) {
           const activeIdx: number = drawOrderList.findIndex((v) => v === key)
           const mean: number = y.reduce((a, b) => a + b) / y.length
@@ -158,7 +159,7 @@ const TimeSeriesPlotImple = memo(function TimeSeriesPlotImple() {
             x: newDataXrange,
             y: y,
             visible: drawOrderList.includes(key) ? true : "legendonly",
-            line: { color: colorScale[new_i] },
+            line: { color: getRoiColor(i) },
             error_y: {
               type: "data",
               array:
@@ -175,7 +176,6 @@ const TimeSeriesPlotImple = memo(function TimeSeriesPlotImple() {
     drawOrderList,
     stdBool,
     span,
-    colorScale,
     dataStd,
     dataKeys,
     newDataXrange,


### PR DESCRIPTION
Modified the ROI color mapping to ensure consistent colors across different visualizations (heatmaps and time series plots). Previously, colors could appear differently between views due to different mapping formulas.

Key changes:

1. Created a unified color mapping function:
```typescript
function getRoiColor(roiIndex: number): string {
    const colors = createColormap({
        colormap: 'jet',
        nshades: 200,
        format: 'hex'
    })
    return colors[(Math.abs(roiIndex) * 9) % 200]
}
```

This function:
- Uses 200 distinct colors instead of 100 for finer gradation
- Multiplies the ROI index by 9 to spread consecutive ROIs further apart in the color spectrum
- Uses modulo 200 to wrap around when we exceed 200 ROIs
- Returns consistent hex colors

2. Replaced the old formula in TimeSeriesPlot:
```typescript
// Old: Unpredictable spreading
const new_i = Math.floor((i % 10) * 10 + i / 10) % 100
line: { color: colorScale[new_i] }

// New: Consistent spreading by steps of 9
line: { color: getRoiColor(i) }
```

3. Updated ImagePlot's ROI heatmap to use the same color function:
```typescript
// In heatmap colorscale
return [offset, getRoiColor(i)]
```

This ensures:
- ROI #1 always gets the same color whether shown in ROI view or time series
- Consecutive ROIs (e.g., 1,2,3) get visually distinct colors by being 9 steps apart
- The pattern repeats predictably after 200 ROIs
- Special action colors (white for deleted, purple for merge, blue for add) remain unchanged

For example, ROIs 0-3 will consistently get these positions in the color spectrum:
- ROI 0 → color index 0
- ROI 1 → color index 9
- ROI 2 → color index 18
- ROI 3 → color index 27

This provides better visual distinction between neighboring ROIs while maintaining consistency across different visualization types.