### PR TITLE
Support lock when writing pkl (implemented by rename)

### DIFF
--- a/studio/app/common/core/utils/pickle_handler.py
+++ b/studio/app/common/core/utils/pickle_handler.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import traceback
 
@@ -37,11 +38,20 @@ class PickleReader:
 class PickleWriter:
     @classmethod
     def write(cls, pickle_path, info):
-        # ファイル保存先
         dirpath = join_filepath(pickle_path.split("/")[:-1])
         create_directory(dirpath)
-        with open(pickle_path, "wb") as f:
+
+        # Note: Use temporary files to avoid read during file writing.
+        tmp_pickle_path = f"{pickle_path}.tmp"
+
+        if os.path.exists(pickle_path):
+            os.remove(pickle_path)
+
+        with open(tmp_pickle_path, "wb") as f:
             pickle.dump(info, f)
+            f.flush()
+
+        os.rename(tmp_pickle_path, pickle_path)
 
     @classmethod
     def write_error(cls, pickle_path, err: Exception):
@@ -57,5 +67,14 @@ class PickleWriter:
         if isinstance(old_pkl, dict) and isinstance(info, dict):
             old_pkl.update(info)
 
-            with open(pickle_path, "wb") as f:
+            # Note: Use temporary files to avoid read during file writing.
+            tmp_pickle_path = f"{pickle_path}.tmp"
+
+            if os.path.exists(pickle_path):
+                os.remove(pickle_path)
+
+            with open(tmp_pickle_path, "wb") as f:
                 pickle.dump(old_pkl, f)
+                f.flush()
+
+            os.rename(tmp_pickle_path, pickle_path)

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -202,8 +202,9 @@ class NodeResult:
             self.algo_name = os.path.splitext(os.path.basename(pickle_filepath))[0]
             try:
                 self.info = PickleReader.read(pickle_filepath)
-            except EOFError:
+            except Exception as e:
                 self.info = None  # indicates error
+                logger.error(e, exc_info=True)
         else:
             self.algo_name = None
             self.info = None


### PR DESCRIPTION
### Problem

- When generating a large pkl file (over 1GB, for example), there is a delay in writing the file (probably a few seconds). If there is a file read access (checking the end of the workflow) during writing, a pkl read error occurs.
- Reproducibility is not 100% (depending on the environment and timing)

### Countermeasure

Until the pkl file has been completely written, it cannot be read (this is handled by a temporary file)

### Testcase

#### Normal Workflow

1. Run All (Tutorial 1)
    - [x] 1. mac - native
    - [x] 2. mac - docker
    - [x] 3. ubuntu - native
    - [x] 4. ubuntu - docker
    - [x] 5. windows - native

#### Workflow with large output

2. Run All (Microscope(.nd2 > 1GB) + suite2p_file_convert)
    - [x] ~~1. mac - native~~  (microscope node is not supported)
    - [x] 2. mac - docker
    - [x] 3. ubuntu - native
    - [ ] 4. ubuntu - docker
    - [ ] 5. windows - native

