### PR TITLE
Fix node_id in tutorial data

### DIFF
--- a/sample_data/tutorial/output/tutorial3/experiment.yaml
+++ b/sample_data/tutorial/output/tutorial3/experiment.yaml
@@ -6,8 +6,8 @@ finished_at: '2025-02-13 15:34:57'
 success: success
 hasNWB: true
 function:
-  input_0:
-    unique_id: input_0
+  input_qsxe86gdqi:
+    unique_id: input_qsxe86gdqi
     name: sample_mouse2p_image.tiff
     success: success
     hasNWB: false

--- a/sample_data/tutorial/output/tutorial3/snakemake.yaml
+++ b/sample_data/tutorial/output/tutorial3/snakemake.yaml
@@ -1,10 +1,10 @@
 rules:
-  input_0:
+  input_qsxe86gdqi:
     input:
     - 1/sample_mouse2p_image.tiff
-    return_arg: input_0
+    return_arg: input_qsxe86gdqi
     params: {}
-    output: 1/tutorial3/input_0/sample_mouse2p_image.pkl
+    output: 1/tutorial3/input_qsxe86gdqi/sample_mouse2p_image.pkl
     type: image
     nwbfile:
       session_description: optinist
@@ -39,9 +39,9 @@ rules:
     path: null
   suite2p_file_convert_uwyrgu1xyc:
     input:
-    - 1/tutorial3/input_0/sample_mouse2p_image.pkl
+    - 1/tutorial3/input_qsxe86gdqi/sample_mouse2p_image.pkl
     return_arg:
-      input_0: image
+      input_qsxe86gdqi: image
     params:
       force_sktiff: false
       batch_size: 500

--- a/sample_data/tutorial/output/tutorial3/workflow.yaml
+++ b/sample_data/tutorial/output/tutorial3/workflow.yaml
@@ -1,6 +1,6 @@
 nodeDict:
-  input_0:
-    id: input_0
+  input_qsxe86gdqi:
+    id: input_qsxe86gdqi
     type: ImageFileNode
     data:
       label: sample_mouse2p_image.tiff
@@ -351,12 +351,12 @@ nodeDict:
       width: 250
       borderRadius: 0
 edgeDict:
-  ? reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_uwyrgu1xycsuite2p_file_convert_uwyrgu1xyc--image--ImageData
-  : id: reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_uwyrgu1xycsuite2p_file_convert_uwyrgu1xyc--image--ImageData
+  ? reactflow__edge-input_qsxe86gdqiinput_qsxe86gdqi--image--ImageData-suite2p_file_convert_uwyrgu1xycsuite2p_file_convert_uwyrgu1xyc--image--ImageData
+  : id: reactflow__edge-input_qsxe86gdqiinput_qsxe86gdqi--image--ImageData-suite2p_file_convert_uwyrgu1xycsuite2p_file_convert_uwyrgu1xyc--image--ImageData
     type: buttonedge
     animated: false
-    source: input_0
-    sourceHandle: input_0--image--ImageData
+    source: input_qsxe86gdqi
+    sourceHandle: input_qsxe86gdqi--image--ImageData
     target: suite2p_file_convert_uwyrgu1xyc
     targetHandle: suite2p_file_convert_uwyrgu1xyc--image--ImageData
     style:


### PR DESCRIPTION
Fix node_id (input_0) in tutorial data  
*In folk repository (optinist-for-server), the default input node type is not Image, and duplicate node_ids are not allowed.
