### PR TITLE
Improved try-catch for scripts kicked from snakefile

### DIFF
--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import os
+import traceback
 
 import yaml
 
@@ -54,7 +55,7 @@ class AppLogger:
             logging.config.dictConfig(log_config)
 
     @staticmethod
-    def get_logger():
+    def get_logger() -> logging.Logger:
         logger = logging.getLogger(__class__.LOGGER_NAME)
 
         # If before initialization, call init
@@ -62,3 +63,7 @@ class AppLogger:
             __class__.init_logger()
 
         return logger
+
+    @staticmethod
+    def format_exc_traceback(e: Exception):
+        return "{}: {}\n{}".format(type(e), e, traceback.format_exc())

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -9,39 +9,52 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.rules.file_writer import FileWriter
-from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
-from studio.app.common.core.utils.pickle_handler import PickleWriter
-from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
-from studio.app.const import FILETYPE
+from studio.app.common.core.logger import AppLogger
+
+logger = AppLogger.get_logger()
+
+
+def main():
+    try:
+        from studio.app.common.core.rules.file_writer import FileWriter
+        from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
+        from studio.app.common.core.utils.pickle_handler import PickleWriter
+        from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
+        from studio.app.const import FILETYPE
+
+        last_output = snakemake.config["last_output"]
+
+        rule_config = RuleConfigReader.read(snakemake.params.name)
+
+        if NodeTypeUtil.check_nodetype_from_filetype(rule_config.type) == NodeType.DATA:
+            if rule_config.type in [FILETYPE.IMAGE]:
+                rule_config.input = snakemake.input
+            else:
+                rule_config.input = snakemake.input[0]
+        else:
+            assert False, f"Invalid rule type: {rule_config.type}"
+
+        rule_config.output = snakemake.output[0]
+
+        outputfile = None
+        if rule_config.type in [FILETYPE.CSV, FILETYPE.BEHAVIOR]:
+            outputfile = FileWriter.csv(rule_config, rule_config.type)
+        elif rule_config.type == FILETYPE.IMAGE:
+            outputfile = FileWriter.image(rule_config)
+        elif rule_config.type == FILETYPE.HDF5:
+            outputfile = FileWriter.hdf5(rule_config)
+        elif rule_config.type == FILETYPE.MATLAB:
+            outputfile = FileWriter.mat(rule_config)
+        elif rule_config.type == FILETYPE.MICROSCOPE:
+            outputfile = FileWriter.microscope(rule_config)
+        else:
+            assert False, f"Invalid file type: {rule_config.type}"
+
+        PickleWriter.write(rule_config.output, outputfile)
+
+    except Exception as e:
+        logger.error(AppLogger.format_exc_traceback(e))
+
 
 if __name__ == "__main__":
-    last_output = snakemake.config["last_output"]
-
-    rule_config = RuleConfigReader.read(snakemake.params.name)
-
-    if NodeTypeUtil.check_nodetype_from_filetype(rule_config.type) == NodeType.DATA:
-        if rule_config.type in [FILETYPE.IMAGE]:
-            rule_config.input = snakemake.input
-        else:
-            rule_config.input = snakemake.input[0]
-    else:
-        assert False, f"Invalid rule type: {rule_config.type}"
-
-    rule_config.output = snakemake.output[0]
-
-    outputfile = None
-    if rule_config.type in [FILETYPE.CSV, FILETYPE.BEHAVIOR]:
-        outputfile = FileWriter.csv(rule_config, rule_config.type)
-    elif rule_config.type == FILETYPE.IMAGE:
-        outputfile = FileWriter.image(rule_config)
-    elif rule_config.type == FILETYPE.HDF5:
-        outputfile = FileWriter.hdf5(rule_config)
-    elif rule_config.type == FILETYPE.MATLAB:
-        outputfile = FileWriter.mat(rule_config)
-    elif rule_config.type == FILETYPE.MICROSCOPE:
-        outputfile = FileWriter.microscope(rule_config)
-    else:
-        assert False, f"Invalid file type: {rule_config.type}"
-
-    PickleWriter.write(rule_config.output, outputfile)
+    main()

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -7,23 +7,36 @@ import sys
 from os.path import abspath, dirname
 
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
-
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.rules.runner import Runner
-from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
-from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.dir_path import DIRPATH
+from studio.app.common.core.logger import AppLogger
+
+logger = AppLogger.get_logger()
+
+
+def main():
+    try:
+        from studio.app.common.core.rules.runner import Runner
+        from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
+        from studio.app.common.core.utils.filepath_creater import join_filepath
+        from studio.app.dir_path import DIRPATH
+
+        last_output = [
+            join_filepath([DIRPATH.OUTPUT_DIR, x])
+            for x in snakemake.config["last_output"]
+        ]
+
+        rule_config = RuleConfigReader.read(snakemake.params.name)
+
+        rule_config.input = snakemake.input
+        rule_config.output = snakemake.output[0]
+        run_script_path = sys.argv[0]
+
+        Runner.run(rule_config, last_output, run_script_path)
+
+    except Exception as e:
+        logger.error(AppLogger.format_exc_traceback(e))
+
 
 if __name__ == "__main__":
-    last_output = [
-        join_filepath([DIRPATH.OUTPUT_DIR, x]) for x in snakemake.config["last_output"]
-    ]
-
-    rule_config = RuleConfigReader.read(snakemake.params.name)
-
-    rule_config.input = snakemake.input
-    rule_config.output = snakemake.output[0]
-    run_script_path = sys.argv[0]
-
-    Runner.run(rule_config, last_output, run_script_path)
+    main()

--- a/studio/app/optinist/core/rules/edit_ROI.py
+++ b/studio/app/optinist/core/rules/edit_ROI.py
@@ -9,8 +9,21 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.optinist.core.edit_ROI import EditROI
+from studio.app.common.core.logger import AppLogger
+
+logger = AppLogger.get_logger()
+
+
+def main():
+    try:
+        from studio.app.optinist.core.edit_ROI import EditROI
+
+        config = snakemake.config
+        EditROI(file_path=config["file_path"]).commit()
+
+    except Exception as e:
+        logger.error(AppLogger.format_exc_traceback(e))
+
 
 if __name__ == "__main__":
-    config = snakemake.config
-    EditROI(file_path=config["file_path"]).commit()
+    main()


### PR DESCRIPTION
For each script (.py) kicked from within the Snakefile, there were cases where exceptions were not caught (such as exceptions when importing a module), so exception handling has been improved.