### PR TITLE
Fix: pop received too many inputs, caused error

### DIFF
--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -317,7 +317,7 @@ class NWBCreater:
                     nwbfile.processing["config"].add_container(config_container)
                 except ValueError:
                     # Remove existing container if it exists
-                    nwbfile.processing["config"].data_interfaces.pop(config_name, None)
+                    nwbfile.processing["config"].data_interfaces.pop(config_name)
                     nwbfile.processing["config"].add_container(config_container)
 
             except Exception as e:


### PR DESCRIPTION
there was an error that pop did not accept both config_name and none as too many arguments, so removed the `none`