### PR TITLE
Update NWB spec optinist version

### DIFF
--- a/studio/app/optinist/core/nwb/nwb_spec_utils.py
+++ b/studio/app/optinist/core/nwb/nwb_spec_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from typing import List, Union
 
@@ -6,8 +7,10 @@ from filelock import FileLock
 from pynwb.spec import NWBGroupSpec, NWBNamespaceBuilder
 
 from studio.app.common.core.utils.filelock_handler import FileLockUtils
+from studio.app.dir_path import DIRPATH
 
 NWB_SPEC_FILE_EXPORT_DIR = os.path.join(os.path.dirname(__file__), "specs")
+root_dir = DIRPATH.ROOT_DIR
 
 
 def get_namespace_file_path(ns_name: str) -> str:
@@ -43,8 +46,9 @@ def export_spec_files(
         if (not os.path.exists(ns_path)) or (
             flle_update_elapsed_time > file_cache_interval
         ):
+            current_version = get_version_from_pyproject()
             ns_builder = NWBNamespaceBuilder(
-                f"{ns_name} extensions", ns_name, version="0.1.0"
+                f"{ns_name} extensions", ns_name, version=current_version
             )
 
             if isinstance(group_spec, list):
@@ -71,3 +75,21 @@ def export_spec_files(
             finally:
                 # Return current directory
                 os.chdir(previous_dir)
+
+
+def get_version_from_pyproject() -> str:
+    """Extract version from pyproject.toml."""
+    # Look for pyproject.toml in parent directories
+    pyproject_path = os.path.join(root_dir, "pyproject.toml")
+
+    # Read and parse the version from pyproject.toml
+    with open(pyproject_path, "r") as f:
+        content = f.read()
+
+    # Use regex to extract version
+    version_match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+    if version_match:
+        version = version_match.group(1)
+        return version
+    else:
+        return "2.0.0"

--- a/studio/app/optinist/core/nwb/specs/optinist.namespace.yaml
+++ b/studio/app/optinist/core/nwb/specs/optinist.namespace.yaml
@@ -4,4 +4,4 @@ namespaces:
   schema:
   - namespace: core
   - source: optinist.extensions.yaml
-  version: 0.1.0
+  version: 2.1.0


### PR DESCRIPTION

### Content
Read version from pyproject/toml, add this to spec file when calling export_spec_files

### References
> *nwbに保存されるoptinistモジュールのバージョン
[#466](https://github.com/oist/optinist/issues/466)

### Testcase
Change pyproject toml version
$` cd studio/app/optinist/core/nwb/specs/`
$` python export_spec_files.py`
RUN ALL to generate an NWB
Check specifcations/optinist/ for version change

### Comments
This could maybe be made automatic in future
