### PR TITLE
Add Delete Button to Tree Node Without Enabling Multi-Select

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
@@ -37,6 +37,7 @@ describe("TreeItemLabel Component", () => {
     render(
       <Provider store={store}>
         <TreeItemLabel
+          multiSelect={true}
           fileType="image"
           shape={[100, 100]}
           label="testFile"
@@ -69,6 +70,7 @@ describe("TreeItemLabel Component", () => {
     render(
       <Provider store={store}>
         <TreeItemLabel
+          multiSelect={true}
           fileType="image"
           shape={[100, 100]}
           label="testFile"
@@ -95,6 +97,7 @@ describe("TreeItemLabel Component", () => {
     render(
       <Provider store={store}>
         <TreeItemLabel
+          multiSelect={true}
           fileType="image"
           shape={[100, 100]}
           label="testFile"
@@ -114,6 +117,7 @@ describe("TreeItemLabel Component", () => {
     render(
       <Provider store={store}>
         <TreeItemLabel
+          multiSelect={true}
           fileType="image"
           shape={[100, 100]}
           label="testFile"


### PR DESCRIPTION
## 【DESCRIPTION】
Previously, the delete button was only available on the Image input when multi-selection was enabled. This was limiting and inconsistent.
Now, single-select inputs can also display a delete button, providing a more flexible and user-friendly experience.

## Evidence:

https://github.com/user-attachments/assets/f24af3b5-ffc5-4574-9334-806e00a3fc90

