### PR TITLE
Change logs output dir

### DIFF
--- a/docker-compose.dev.multiuser.yml
+++ b/docker-compose.dev.multiuser.yml
@@ -26,7 +26,6 @@ services:
       - .:/app
       # optinist data outputs directories
       - ../optinist-docker-volumes/.snakemake/:/app/.snakemake
-      - ../optinist-docker-volumes/logs/:/app/logs
       - ../optinist-docker-volumes/studio_data/:/app/studio_data
     ports:
       - "127.0.0.1:8000:8000"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,6 @@ services:
       - .:/app
       # optinist data outputs directories
       - ../optinist-docker-volumes/.snakemake/:/app/.snakemake
-      - ../optinist-docker-volumes/logs/:/app/logs
       - ../optinist-docker-volumes/studio_data/:/app/studio_data
     ports:
       - "127.0.0.1:8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     working_dir: /app
     volumes:
       - ../optinist-docker-volumes/.snakemake/:/app/.snakemake
-      - ../optinist-docker-volumes/logs/:/app/logs
       - ../optinist-docker-volumes/studio_data/:/app/studio_data
     ports:
       - "127.0.0.1:8000:8000"

--- a/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
+++ b/frontend/src/components/Workspace/FlowChart/ModalLogs/index.tsx
@@ -423,6 +423,7 @@ const Content = styled(Box)`
   position: relative;
   white-space: pre-wrap;
   margin: auto;
+  padding: 12px 0 12px 0;
   outline: none;
 `
 

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -127,11 +127,7 @@ def main(develop_mode: bool = False):
     parser.add_argument("--reload", action="store_true")
     args = parser.parse_args()
 
-    log_config_file = (
-        f"{DIRPATH.CONFIG_DIR}/logging.yaml"
-        if MODE.IS_STANDALONE
-        else f"{DIRPATH.CONFIG_DIR}/logging.multiuser.yaml"
-    )
+    logging_config = AppLogger.get_logging_config()
 
     if develop_mode:
         reload_options = {"reload_dirs": ["studio"]} if args.reload else {}
@@ -139,7 +135,7 @@ def main(develop_mode: bool = False):
             "studio.__main_unit__:app",
             host=args.host,
             port=args.port,
-            log_config=log_config_file,
+            log_config=logging_config,
             reload=args.reload,
             **reload_options,
         )
@@ -148,6 +144,6 @@ def main(develop_mode: bool = False):
             "studio.__main_unit__:app",
             host=args.host,
             port=args.port,
-            log_config=log_config_file,
+            log_config=logging_config,
             reload=False,
         )

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -27,7 +27,8 @@ class AppLogger:
 
             - logger initialization location
               - Web App ... studio.__main_unit__
-              - Batch App ... studio.app.optinist.core.expdb.batch_runner (optinist-for-server)
+              - Batch App ... studio.app.optinist.core.expdb.batch_runner
+                (optinist-for-server)
 
         Note #2.
             However, only in the case of the snakemake process,

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -16,8 +16,8 @@ class AppLogger:
 
     LOGGER_NAME = "optinist"
 
-    @staticmethod
-    def init_logger():
+    @classmethod
+    def init_logger(cls):
         """
         Note #1.
             At the time of starting to use this Logger,
@@ -27,32 +27,52 @@ class AppLogger:
 
             - logger initialization location
               - Web App ... studio.__main_unit__
-              - Batch App ... studio.app.optinist.core.expdb.batch_runner
+              - Batch App ... studio.app.optinist.core.expdb.batch_runner (optinist-for-server)
 
         Note #2.
             However, only in the case of the snakemake process,
             the initialization process is required because it is a separate process.
         """
 
-        log_config_file = (
+        # read logging config
+        logging_config = cls.get_logging_config()
+
+        # create log output directory (if none exists)
+        log_file = (
+            logging_config.get("handlers", {}).get("rotating_file", {}).get("filename")
+        )
+        if log_file:
+            log_dir = os.path.dirname(log_file)
+            if not os.path.isdir(log_dir):
+                os.makedirs(log_dir)
+
+        # set logging config
+        logging.config.dictConfig(logging_config)
+
+    @staticmethod
+    def get_logging_config() -> dict:
+        logging_config_file = (
             f"{DIRPATH.CONFIG_DIR}/logging.yaml"
             if MODE.IS_STANDALONE
             else f"{DIRPATH.CONFIG_DIR}/logging.multiuser.yaml"
         )
 
-        with open(log_config_file) as file:
-            log_config = yaml.load(file.read(), yaml.FullLoader)
+        logging_config = None
 
-            # create log output directory (if none exists)
+        with open(logging_config_file) as file:
+            logging_config = yaml.load(file.read(), yaml.FullLoader)
+
+            # Adjust log file path (if none exists)
             log_file = (
-                log_config.get("handlers", {}).get("rotating_file", {}).get("filename")
+                logging_config.get("handlers", {})
+                .get("rotating_file", {})
+                .get("filename")
             )
             if log_file:
-                log_dir = os.path.dirname(log_file)
-                if not os.path.isdir(log_dir):
-                    os.makedirs(log_dir)
+                log_file = f"{DIRPATH.DATA_DIR}/{log_file}"
+                logging_config["handlers"]["rotating_file"]["filename"] = log_file
 
-            logging.config.dictConfig(log_config)
+        return logging_config
 
     @staticmethod
     def get_logger() -> logging.Logger:

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -43,7 +43,7 @@ class DIRPATH:
     MICROSCOPE_LIB_DIR = f"{APP_DIR}/optinist/microscopes/libs"
     MICROSCOPE_LIB_ZIP = f"{APP_DIR}/optinist/microscopes/libs.zip"
 
-    LOG_FILE_PATH = f"{ROOT_DIR}/logs/studio.log"
+    LOG_FILE_PATH = f"{DATA_DIR}/logs/studio.log"
 
 
 class CORE_PARAM_PATH(Enum):

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -17,6 +17,7 @@ handlers:
     level: DEBUG
     formatter: default
     filename: logs/studio.log
+    encoding: utf-8
     when: midnight
     interval: 1
     backupCount: 365

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -17,6 +17,7 @@ handlers:
     level: DEBUG
     formatter: default
     filename: logs/studio.log
+    encoding: utf-8
     when: midnight
     interval: 1
     backupCount: 365


### PR DESCRIPTION
### Content

Change logs output dir
- Switch output destination to the path in the env var (OPTINIST_DIR)
- Adjustments to support logging in pip version

### Testcase

- Check point
  1. Log files are output under $OPTINIST_DIR/logs.
  2. Logs are displayed without delay in Log Viewer.

- Check target environments
  - Native
    - Development
      - [x] Mac
      - [x] Ubuntu
      - [x] Windows
    - Pip
      - [x] Mac
      - [x] Ubuntu
      - [x] Windows
  - Docker
    - [x] Mac
