### PR TITLE
Fix/numpy version instruction

### DIFF
--- a/docs/specifications/add_algorithm.md
+++ b/docs/specifications/add_algorithm.md
@@ -130,7 +130,11 @@ If your function requires specific packages, you can set them using a conda env 
 ```yaml
 dependencies:
   - python=3.9 # Add the dependencies needed for you function
+  - numpy>2 # Exclude numpy 2.x versions
 ```
+
+- Note:
+  - Currently, Optinist only supports NumPy versions below 2. Please ensure that your Conda environment is configured with an appropriate version of NumPy.
 
 ### Check your custom node inputs and outputs
 

--- a/docs/specifications/add_algorithm.md
+++ b/docs/specifications/add_algorithm.md
@@ -130,7 +130,7 @@ If your function requires specific packages, you can set them using a conda env 
 ```yaml
 dependencies:
   - python=3.9 # Add the dependencies needed for you function
-  - numpy>2 # Exclude numpy 2.x versions
+  - numpy<2 # Exclude numpy 2.x versions
 ```
 
 - Note:

--- a/docs/specifications/add_algorithm.md
+++ b/docs/specifications/add_algorithm.md
@@ -134,7 +134,8 @@ dependencies:
 ```
 
 - Note:
-  - Currently, Optinist only supports NumPy versions below 2. Please ensure that your Conda environment is configured with an appropriate version of NumPy.
+  - Currently, Optinist packages supports NumPy versions below 2. Please ensure that your Conda environment is configured with an appropriate version of NumPy.
+  - If you plan to use NumPy 2.x or higher, ensure all other packages in your environment are compatible with it.
 
 ### Check your custom node inputs and outputs
 

--- a/studio/app/optinist/wrappers/custom/conda/custom.yaml
+++ b/studio/app/optinist/wrappers/custom/conda/custom.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - python=3.9
+  - numpy<2 # Exclude numpy 2.x versions

--- a/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
+++ b/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
@@ -1,11 +1,12 @@
 # Packages in conda env for [optinist]
 dependencies:
   - python=3.9
+  - numpy<2
   - pip
   - pip:
-    - scikit-learn==1.1.*
-    - statsmodels==0.13.*
-    - pynwb==2.2.0
-    - numexpr
-    - numba
-    - dpca
+      - scikit-learn==1.1.*
+      - statsmodels==0.13.*
+      - pynwb==2.2.0
+      - numexpr
+      - numba
+      - dpca


### PR DESCRIPTION
## PROBLEM:
There was no instructions on setting numPy version to below version 2.  
Currently, Optinist only supports NumPy versions below 2.
## WHAT I DID
• Add numpy set to custom node conda environment
• Add Instruction at Add Algorithm Documentation

![Screenshot 2025-04-07 at 10 22 11](https://github.com/user-attachments/assets/1a038fe0-223d-4965-abcc-23e6bbd64d81)

![Screenshot 2025-04-04 at 15 15 45](https://github.com/user-attachments/assets/a83265e4-7a3a-4616-91f0-631e4ff9851d)

