### PR TITLE
Feature/minor refine frontend

### DIFF
--- a/frontend/src/components/Workspace/Experiment/Button/DeleteButton.tsx
+++ b/frontend/src/components/Workspace/Experiment/Button/DeleteButton.tsx
@@ -63,6 +63,7 @@ export const DeleteButton = memo(function DeleteButton() {
         content={`${name} (${uid})`}
         confirmLabel="delete"
         iconType="warning"
+        confirmButtonColor="error"
       />
     </>
   )

--- a/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
+++ b/frontend/src/components/Workspace/Experiment/ExperimentTable.tsx
@@ -294,6 +294,7 @@ const TableImple = memo(function TableImple() {
         }
         iconType="warning"
         confirmLabel="delete"
+        confirmButtonColor="error"
       />
       <ConfirmDialog
         open={openCopy}

--- a/frontend/src/components/Workspace/FlowChart/Buttons/CondaNoticeButton.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/CondaNoticeButton.tsx
@@ -1,4 +1,4 @@
-import { memo, SyntheticEvent, useState } from "react"
+import { memo, SyntheticEvent, useState, useCallback } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import { enqueueSnackbar } from "notistack"
@@ -6,6 +6,7 @@ import { enqueueSnackbar } from "notistack"
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined"
 import { Typography } from "@mui/material"
 import IconButton from "@mui/material/IconButton"
+import Tooltip from "@mui/material/Tooltip"
 
 import { ConfirmDialog } from "components/common/ConfirmDialog"
 import { AlgorithmChild } from "store/slice/AlgorithmList/AlgorithmListType"
@@ -33,14 +34,15 @@ interface CondaNoticeButtonProps {
 export const CondaNoticeButton = memo(function CondaNoticeButton({
   name,
   node,
-  onSkipClick: onSkipClick,
+  onSkipClick,
 }: CondaNoticeButtonProps) {
   const condaName = node.condaName
 
   const [open, setOpen] = useState(false)
-  const openDialog = () => {
+
+  const openDialog = useCallback(() => {
     setOpen(true)
-  }
+  }, [])
 
   const dispatch = useDispatch<AppDispatch>()
   const workspaceId = useSelector(selectCurrentWorkspaceId) || -1
@@ -99,17 +101,16 @@ export const CondaNoticeButton = memo(function CondaNoticeButton({
       >
         <InfoOutlinedIcon />
       </IconButton>
-      <Typography
-        variant="inherit"
-        style={{
-          textOverflow: "ellipsis",
-          overflow: "visible",
-          width: "8rem",
-          display: "inline-block",
-        }}
-      >
-        {name}
-      </Typography>
+      <Tooltip title={name} placement="right-start">
+        <Typography
+          variant="inherit"
+          style={{
+            display: "inline-block",
+          }}
+        >
+          {name}
+        </Typography>
+      </Tooltip>
 
       <ConfirmDialog
         open={open}

--- a/frontend/src/components/Workspace/FlowChart/TreeView.tsx
+++ b/frontend/src/components/Workspace/FlowChart/TreeView.tsx
@@ -5,7 +5,7 @@ import { useSelector, useDispatch } from "react-redux"
 import AddIcon from "@mui/icons-material/Add"
 import ChevronRightIcon from "@mui/icons-material/ChevronRight"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
-import { styled, Typography } from "@mui/material"
+import { styled, Typography, Tooltip } from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 import { treeItemClasses } from "@mui/x-tree-view"
 import { TreeItem } from "@mui/x-tree-view/TreeItem"
@@ -301,6 +301,7 @@ const AlgoNodeComponent = memo(function AlgoNodeComponent({
             style={{
               display: "flex", // Place Items on single line.
             }}
+            onClick={(e) => e.stopPropagation()}
           >
             {node.condaEnvExists ? (
               <AddButton
@@ -317,7 +318,6 @@ const AlgoNodeComponent = memo(function AlgoNodeComponent({
                   if (reason !== undefined) {
                     return
                   }
-
                   onAddAlgoNode(name, node.functionPath)
                 }}
               />
@@ -345,17 +345,16 @@ const AddButton = memo(function AddButton({ name, onClick }: AddButtonProps) {
       >
         <AddIcon />
       </IconButton>
-      <Typography
-        variant="inherit"
-        style={{
-          textOverflow: "ellipsis",
-          overflow: "visible",
-          width: "8rem",
-          display: "inline-block",
-        }}
-      >
-        {name}
-      </Typography>
+      <Tooltip title={name} placement="right">
+        <Typography
+          variant="inherit"
+          style={{
+            display: "inline-block",
+          }}
+        >
+          {name}
+        </Typography>
+      </Tooltip>
     </>
   )
 })

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -24,6 +24,14 @@ export interface ConfirmDialogProps {
   content: string | JSX.Element
   confirmLabel?: string
   iconType?: "warning" | "info"
+  confirmButtonColor?:
+    | "inherit"
+    | "primary"
+    | "secondary"
+    | "success"
+    | "error"
+    | "info"
+    | "warning"
 }
 
 export const ConfirmDialog: FC<ConfirmDialogProps> = ({
@@ -36,6 +44,7 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
   content,
   confirmLabel,
   iconType,
+  confirmButtonColor = "primary",
 }) => {
   const dataTestId = confirmLabel
     ? `${confirmLabel}-confirm-button`
@@ -83,6 +92,7 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
           variant="contained"
           onClick={handleConfirm}
           data-testid={dataTestId}
+          color={confirmButtonColor}
         >
           {confirmLabel ?? "ok"}
         </Button>

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -556,6 +556,7 @@ const Workspaces = () => {
         }
         iconType="warning"
         confirmLabel="delete"
+        confirmButtonColor="error"
       />
       <PopupNew
         open={open.new}


### PR DESCRIPTION
- adjust delete button color
  - Delete-type buttons were not unified in style, so they were unified (red emphasis)
  - ![image](https://github.com/user-attachments/assets/a021a5fe-9501-47bc-893b-097929424f36)
- Added tooltip display to AlgoNodes
  - Purpose
    1. consider that the node display may be cut off
    2. node names can now be copied
  - ![image](https://github.com/user-attachments/assets/933bb3c2-84a2-4e55-aca3-3c493cf073d7)
