### PR TITLE
Supported  logging concurrency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -442,6 +442,21 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
+name = "concurrent-log-handler"
+version = "0.9.25"
+description = "RotatingFileHandler replacement with concurrency, gzip and Windows support"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "concurrent_log_handler-0.9.25-py3-none-any.whl", hash = "sha256:157bee12914aa2a72246d1d0641ce07c1aa7a55faa3322bed02f21e60395eb82"},
+    {file = "concurrent_log_handler-0.9.25.tar.gz", hash = "sha256:1e2c6f021414e214d3dac66107894827a3e78db63018304a4f29e55ba549ac22"},
+]
+
+[package.dependencies]
+portalocker = ">=1.6.0"
+
+[[package]]
 name = "configargparse"
 version = "1.7"
 description = "A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables."
@@ -2759,6 +2774,26 @@ files = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.1.1"
+description = "Wraps the portalocker recipe for easy usage"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "portalocker-3.1.1-py3-none-any.whl", hash = "sha256:80e984e24de292ff258a5bea0e4f3f778fff84c0ae1275dbaebc4658de4aacb3"},
+    {file = "portalocker-3.1.1.tar.gz", hash = "sha256:ec20f6dda2ad9ce89fa399a5f31f4f1495f515958f0cb7ca6543cef7bb5a749e"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+docs = ["sphinx (>=1.7.1)"]
+redis = ["redis"]
+tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-rerunfailures (>=15.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
+
+[[package]]
 name = "pre-commit"
 version = "4.1.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -3302,7 +3337,7 @@ description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""
+markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\" or platform_system == \"Windows\""
 files = [
     {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
     {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
@@ -4649,4 +4684,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "8563e71f695a948ce393a30710cd6c536f6c0ad34aa511c0866a77c1452af498"
+content-hash = "ec02d4f7ee8c9d7c212e542724d51f284bdf6a366b292eb421c3066d2043d3e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ ruamel-yaml = "^0.18.5"
 pymatreader = "^0.0.32"
 xmltodict = "*"
 matplotlib = "3.7.*"
+concurrent-log-handler = "^0.9.25"
 
 [tool.poetry.group.dev]
 optional = true

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import os
+import platform
 import traceback
 
 import yaml
@@ -63,15 +64,32 @@ class AppLogger:
         with open(logging_config_file) as file:
             logging_config = yaml.load(file.read(), yaml.FullLoader)
 
-            # Adjust log file path (if none exists)
-            log_file = (
-                logging_config.get("handlers", {})
-                .get("rotating_file", {})
-                .get("filename")
-            )
-            if log_file:
-                log_file = f"{DIRPATH.DATA_DIR}/{log_file}"
-                logging_config["handlers"]["rotating_file"]["filename"] = log_file
+        logging_handers = logging_config.get("handlers", {})
+
+        # Switch rotating_file depending on platform
+        if __class__.is_native_windows():
+            # ATTENTION:
+            # On the Windows Native Platform, "rotating_file_concurrency"
+            # is currently not supported because pywin32 is required to use
+            # concurrent_log_handler. (which is not installed in the conda env).
+            pass
+        else:
+            if ("rotating_file" in logging_handers) and (
+                "rotating_file_concurrency"
+            ) in logging_handers:
+                logging_config["handlers"]["rotating_file"] = logging_config[
+                    "handlers"
+                ]["rotating_file_concurrency"]
+
+        # Delete unnecessary items
+        if "rotating_file_concurrency" in logging_handers:
+            del logging_config["handlers"]["rotating_file_concurrency"]
+
+        # Adjust log file path (if none exists)
+        log_file = logging_handers.get("rotating_file", {}).get("filename")
+        if log_file:
+            log_file = f"{DIRPATH.DATA_DIR}/{log_file}"
+            logging_config["handlers"]["rotating_file"]["filename"] = log_file
 
         return logging_config
 
@@ -88,3 +106,14 @@ class AppLogger:
     @staticmethod
     def format_exc_traceback(e: Exception):
         return "{}: {}\n{}".format(type(e), e, traceback.format_exc())
+
+    @staticmethod
+    def is_native_windows():
+        if platform.system() != "Windows":
+            return False
+
+        # Check WSL Platform
+        if "WSL_DISTRO_NAME" in os.environ or "WSL_INTEROP" in os.environ:
+            return False
+
+        return True

--- a/studio/app/common/core/utils/log_reader.py
+++ b/studio/app/common/core/utils/log_reader.py
@@ -33,6 +33,7 @@ class LogRecordReader(ContentUnitReader):
             rb"^(?P<asctime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) "
             rb"(?:\x1b\[\d+m)?(?P<levelprefix>\w+)(?:\x1b\[0m)?:?\s+"
             rb"\[(?P<name>[^\]]+)\] "
+            rb"\((?P<process>\w+)\) "
             rb"(?P<funcName>\w+)\(\):(?P<lineno>\d+) - "
             rb"(?P<message>.*)",
             re.DOTALL,

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -13,22 +13,23 @@ handlers:
     level: DEBUG
     formatter: default
   rotating_file:
+    class: logging.handlers.TimedRotatingFileHandler
+    level: DEBUG
+    formatter: default
+    filename: logs/studio.log
+    encoding: utf-8
+    when: midnight
+    interval: 1
+    backupCount: 365
+  rotating_file_concurrency:
     class: concurrent_log_handler.ConcurrentTimedRotatingFileHandler
     level: DEBUG
     formatter: default
     filename: logs/studio.log
     encoding: utf-8
     maxBytes: 5242880
-    backupCount: 200
-  # rotating_file_standard:
-  #   class: logging.handlers.TimedRotatingFileHandler
-  #   level: DEBUG
-  #   formatter: default
-  #   filename: logs/studio.log
-  #   encoding: utf-8
-  #   when: midnight
-  #   interval: 1
-  #   backupCount: 365
+    # backupCount ... Number of backups on the same date
+    backupCount: 100
 loggers:
   optinist:
     level: DEBUG

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -3,24 +3,32 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler
     level: DEBUG
     formatter: default
   rotating_file:
-    class: logging.handlers.TimedRotatingFileHandler
+    class: concurrent_log_handler.ConcurrentTimedRotatingFileHandler
     level: DEBUG
     formatter: default
     filename: logs/studio.log
     encoding: utf-8
-    when: midnight
-    interval: 1
-    backupCount: 365
+    maxBytes: 5242880
+    backupCount: 200
+  # rotating_file_standard:
+  #   class: logging.handlers.TimedRotatingFileHandler
+  #   level: DEBUG
+  #   formatter: default
+  #   filename: logs/studio.log
+  #   encoding: utf-8
+  #   when: midnight
+  #   interval: 1
+  #   backupCount: 365
 loggers:
   optinist:
     level: DEBUG

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -13,22 +13,23 @@ handlers:
     level: DEBUG
     formatter: default
   rotating_file:
+    class: logging.handlers.TimedRotatingFileHandler
+    level: DEBUG
+    formatter: default
+    filename: logs/studio.log
+    encoding: utf-8
+    when: midnight
+    interval: 1
+    backupCount: 365
+  rotating_file_concurrency:
     class: concurrent_log_handler.ConcurrentTimedRotatingFileHandler
     level: DEBUG
     formatter: default
     filename: logs/studio.log
     encoding: utf-8
     maxBytes: 5242880
-    backupCount: 200
-  # rotating_file_standard:
-  #   class: logging.handlers.TimedRotatingFileHandler
-  #   level: DEBUG
-  #   formatter: default
-  #   filename: logs/studio.log
-  #   encoding: utf-8
-  #   when: midnight
-  #   interval: 1
-  #   backupCount: 365
+    # backupCount ... Number of backups on the same date
+    backupCount: 100
 loggers:
   optinist:
     level: DEBUG

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -3,24 +3,32 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler
     level: DEBUG
     formatter: default
   rotating_file:
-    class: logging.handlers.TimedRotatingFileHandler
+    class: concurrent_log_handler.ConcurrentTimedRotatingFileHandler
     level: DEBUG
     formatter: default
     filename: logs/studio.log
     encoding: utf-8
-    when: midnight
-    interval: 1
-    backupCount: 365
+    maxBytes: 5242880
+    backupCount: 200
+  # rotating_file_standard:
+  #   class: logging.handlers.TimedRotatingFileHandler
+  #   level: DEBUG
+  #   formatter: default
+  #   filename: logs/studio.log
+  #   encoding: utf-8
+  #   when: midnight
+  #   interval: 1
+  #   backupCount: 365
 loggers:
   optinist:
     level: DEBUG


### PR DESCRIPTION
### 目的

optinist の並列化対応（multi-processing）の改善に伴い、logging も並列化に対応させる。

\*現在使用中の `logging.FileHandler` は、multi-processing に非対応である

### 検証

#### 検証 1. QueueHandler, QueueListener

- mutiprocessing下での標準的なlogging方式である、QueueHandler, QueueListener を検証。
- しかし以下のような課題があり、 optinsit (fastapi,uvicorn) には適合しないようであることを確認。
  1. uvicorn の workers 毎のプロセスは、アプリケーションのコード管理外でプロセスが分離されており、worker間でloggingのQueue Stackを共有できない。
      - 実際に動作検証すると、動作が不安定である模様。
  2. また、QueueHandler と TimedRotatingFileHandler の組み合わせも、うまく連動していない？ようである。

上記から、他の方式を検討する。

#### 検証 2. concurrent_log_handler

- `concurrent_log_handler.ConcurrentRotatingFileHandler|ConcurrentTimedRotatingFileHandler` を検証
- 基本的には問題なく動作している模様
- しかし以下の様な課題も確認
  1. 標準の TimedRotatingFileHandler に相当する ConcurrentTimedRotatingFileHandler の動作仕様が、TimedRotatingFileHandler とやや異なり、独自の動作仕様となっている
      - 実際に動作検証すると、Rotation の動作（タイミングやbackup のnamingなど）などが異なる模様。
- 上記の課題はあるが、logging,rotation自体は正常動作するようであるため、ConcurrentTimedRotatingFileHandler を採用する方針とする。

- ConcurrentRotatingFileHandler 仕様補足
  - rotation が実施された際、backupされたファイル名は `{basename}.{date}_{hour}.{seqno}` となる。 (例: "studio.log.2025-04-09_06.1")

### テストケース

- Platforms
  - Native
    - [x] Mac
    - [x] Ubuntu
    - [x] Windows
      - *Windows環境では、concurrent_log_handler に環境依存（pywin32）の課題があることから、concurrent_log_handlerは非サポートとした（暫定対応）
  - [x] Docker

- Testcase
  - 以下のテストケースに同じ
  - https://github.com/arayabrain/barebone-studio/pull/739

テストケースを実施し、logging の失敗や、その他 logging に関するエラーが発生していないことを確認する。
