### PR TITLE
Improved resource contention during parallel execution of caiman_mc

### DIFF
--- a/studio/app/optinist/wrappers/caiman/caiman_utils.py
+++ b/studio/app/optinist/wrappers/caiman/caiman_utils.py
@@ -1,0 +1,42 @@
+import os
+import re
+import shutil
+
+
+class CaimanUtils:
+    """
+    Utilty functions for Caiman
+    """
+
+    CAIMAN_TEMP_ENV_VAR_NAME = "CAIMAN_TEMP"
+
+    @staticmethod
+    def get_caiman_tempdir() -> str:
+        import caiman.paths
+
+        try:
+            caiman_tempdir_path = caiman.paths.get_tempdir()
+        except Exception:
+            caiman_tempdir_path = os.path.join(caiman.paths.caiman_datadir(), "temp")
+
+        return caiman_tempdir_path
+
+    @classmethod
+    def set_caimam_byid_tempdir(cls, id: str):
+        # If "CAIMAN_TEMP" env var is specified, skip
+        if cls.CAIMAN_TEMP_ENV_VAR_NAME in os.environ:
+            return
+
+        caiman_tempdir_path = os.path.join(cls.get_caiman_tempdir(), id)
+        os.makedirs(caiman_tempdir_path, exist_ok=True)
+        os.environ[cls.CAIMAN_TEMP_ENV_VAR_NAME] = caiman_tempdir_path
+
+    @classmethod
+    def cleanup_caiman_byid_tempdir(cls, id: str):
+        caiman_tempdir_path = cls.get_caiman_tempdir()
+
+        if re.search(f"{id}$", caiman_tempdir_path):
+            shutil.rmtree(caiman_tempdir_path)
+
+            if cls.CAIMAN_TEMP_ENV_VAR_NAME in os.environ:
+                del os.environ[cls.CAIMAN_TEMP_ENV_VAR_NAME]

--- a/studio/app/optinist/wrappers/caiman/caiman_utils.py
+++ b/studio/app/optinist/wrappers/caiman/caiman_utils.py
@@ -5,7 +5,7 @@ import shutil
 
 class CaimanUtils:
     """
-    Utilty functions for Caiman
+    Utility functions for Caiman
     """
 
     CAIMAN_TEMP_ENV_VAR_NAME = "CAIMAN_TEMP"

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -10,9 +10,8 @@ from studio.app.common.core.utils.filepath_creater import (
 from studio.app.common.dataclass import ImageData
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass import RoiData
-from studio.app.optinist.wrappers.optinist.utils import recursive_flatten_params
-
 from studio.app.optinist.wrappers.caiman.caiman_utils import CaimanUtils
+from studio.app.optinist.wrappers.optinist.utils import recursive_flatten_params
 
 logger = AppLogger.get_logger()
 

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -12,6 +12,8 @@ from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.dataclass import RoiData
 from studio.app.optinist.wrappers.optinist.utils import recursive_flatten_params
 
+from studio.app.optinist.wrappers.caiman.caiman_utils import CaimanUtils
+
 logger = AppLogger.get_logger()
 
 
@@ -25,10 +27,17 @@ def caiman_mc(
     from caiman.source_extraction.cnmf.params import CNMFParams
 
     function_id = ExptOutputPathIds(output_dir).function_id
+    unique_id = ExptOutputPathIds(output_dir).unique_id
     logger.info(f"start caiman motion_correction: {function_id}")
+
     flattened_params = {}
     recursive_flatten_params(params, flattened_params)
     params = flattened_params
+
+    # Specify a unique CAIMAN_TEMPDIR
+    # *To avoid collisions of temporary files (memmap files)
+    mc_unique_id = f"{unique_id}_{function_id}"
+    CaimanUtils.set_caimam_byid_tempdir(mc_unique_id)
 
     opts = CNMFParams()
 
@@ -96,7 +105,18 @@ def caiman_mc(
     }
 
     # Clean up temporary files
-    __handle_mmap_cleanup(mc, fname_new, output_dir)
+    try:
+        __handle_mmap_cleanup(mc, fname_new, output_dir)
+    except Exception as e:
+        logger.error("caiman_mc: Failed to cleanup memmap files.")
+        logger.error(e)
+
+    # Clean up unique CAIMAN_TEMPDIR
+    try:
+        CaimanUtils.cleanup_caiman_byid_tempdir(mc_unique_id)
+    except Exception as e:
+        logger.error("caiman_mc: Failed to cleanup tempdir.")
+        logger.error(e)
 
     return info
 
@@ -151,4 +171,7 @@ def __move_file_safely(src: str, dest: str) -> None:
             shutil.rmtree(dest)
 
     if os.path.exists(src):
-        shutil.move(src, dest)
+        try:
+            shutil.move(src, dest)
+        except FileNotFoundError:
+            logger.warning("caiman_mc: Failed to cleanup move files.")


### PR DESCRIPTION
### Countermeasure

#### Constraints
Some of the memmap files automatically generated by caiman cannot have their names changed. This can lead to file name duplications.

#### Countermeasures
As mentioned above, the naming of some of the automatically generated files cannot be controlled, so we dealt with this by dynamically adjusting the storage folder for the automatically generated files.

#### Spec
The following rules were used to generate a temporary folder dedicated to caiman_mc.
- `f"{unique_id}_{function_id}"`

- Exapmle
  ```
  $HOME/caiman_data/temp
    19009979_caiman_mc_o5k0ez4d9p
    f02f0e7f_caiman_mc_o5k0ez4d9p
  ```

### Test result

- Testing platforms
  - Native
    - [x] Mac
    - [x] Ubuntu
    - [x] Windows
  - Docker
    - [x] Mac

- Multiple simultaneous runs of caiman_mc to ensure no resource (memmap files) conflicts
![2025-04-07 16 47 17](https://github.com/user-attachments/assets/ad157713-6e4b-4eb6-875a-4c487adf7d6c)
