### PR TITLE
Improve nodes file i/o concurrency

### DIFF
--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.utils.config_handler import ConfigReader
@@ -8,18 +8,10 @@ from studio.app.dir_path import DIRPATH
 
 
 class ExptConfigReader:
-    @staticmethod
-    def read_raw(workspace_id: str, unique_id: str) -> dict:
-        config = ConfigReader.read(
-            join_filepath(
-                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
-            )
-        )
-        return config
-
     @classmethod
-    def read(cls, filepath) -> ExptConfig:
-        config = ConfigReader.read(filepath)
+    def read(cls, file: Union[str, bytes]) -> ExptConfig:
+        config = ConfigReader.read(file)
+        assert config, f"Invalid config yaml file: [{file}] [{config}]"
 
         return ExptConfig(
             workspace_id=config["workspace_id"],
@@ -34,6 +26,15 @@ class ExptConfigReader:
             snakemake=config.get("snakemake"),
             data_usage=config.get("data_usage"),
         )
+
+    @staticmethod
+    def read_raw(workspace_id: str, unique_id: str) -> dict:
+        config = ConfigReader.read(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+            )
+        )
+        return config
 
     @classmethod
     def read_function(cls, config) -> Dict[str, ExptFunction]:

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -3,10 +3,22 @@ from typing import Dict
 import yaml
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
+from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.workflow.workflow import NodeRunStatus, OutputPath
+from studio.app.dir_path import DIRPATH
 
 
 class ExptConfigReader:
+    @staticmethod
+    def read_raw(workspace_id: str, unique_id: str) -> dict:
+        config = ConfigReader.read(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+            )
+        )
+        return config
+
     @classmethod
     def read(cls, filepath) -> ExptConfig:
         with open(filepath, "r") as f:

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -21,8 +21,7 @@ class ExptConfigReader:
 
     @classmethod
     def read(cls, filepath) -> ExptConfig:
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
+        config = ConfigReader.read(filepath)
 
         return ExptConfig(
             workspace_id=config["workspace_id"],

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-import yaml
-
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -37,14 +37,6 @@ class ExptConfigWriter:
         self.snakemake = snakemake
         self.builder = ExptConfigBuilder()
 
-    @staticmethod
-    def write_raw(workspace_id: str, unique_id: str, config: dict) -> None:
-        ConfigWriter.write(
-            dirname=join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
-            filename=DIRPATH.EXPERIMENT_YML,
-            config=config,
-        )
-
     def write(self) -> None:
         expt_filepath = join_filepath(
             [
@@ -66,6 +58,14 @@ class ExptConfigWriter:
         # Write EXPERIMENT_YML
         self.write_raw(
             self.workspace_id, self.unique_id, config=asdict(self.builder.build())
+        )
+
+    @staticmethod
+    def write_raw(workspace_id: str, unique_id: str, config: dict) -> None:
+        ConfigWriter.write(
+            dirname=join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
+            filename=DIRPATH.EXPERIMENT_YML,
+            config=config,
         )
 
     def create_config(self) -> ExptConfig:

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -143,11 +143,11 @@ class ExptDataWriter:
         # Note: "r+" option for file-open is not used here
         #   because it requires file pointer control.
 
-        # Read cofig
+        # Read config
         config = ExptConfigReader.read_raw(self.workspace_id, self.unique_id)
         config["name"] = new_name
 
-        # Update & Write cofig
+        # Update & Write config
         ExptConfigWriter.write_raw(self.workspace_id, self.unique_id, config)
 
         config_path = join_filepath(
@@ -341,11 +341,11 @@ class ExptDataWriter:
         logger = AppLogger.get_logger()
 
         try:
-            # Read cofig
+            # Read config
             config = ExptConfigReader.read_raw(workspace_id, unique_id)
             config["name"] = f"{config.get('name', 'experiment')}_copy"
 
-            # Update & Write cofig
+            # Update & Write config
             ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
             logger.info(f"Updated experiment.yml: {workspace_id}/{unique_id}")

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Dict
 
 import numpy as np
-import yaml
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.experiment.experiment_builder import ExptConfigBuilder
@@ -138,7 +137,20 @@ class ExptDataWriter:
         return result
 
     def rename(self, new_name: str) -> ExptConfig:
-        filepath = join_filepath(
+        # validate params
+        new_name = "" if new_name is None else new_name  # filter None
+
+        # Note: "r+" option for file-open is not used here
+        #   because it requires file pointer control.
+
+        # Read cofig
+        config = ExptConfigReader.read_raw(self.workspace_id, self.unique_id)
+        config["name"] = new_name
+
+        # Update & Write cofig
+        ExptConfigWriter.write_raw(self.workspace_id, self.unique_id, config)
+
+        config_path = join_filepath(
             [
                 DIRPATH.OUTPUT_DIR,
                 self.workspace_id,
@@ -146,31 +158,7 @@ class ExptDataWriter:
                 DIRPATH.EXPERIMENT_YML,
             ]
         )
-
-        # validate params
-        new_name = "" if new_name is None else new_name  # filter None
-
-        # Note: "r+" option is not used here because it requires file pointer control.
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
-            config["name"] = new_name
-
-        with open(filepath, "w") as f:
-            yaml.dump(config, f, sort_keys=False)
-
-        return ExptConfig(
-            workspace_id=config["workspace_id"],
-            unique_id=config["unique_id"],
-            name=config["name"],
-            started_at=config.get("started_at"),
-            finished_at=config.get("finished_at"),
-            success=config.get("success", WorkflowRunStatus.RUNNING.value),
-            hasNWB=config["hasNWB"],
-            function=ExptConfigReader.read_function(config["function"]),
-            nwb=config.get("nwb"),
-            snakemake=config.get("snakemake"),
-            data_usage=config.get("data_usage"),
-        )
+        return ExptConfigReader.read(config_path)
 
     def copy_data(self, new_unique_id: str) -> bool:
         logger = AppLogger.get_logger()
@@ -188,7 +176,9 @@ class ExptDataWriter:
             shutil.copytree(output_dir, new_output_dir)
 
             # Update experiment configuration and unique IDs
-            if not self.__copy_data_update_experiment_config_name(new_output_dir):
+            if not self.__copy_data_update_experiment_config_name(
+                self.workspace_id, new_unique_id
+            ):
                 logger.error("Failed to update experiment.yml after copying.")
                 return False
 
@@ -345,23 +335,20 @@ class ExptDataWriter:
         else:
             return obj
 
-    def __copy_data_update_experiment_config_name(self, output_dir: str) -> bool:
+    def __copy_data_update_experiment_config_name(
+        self, workspace_id: str, unique_id: str
+    ) -> bool:
         logger = AppLogger.get_logger()
-        config_path = join_filepath([output_dir, DIRPATH.EXPERIMENT_YML])
 
         try:
-            with open(config_path, "r") as file:
-                config = yaml.safe_load(file)
-
-            if not config:
-                logger.error(f"Invalid YAML at {config_path}")
-                return False
-
+            # Read cofig
+            config = ExptConfigReader.read_raw(workspace_id, unique_id)
             config["name"] = f"{config.get('name', 'experiment')}_copy"
-            with open(config_path, "w") as file:
-                yaml.dump(config, file, sort_keys=False)
 
-            logger.info(f"Updated experiment.yml: {config_path}")
+            # Update & Write cofig
+            ExptConfigWriter.write_raw(workspace_id, unique_id, config)
+
+            logger.info(f"Updated experiment.yml: {workspace_id}/{unique_id}")
             return True
 
         except Exception as e:

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -166,7 +166,7 @@ class Runner:
 
         # Controls locking for simultaneous writing to nwbfile from multiple nodes.
         lock_path = FileLockUtils.get_lockfile_path(save_path)
-        with FileLock(lock_path, timeout=30):
+        with FileLock(lock_path, timeout=120):
             if os.path.exists(save_path):
                 overwrite_nwbfile(save_path, nwbconfig)
             else:

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -5,14 +5,11 @@ import os
 import time
 import traceback
 from dataclasses import asdict
-from datetime import datetime
 from pathlib import Path
 
 from filelock import FileLock
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
-from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
-from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import Rule
 from studio.app.common.core.utils.config_handler import ConfigReader
@@ -22,7 +19,6 @@ from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.utils.pickle_handler import PickleReader, PickleWriter
 from studio.app.common.schemas.workflow import WorkflowPIDFileData
-from studio.app.const import DATE_FORMAT
 from studio.app.dir_path import DIRPATH
 from studio.app.optinist.core.nwb.nwb import NWBDATASET
 from studio.app.optinist.core.nwb.nwb_creater import (
@@ -55,8 +51,6 @@ class Runner:
             for key in list(input_info):
                 if key not in __rule.return_arg.values():
                     input_info.pop(key)
-
-            cls.__set_func_start_timestamp(os.path.dirname(__rule.output))
 
             # output_info
             output_info = cls.__execute_function(
@@ -150,20 +144,6 @@ class Runner:
         pid_data = WorkflowPIDFileData(**pid_data_json)
 
         return pid_data
-
-    @classmethod
-    def __set_func_start_timestamp(cls, output_dirpath):
-        workflow_dirpath = os.path.dirname(output_dirpath)
-        ids = ExptOutputPathIds(output_dirpath)
-
-        expt_config = ExptConfigReader.read(
-            join_filepath([workflow_dirpath, DIRPATH.EXPERIMENT_YML])
-        )
-        expt_config.function[ids.function_id].started_at = datetime.now().strftime(
-            DATE_FORMAT
-        )
-
-        ExptConfigWriter.write_raw(ids.workspace_id, ids.unique_id, asdict(expt_config))
 
     @classmethod
     def __save_func_nwb(cls, save_path, name, nwbfile, output_info):

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -66,6 +66,7 @@ def _snakemake_execute_process(
         logger.error("snakemake_execute failed..")
 
     WorkspaceService.update_experiment_data_usage(workspace_id, unique_id)
+
     smk_logger.clean_up()
 
     return result

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union
 
 import yaml
 from filelock import FileLock
@@ -12,11 +13,20 @@ from studio.app.common.core.utils.filepath_creater import (
 
 class ConfigReader:
     @classmethod
-    def read(cls, filepath):
+    def read(cls, file: Union[str, bytes]):
         config = {}
-        if filepath is not None and os.path.exists(filepath):
-            with open(filepath) as f:
+
+        if file is None:
+            return config
+
+        if isinstance(file, bytes):
+            config = yaml.safe_load(file)
+        elif isinstance(file, str) and os.path.exists(file):
+            with open(file) as f:
                 config = yaml.safe_load(f)
+        else:
+            assert False, f"Invalid file [{file}]"
+
         return config
 
 

--- a/studio/app/common/core/utils/filelock_handler.py
+++ b/studio/app/common/core/utils/filelock_handler.py
@@ -1,0 +1,23 @@
+import hashlib
+import os
+
+from studio.app.dir_path import DIRPATH
+
+
+class FileLockUtils:
+    @classmethod
+    def get_lockfile_path(cls, file_path: str) -> str:
+        """
+        Automatically generate the save path for the lockfile
+          used in the FileLock module.
+        """
+        file_basename = os.path.basename(file_path)
+
+        file_path_hash = hashlib.md5(file_path.encode()).hexdigest()
+        file_path_hash = file_path_hash[:16]
+
+        lockfile_path = os.path.join(
+            DIRPATH.LOCKFILE_DIR, f"{file_path_hash}_{file_basename}.lock"
+        )
+
+        return lockfile_path

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
@@ -13,8 +13,9 @@ from studio.app.common.schemas.workflow import WorkflowConfig
 
 class WorkflowConfigReader:
     @classmethod
-    def read(cls, filepath) -> WorkflowConfig:
-        config = ConfigReader.read(filepath)
+    def read(cls, file: Union[str, bytes]) -> WorkflowConfig:
+        config = ConfigReader.read(file)
+        assert config, f"Invalid config yaml file: [{file}] [{config}]"
 
         return WorkflowConfig(
             nodeDict=cls.read_nodeDict(config["nodeDict"]),

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-import yaml
-
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
     Edge,

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import yaml
 
+from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
     Edge,
     Node,
@@ -15,8 +16,7 @@ from studio.app.common.schemas.workflow import WorkflowConfig
 class WorkflowConfigReader:
     @classmethod
     def read(cls, filepath) -> WorkflowConfig:
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
+        config = ConfigReader.read(filepath)
 
         return WorkflowConfig(
             nodeDict=cls.read_nodeDict(config["nodeDict"]),

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -225,6 +225,12 @@ class NodeResult:
 
         expt_config.function[self.node_id].success = message.status
 
+        # TODO: Set started_at on the node
+        #   At the moment, there is insufficient data to obtain an accurate started_at,
+        #  so set it to None.
+        #   separate modification is required to record running info for each node.
+        expt_config.function[self.node_id].started_at = None
+
         now = datetime.now().strftime(DATE_FORMAT)
         expt_config.function[self.node_id].finished_at = now
         expt_config.function[self.node_id].message = message.message

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -21,7 +21,7 @@ logger = AppLogger.get_logger()
 class WorkspaceService:
     @classmethod
     def _update_exp_data_usage_yaml(cls, workspace_id: str, unique_id: str, data_usage):
-        # Read cofig
+        # Read config
         config = ExptConfigReader.read_raw(workspace_id, unique_id)
         if not config:
             logger.error(f"[{workspace_id}/{unique_id}] does not exist")
@@ -29,7 +29,7 @@ class WorkspaceService:
 
         config["data_usage"] = data_usage
 
-        # Update & Write cofig
+        # Update & Write config
         ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
     @classmethod

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
 
-import yaml
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, delete, update
 
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.file_reader import get_folder_size
@@ -19,20 +20,22 @@ logger = AppLogger.get_logger()
 
 class WorkspaceService:
     @classmethod
-    def _update_exp_data_usage_yaml(cls, exp_filepath, data_usage):
-        if not os.path.isfile(exp_filepath):
-            logger.error(f"'{exp_filepath}' does not exist")
+    def _update_exp_data_usage_yaml(cls, workspace_id: str, unique_id: str, data_usage):
+        # Read cofig
+        config = ExptConfigReader.read_raw(workspace_id, unique_id)
+        if not config:
+            logger.error(f"[{workspace_id}/{unique_id}] does not exist")
             return
 
-        with open(exp_filepath, "r") as f:
-            config = yaml.safe_load(f)
-            config["data_usage"] = data_usage
+        config["data_usage"] = data_usage
 
-        with open(exp_filepath, "w") as f:
-            yaml.dump(config, f, sort_keys=False)
+        # Update & Write cofig
+        ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
     @classmethod
-    def _update_exp_data_usage_db(cls, workspace_id, unique_id, data_usage):
+    def _update_exp_data_usage_db(
+        cls, workspace_id: str, unique_id: str, data_usage: int
+    ):
         with session_scope() as db:
             try:
                 exp = (
@@ -53,22 +56,21 @@ class WorkspaceService:
                 db.add(exp)
 
     @classmethod
-    def update_experiment_data_usage(cls, workspace_id, unique_id):
+    def update_experiment_data_usage(cls, workspace_id: str, unique_id: str):
         workflow_dir = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
         if not os.path.exists(workflow_dir):
             logger.error(f"'{workflow_dir}' does not exist")
             return
 
-        exp_filepath = join_filepath([workflow_dir, DIRPATH.EXPERIMENT_YML])
         data_usage = get_folder_size(workflow_dir)
 
-        cls._update_exp_data_usage_yaml(exp_filepath, data_usage)
+        cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
 
         if not MODE.IS_STANDALONE:
             cls._update_exp_data_usage_db(workspace_id, unique_id, data_usage)
 
     @classmethod
-    def update_workspace_data_usage(cls, db: Session, workspace_id):
+    def update_workspace_data_usage(cls, db: Session, workspace_id: str):
         workspace_dir = join_filepath([DIRPATH.INPUT_DIR, workspace_id])
         if not os.path.exists(workspace_dir):
             logger.error(f"'{workspace_dir}' does not exist")
@@ -83,7 +85,9 @@ class WorkspaceService:
         db.commit()
 
     @classmethod
-    def delete_workspace_experiment(cls, db: Session, workspace_id, unique_id):
+    def delete_workspace_experiment(
+        cls, db: Session, workspace_id: str, unique_id: str
+    ):
         db.execute(
             delete(ExperimentRecord).where(
                 ExperimentRecord.workspace_id == workspace_id,
@@ -93,7 +97,7 @@ class WorkspaceService:
         db.commit()
 
     @classmethod
-    def sync_workspace_experiment(cls, db: Session, workspace_id):
+    def sync_workspace_experiment(cls, db: Session, workspace_id: str):
         folder = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
         if not os.path.exists(folder):
             logger.error(f"'{folder}' does not exist")
@@ -101,14 +105,15 @@ class WorkspaceService:
         exp_records = []
 
         for exp_folder in Path(folder).iterdir():
+            unique_id = exp_folder.name
             data_usage = get_folder_size(exp_folder.as_posix())
-            cls._update_exp_data_usage_yaml(
-                (exp_folder / DIRPATH.EXPERIMENT_YML).as_posix(), data_usage
-            )
+
+            cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
+
             exp_records.append(
                 ExperimentRecord(
                     workspace_id=workspace_id,
-                    uid=exp_folder.name,
+                    uid=unique_id,
                     data_usage=data_usage,
                 )
             )

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -148,9 +148,11 @@ async def apply_filter(
         WorkflowNodeDataFilter(
             workspace_id=workspace_id, unique_id=uid, node_id=node_id
         ).filter_node_data(params)
+
         background_tasks.add_task(
             WorkspaceService.update_experiment_data_usage, workspace_id, uid
         )
+
         return True
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -1,9 +1,15 @@
 import os
+import platform
 from enum import Enum
 
 from dotenv import load_dotenv
 
-_DEFAULT_DIR = "/tmp/studio"
+_TEMP_DIR = (
+    os.environ.get("TEMP", os.environ.get("TMP", "C:\\temp"))
+    if platform.system() == "Windows"
+    else "/tmp"
+)
+_DEFAULT_DIR = f"{_TEMP_DIR}/studio"
 _ENV_DIR = os.environ.get("OPTINIST_DIR")
 
 
@@ -27,6 +33,11 @@ class DIRPATH:
     CONFIG_DIR = f"{STUDIO_DIR}/config"
     if os.path.isfile(f"{CONFIG_DIR}/.env"):
         load_dotenv(f"{CONFIG_DIR}/.env")
+
+    LOCKFILE_DIR = f"{_DEFAULT_DIR}/locks"
+    if not os.path.exists(LOCKFILE_DIR):
+        os.makedirs(LOCKFILE_DIR)
+    assert os.path.exists(LOCKFILE_DIR)
 
     CONDAENV_DIR = (
         f"{os.path.dirname(os.path.dirname(os.path.dirname(__file__)))}/conda"

--- a/studio/app/optinist/core/nwb/nwb_spec_utils.py
+++ b/studio/app/optinist/core/nwb/nwb_spec_utils.py
@@ -5,6 +5,8 @@ from typing import List, Union
 from filelock import FileLock
 from pynwb.spec import NWBGroupSpec, NWBNamespaceBuilder
 
+from studio.app.common.core.utils.filelock_handler import FileLockUtils
+
 NWB_SPEC_FILE_EXPORT_DIR = os.path.join(os.path.dirname(__file__), "specs")
 
 
@@ -29,11 +31,10 @@ def export_spec_files(
         f"{ns_name}.extensions.yaml"  # This path must be specified in basename.
     )
 
-    lock_path = ns_path + ".lock"
-
     # Note:
     # Considering calls from multi-process exclusive processing
     # is performed (using FileLock)
+    lock_path = FileLockUtils.get_lockfile_path(ns_path)
     with FileLock(lock_path, timeout=10):
         flle_update_elapsed_time = (
             (time.time() - os.path.getmtime(ns_path)) if os.path.exists(ns_path) else 0


### PR DESCRIPTION
### Content

Workflowの各Nodeを並列で実行中（snakemake cores>1）に、各Nodeから同時書き込みされ得るファイルへのFileLockに以下の課題があったため、修正した。

#### 課題

- FileLock の利用時、lock fileの出力先が Local File System 以外（NFSなど）の場合、Lockが機能していなかった
  - optinsitでは、docker 版（ volume mount を利用）が該当
  - snakemake cores を増やした場合に、各nodeからのnwb fileの更新処理でconflictが発生するケースがあった
- また、排他制御が必要な対象ファイルが不足していた
  - 対象: experiment.yaml

#### 対策

- FileLockのlock flieの出力先を、各PlatformのLocal File System (/tmp配下)とした
  - https://github.com/arayabrain/barebone-studio/commit/7b0bd7b3ca81a16bfdb6e2c2f6fb14f0a765c264#diff-af185610f23607ec499a6ed1b7c11851ecccac277619fcc9b5a6ec0beb437e8fR9
- yaml系ファイルの出力にも、FileLock を使用するようにした （ConfigWriter.write）
- また そもそも必須ではない、Workflow実行中の experiment.yaml 更新処理を削減した

### Testcase

添付のWorkflowを各Platformで実行し、Workflowが正常に完了することを確認する

- 条件
  - snakemake cores=8
  - suite2p_roi を cores と同数配置

- 実際の設定例
  - workflow.yaml (importしてテスト利用可能)
    - [workflow.yaml.zip](https://github.com/user-attachments/files/20097419/workflow.yaml.zip)
  - workflow image
    - ![image](https://github.com/user-attachments/assets/6bb74d83-2139-4745-a3a2-ce2b87646146)

#### Testcase

  - [x] 1. Native環境でのWorkflow正常動作
    - [x] Mac or Ubuntu
    - [x] Windows
  - [x] 2. Docker環境でのWorkflow正常動作
