### PR TITLE
Supported nwb initialization concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 
 *.extensions.yaml
 *.namespace.yaml
+*.namespace.yaml.lock
 
 files/*
 Pipfile.lock

--- a/studio/app/optinist/core/nwb/nwb_loader.py
+++ b/studio/app/optinist/core/nwb/nwb_loader.py
@@ -1,0 +1,31 @@
+import os
+import time
+
+from filelock import FileLock
+from pynwb.spec import NWBGroupSpec, NWBNamespaceBuilder
+
+
+def export_nwb_namespace_file(
+    ns_name: str, ns_path: str, ext_path: str, group_spec: NWBGroupSpec
+):
+    """
+    Generation of NWB namespace file (*.extensions.yaml)
+    """
+
+    FILE_CACHE_INTERVAL = 180
+
+    lock_path = ns_path + ".lock"
+
+    with FileLock(lock_path, timeout=10):
+        flle_update_elapsed_time = (
+            (time.time() - os.path.getmtime(ns_path)) if os.path.exists(ns_path) else 0
+        )
+
+        if (not os.path.exists(ns_path)) or (
+            flle_update_elapsed_time > FILE_CACHE_INTERVAL
+        ):
+            ns_builder = NWBNamespaceBuilder(
+                f"{ns_name} extensions", ns_name, version="0.1.0"
+            )
+            ns_builder.add_spec(ext_path, group_spec)
+            ns_builder.export(ns_path)

--- a/studio/app/optinist/core/nwb/optinist_data.py
+++ b/studio/app/optinist/core/nwb/optinist_data.py
@@ -1,5 +1,7 @@
 from pynwb import get_class, load_namespaces
-from pynwb.spec import NWBDatasetSpec, NWBGroupSpec, NWBNamespaceBuilder
+from pynwb.spec import NWBDatasetSpec, NWBGroupSpec
+
+from studio.app.optinist.core.nwb.nwb_loader import export_nwb_namespace_file
 
 name = "optinist"
 ns_path = f"{name}.namespace.yaml"
@@ -31,9 +33,8 @@ postprocess = NWBGroupSpec(
 
 # Now we set up the builder and add this object
 
-ns_builder = NWBNamespaceBuilder(f"{name} extensions", name, version="0.1.0")
-ns_builder.add_spec(ext_source, postprocess)
-ns_builder.export(ns_path)
+export_nwb_namespace_file(name, ns_path, ext_source, postprocess)
 
 load_namespaces(ns_path)
+
 PostProcess = get_class("PostProcess", name)


### PR DESCRIPTION
### 問題

Application起動時には、NWB moduleの初期化処理が実施されているが、初期化処理時に設定ファイル（namespace yaml）の生成が毎回行われており、複数のworker起動時に、ファイル生成のconflict＆NWB初期化失敗が発生するケースがあった。

### 対策

初期化処理時の設定ファイル（namespace yaml）の生成を、並列化に対応。
具体的には、設定ファイルの生成に排他処理を導入した。

### テストケース

- Platforms
  - Native
    - [x] Mac
    - [x] Ubuntu
    - [x] Windows
  - [x] Docker

- Testcase
    - Single Application Process (worker=1)
      - [x] Startup (No error)
      - [x] Run Single Workflow (No error)
    - Multi Application Process (worker>1)
      - [x] Startup (No error)
      - [x] Run Parallel Workflow (No error)

- Other Testcase
    - optinist-for-server
      - [x] Analysis Batch  (No error)
        - ※別プロジェクトだが、Analysis Batch 内の NWB 処理に問題がないかをここで確認しておく