### PR TITLE
Fix/improve workflow observation

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -41,7 +41,7 @@ class Runner:
 
             # write pid file
             workflow_dirpath = str(Path(__rule.output).parent.parent)
-            cls.write_pid_file(workflow_dirpath, run_script_path)
+            cls.write_pid_file(workflow_dirpath, __rule.type, run_script_path)
 
             input_info = cls.read_input_info(__rule.input)
             cls.__change_dict_key_exist(input_info, __rule)
@@ -107,12 +107,15 @@ class Runner:
         return pid_file_path
 
     @classmethod
-    def write_pid_file(cls, workflow_dirpath: str, run_script_path: str) -> None:
+    def write_pid_file(
+        cls, workflow_dirpath: str, func_name: str, run_script_path: str
+    ) -> None:
         """
         save snakemake script file path and PID of current running algo function
         """
         pid_data = WorkflowPIDFileData(
             last_pid=os.getpid(),
+            func_name=func_name,
             last_script_file=run_script_path,
             create_time=time.time(),
         )

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -128,6 +128,12 @@ class Runner:
             os.fsync(f.fileno())
 
     @classmethod
+    def clear_pid_file(cls, workspace_id: str, unique_id: str) -> None:
+        pid_file_path = cls.__get_pid_file_path(workspace_id, unique_id)
+        if os.path.exists(pid_file_path):
+            os.remove(pid_file_path)
+
+    @classmethod
     def read_pid_file(cls, workspace_id: str, unique_id: str) -> WorkflowPIDFileData:
         pid_file_path = cls.__get_pid_file_path(workspace_id, unique_id)
         if not os.path.exists(pid_file_path):

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -315,6 +315,7 @@ class WorkflowMonitor:
             # Set dummy value to proceed to the next step.
             pid_data = WorkflowPIDFileData(
                 last_pid=999999,
+                func_name="__dummy_wrapper",
                 last_script_file="__dummy_wrapper_function.py",
                 create_time=expt_started_time.timestamp(),
             )

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
+from studio.app.common.core.rules.runner import Runner
 from studio.app.common.core.snakemake.smk import FlowConfig, Rule, SmkParam
 from studio.app.common.core.snakemake.snakemake_executor import (
     delete_dependencies,
@@ -60,6 +61,8 @@ class WorkflowRunner:
             snakemake=get_typecheck_params(self.runItem.snakemakeParam, "snakemake"),
         ).write()
 
+        Runner.clear_pid_file(self.workspace_id, self.unique_id)
+
     @staticmethod
     def create_workflow_unique_id() -> str:
         new_unique_id = str(uuid.uuid4())[:8]
@@ -81,6 +84,7 @@ class WorkflowRunner:
                 nodeDict=self.nodeDict,
                 edgeDict=self.edgeDict,
             )
+
         background_tasks.add_task(
             snakemake_execute, self.workspace_id, self.unique_id, snakemake_params
         )

--- a/studio/app/common/schemas/workflow.py
+++ b/studio/app/common/schemas/workflow.py
@@ -30,6 +30,7 @@ class WorkflowWithResults:
 @dataclass
 class WorkflowPIDFileData:
     last_pid: int
+    func_name: str
     last_script_file: str
     create_time: float
     elapsed_time: str = None

--- a/studio/tests/app/common/core/workflow/test_workflow_result.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_result.py
@@ -25,7 +25,9 @@ def test_WorkflowResult_get():
     )
 
     # first, write pid_file
-    Runner.write_pid_file(output_dirpath, "xxxx_dummy_func_script.py")
+    Runner.write_pid_file(
+        output_dirpath, "xxxx_dummy_func", "xxxx_dummy_func_script.py"
+    )
 
     output = WorkflowResult(workspace_id=workspace_id, unique_id=unique_id).observe(
         node_id_list


### PR DESCRIPTION
### Content

When re-running a past workflow, there was a path where the first run would fail ("No Snakemake process found"). This has been improved.

### Testcase

Verify that all of the following workflows are executed successfully (you can verify this by using the Tutorial Record).

- [x] 1. Run All
- [x] 2. Run (Re-Run)
    1. Old Records (2 hours (`PROCESS_SNAKEMAKE_WAIT_TIMEOUT`) have passed since completion)
        - [x] 1. Runs without re-runs
        - [x] 2. Runs with re-runs on some nodes
    1. New Records (2 hours (`PROCESS_SNAKEMAKE_WAIT_TIMEOUT`) have not passed since completion)
        - [ ] 1. Runs without re-runs
        - [ ] 2. Runs with re-runs on some nodes
