### PR TITLE
Refactor yaml handle modules

### DIFF
--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.utils.config_handler import ConfigReader
@@ -8,18 +8,10 @@ from studio.app.dir_path import DIRPATH
 
 
 class ExptConfigReader:
-    @staticmethod
-    def read_raw(workspace_id: str, unique_id: str) -> dict:
-        config = ConfigReader.read(
-            join_filepath(
-                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
-            )
-        )
-        return config
-
     @classmethod
-    def read(cls, filepath) -> ExptConfig:
-        config = ConfigReader.read(filepath)
+    def read(cls, file: Union[str, bytes]) -> ExptConfig:
+        config = ConfigReader.read(file)
+        assert config, f"Invalid config yaml file: [{file}] [{config}]"
 
         return ExptConfig(
             workspace_id=config["workspace_id"],
@@ -34,6 +26,15 @@ class ExptConfigReader:
             snakemake=config.get("snakemake"),
             data_usage=config.get("data_usage"),
         )
+
+    @staticmethod
+    def read_raw(workspace_id: str, unique_id: str) -> dict:
+        config = ConfigReader.read(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+            )
+        )
+        return config
 
     @classmethod
     def read_function(cls, config) -> Dict[str, ExptFunction]:

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -3,10 +3,22 @@ from typing import Dict
 import yaml
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
+from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.workflow.workflow import NodeRunStatus, OutputPath
+from studio.app.dir_path import DIRPATH
 
 
 class ExptConfigReader:
+    @staticmethod
+    def read_raw(workspace_id: str, unique_id: str) -> dict:
+        config = ConfigReader.read(
+            join_filepath(
+                [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+            )
+        )
+        return config
+
     @classmethod
     def read(cls, filepath) -> ExptConfig:
         with open(filepath, "r") as f:

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -21,8 +21,7 @@ class ExptConfigReader:
 
     @classmethod
     def read(cls, filepath) -> ExptConfig:
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
+        config = ConfigReader.read(filepath)
 
         return ExptConfig(
             workspace_id=config["workspace_id"],

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-import yaml
-
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -37,14 +37,6 @@ class ExptConfigWriter:
         self.snakemake = snakemake
         self.builder = ExptConfigBuilder()
 
-    @staticmethod
-    def write_raw(workspace_id: str, unique_id: str, config: dict) -> None:
-        ConfigWriter.write(
-            dirname=join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
-            filename=DIRPATH.EXPERIMENT_YML,
-            config=config,
-        )
-
     def write(self) -> None:
         expt_filepath = join_filepath(
             [
@@ -66,6 +58,14 @@ class ExptConfigWriter:
         # Write EXPERIMENT_YML
         self.write_raw(
             self.workspace_id, self.unique_id, config=asdict(self.builder.build())
+        )
+
+    @staticmethod
+    def write_raw(workspace_id: str, unique_id: str, config: dict) -> None:
+        ConfigWriter.write(
+            dirname=join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
+            filename=DIRPATH.EXPERIMENT_YML,
+            config=config,
         )
 
     def create_config(self) -> ExptConfig:

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -143,11 +143,11 @@ class ExptDataWriter:
         # Note: "r+" option for file-open is not used here
         #   because it requires file pointer control.
 
-        # Read cofig
+        # Read config
         config = ExptConfigReader.read_raw(self.workspace_id, self.unique_id)
         config["name"] = new_name
 
-        # Update & Write cofig
+        # Update & Write config
         ExptConfigWriter.write_raw(self.workspace_id, self.unique_id, config)
 
         config_path = join_filepath(
@@ -341,11 +341,11 @@ class ExptDataWriter:
         logger = AppLogger.get_logger()
 
         try:
-            # Read cofig
+            # Read config
             config = ExptConfigReader.read_raw(workspace_id, unique_id)
             config["name"] = f"{config.get('name', 'experiment')}_copy"
 
-            # Update & Write cofig
+            # Update & Write config
             ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
             logger.info(f"Updated experiment.yml: {workspace_id}/{unique_id}")

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Dict
 
 import numpy as np
-import yaml
 
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.experiment.experiment_builder import ExptConfigBuilder
@@ -138,7 +137,20 @@ class ExptDataWriter:
         return result
 
     def rename(self, new_name: str) -> ExptConfig:
-        filepath = join_filepath(
+        # validate params
+        new_name = "" if new_name is None else new_name  # filter None
+
+        # Note: "r+" option for file-open is not used here
+        #   because it requires file pointer control.
+
+        # Read cofig
+        config = ExptConfigReader.read_raw(self.workspace_id, self.unique_id)
+        config["name"] = new_name
+
+        # Update & Write cofig
+        ExptConfigWriter.write_raw(self.workspace_id, self.unique_id, config)
+
+        config_path = join_filepath(
             [
                 DIRPATH.OUTPUT_DIR,
                 self.workspace_id,
@@ -146,31 +158,7 @@ class ExptDataWriter:
                 DIRPATH.EXPERIMENT_YML,
             ]
         )
-
-        # validate params
-        new_name = "" if new_name is None else new_name  # filter None
-
-        # Note: "r+" option is not used here because it requires file pointer control.
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
-            config["name"] = new_name
-
-        with open(filepath, "w") as f:
-            yaml.dump(config, f, sort_keys=False)
-
-        return ExptConfig(
-            workspace_id=config["workspace_id"],
-            unique_id=config["unique_id"],
-            name=config["name"],
-            started_at=config.get("started_at"),
-            finished_at=config.get("finished_at"),
-            success=config.get("success", WorkflowRunStatus.RUNNING.value),
-            hasNWB=config["hasNWB"],
-            function=ExptConfigReader.read_function(config["function"]),
-            nwb=config.get("nwb"),
-            snakemake=config.get("snakemake"),
-            data_usage=config.get("data_usage"),
-        )
+        return ExptConfigReader.read(config_path)
 
     def copy_data(self, new_unique_id: str) -> bool:
         logger = AppLogger.get_logger()
@@ -188,7 +176,9 @@ class ExptDataWriter:
             shutil.copytree(output_dir, new_output_dir)
 
             # Update experiment configuration and unique IDs
-            if not self.__copy_data_update_experiment_config_name(new_output_dir):
+            if not self.__copy_data_update_experiment_config_name(
+                self.workspace_id, new_unique_id
+            ):
                 logger.error("Failed to update experiment.yml after copying.")
                 return False
 
@@ -345,23 +335,20 @@ class ExptDataWriter:
         else:
             return obj
 
-    def __copy_data_update_experiment_config_name(self, output_dir: str) -> bool:
+    def __copy_data_update_experiment_config_name(
+        self, workspace_id: str, unique_id: str
+    ) -> bool:
         logger = AppLogger.get_logger()
-        config_path = join_filepath([output_dir, DIRPATH.EXPERIMENT_YML])
 
         try:
-            with open(config_path, "r") as file:
-                config = yaml.safe_load(file)
-
-            if not config:
-                logger.error(f"Invalid YAML at {config_path}")
-                return False
-
+            # Read cofig
+            config = ExptConfigReader.read_raw(workspace_id, unique_id)
             config["name"] = f"{config.get('name', 'experiment')}_copy"
-            with open(config_path, "w") as file:
-                yaml.dump(config, file, sort_keys=False)
 
-            logger.info(f"Updated experiment.yml: {config_path}")
+            # Update & Write cofig
+            ExptConfigWriter.write_raw(workspace_id, unique_id, config)
+
+            logger.info(f"Updated experiment.yml: {workspace_id}/{unique_id}")
             return True
 
         except Exception as e:

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -66,6 +66,7 @@ def _snakemake_execute_process(
         logger.error("snakemake_execute failed..")
 
     WorkspaceService.update_experiment_data_usage(workspace_id, unique_id)
+
     smk_logger.clean_up()
 
     return result

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union
 
 import yaml
 from filelock import FileLock
@@ -12,11 +13,20 @@ from studio.app.common.core.utils.filepath_creater import (
 
 class ConfigReader:
     @classmethod
-    def read(cls, filepath):
+    def read(cls, file: Union[str, bytes]):
         config = {}
-        if filepath is not None and os.path.exists(filepath):
-            with open(filepath) as f:
+
+        if file is None:
+            return config
+
+        if isinstance(file, bytes):
+            config = yaml.safe_load(file)
+        elif isinstance(file, str) and os.path.exists(file):
+            with open(file) as f:
                 config = yaml.safe_load(f)
+        else:
+            assert False, f"Invalid file [{file}]"
+
         return config
 
 

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
@@ -13,8 +13,9 @@ from studio.app.common.schemas.workflow import WorkflowConfig
 
 class WorkflowConfigReader:
     @classmethod
-    def read(cls, filepath) -> WorkflowConfig:
-        config = ConfigReader.read(filepath)
+    def read(cls, file: Union[str, bytes]) -> WorkflowConfig:
+        config = ConfigReader.read(file)
+        assert config, f"Invalid config yaml file: [{file}] [{config}]"
 
         return WorkflowConfig(
             nodeDict=cls.read_nodeDict(config["nodeDict"]),

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-import yaml
-
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
     Edge,

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import yaml
 
+from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
     Edge,
     Node,
@@ -15,8 +16,7 @@ from studio.app.common.schemas.workflow import WorkflowConfig
 class WorkflowConfigReader:
     @classmethod
     def read(cls, filepath) -> WorkflowConfig:
-        with open(filepath, "r") as f:
-            config = yaml.safe_load(f)
+        config = ConfigReader.read(filepath)
 
         return WorkflowConfig(
             nodeDict=cls.read_nodeDict(config["nodeDict"]),

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -21,7 +21,7 @@ logger = AppLogger.get_logger()
 class WorkspaceService:
     @classmethod
     def _update_exp_data_usage_yaml(cls, workspace_id: str, unique_id: str, data_usage):
-        # Read cofig
+        # Read config
         config = ExptConfigReader.read_raw(workspace_id, unique_id)
         if not config:
             logger.error(f"[{workspace_id}/{unique_id}] does not exist")
@@ -29,7 +29,7 @@ class WorkspaceService:
 
         config["data_usage"] = data_usage
 
-        # Update & Write cofig
+        # Update & Write config
         ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
     @classmethod

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
 
-import yaml
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, delete, update
 
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.file_reader import get_folder_size
@@ -19,20 +20,22 @@ logger = AppLogger.get_logger()
 
 class WorkspaceService:
     @classmethod
-    def _update_exp_data_usage_yaml(cls, exp_filepath, data_usage):
-        if not os.path.isfile(exp_filepath):
-            logger.error(f"'{exp_filepath}' does not exist")
+    def _update_exp_data_usage_yaml(cls, workspace_id: str, unique_id: str, data_usage):
+        # Read cofig
+        config = ExptConfigReader.read_raw(workspace_id, unique_id)
+        if not config:
+            logger.error(f"[{workspace_id}/{unique_id}] does not exist")
             return
 
-        with open(exp_filepath, "r") as f:
-            config = yaml.safe_load(f)
-            config["data_usage"] = data_usage
+        config["data_usage"] = data_usage
 
-        with open(exp_filepath, "w") as f:
-            yaml.dump(config, f, sort_keys=False)
+        # Update & Write cofig
+        ExptConfigWriter.write_raw(workspace_id, unique_id, config)
 
     @classmethod
-    def _update_exp_data_usage_db(cls, workspace_id, unique_id, data_usage):
+    def _update_exp_data_usage_db(
+        cls, workspace_id: str, unique_id: str, data_usage: int
+    ):
         with session_scope() as db:
             try:
                 exp = (
@@ -53,22 +56,21 @@ class WorkspaceService:
                 db.add(exp)
 
     @classmethod
-    def update_experiment_data_usage(cls, workspace_id, unique_id):
+    def update_experiment_data_usage(cls, workspace_id: str, unique_id: str):
         workflow_dir = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
         if not os.path.exists(workflow_dir):
             logger.error(f"'{workflow_dir}' does not exist")
             return
 
-        exp_filepath = join_filepath([workflow_dir, DIRPATH.EXPERIMENT_YML])
         data_usage = get_folder_size(workflow_dir)
 
-        cls._update_exp_data_usage_yaml(exp_filepath, data_usage)
+        cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
 
         if not MODE.IS_STANDALONE:
             cls._update_exp_data_usage_db(workspace_id, unique_id, data_usage)
 
     @classmethod
-    def update_workspace_data_usage(cls, db: Session, workspace_id):
+    def update_workspace_data_usage(cls, db: Session, workspace_id: str):
         workspace_dir = join_filepath([DIRPATH.INPUT_DIR, workspace_id])
         if not os.path.exists(workspace_dir):
             logger.error(f"'{workspace_dir}' does not exist")
@@ -83,7 +85,9 @@ class WorkspaceService:
         db.commit()
 
     @classmethod
-    def delete_workspace_experiment(cls, db: Session, workspace_id, unique_id):
+    def delete_workspace_experiment(
+        cls, db: Session, workspace_id: str, unique_id: str
+    ):
         db.execute(
             delete(ExperimentRecord).where(
                 ExperimentRecord.workspace_id == workspace_id,
@@ -93,7 +97,7 @@ class WorkspaceService:
         db.commit()
 
     @classmethod
-    def sync_workspace_experiment(cls, db: Session, workspace_id):
+    def sync_workspace_experiment(cls, db: Session, workspace_id: str):
         folder = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
         if not os.path.exists(folder):
             logger.error(f"'{folder}' does not exist")
@@ -101,14 +105,15 @@ class WorkspaceService:
         exp_records = []
 
         for exp_folder in Path(folder).iterdir():
+            unique_id = exp_folder.name
             data_usage = get_folder_size(exp_folder.as_posix())
-            cls._update_exp_data_usage_yaml(
-                (exp_folder / DIRPATH.EXPERIMENT_YML).as_posix(), data_usage
-            )
+
+            cls._update_exp_data_usage_yaml(workspace_id, unique_id, data_usage)
+
             exp_records.append(
                 ExperimentRecord(
                     workspace_id=workspace_id,
-                    uid=exp_folder.name,
+                    uid=unique_id,
                     data_usage=data_usage,
                 )
             )

--- a/studio/app/common/routers/run.py
+++ b/studio/app/common/routers/run.py
@@ -148,9 +148,11 @@ async def apply_filter(
         WorkflowNodeDataFilter(
             workspace_id=workspace_id, unique_id=uid, node_id=node_id
         ).filter_node_data(params)
+
         background_tasks.add_task(
             WorkspaceService.update_experiment_data_usage, workspace_id, uid
         )
+
         return True
     except Exception as e:
         logger.error(e, exc_info=True)


### PR DESCRIPTION
### Content

#795 で、Workflow Nodes の並列処理（snakemake cores>1) に関する、ファイル更新の排他制御を強化したが、
それに伴い、すべての yaml config ファイルへのアクセス箇所を、ConfigReader/ConfigWriter を使用する形式に修正した。

### Testcase

#### Testcase 1)

#795 と同等のテストケース：特定Workflowの実行

- workflow image
  - ![image](https://github.com/user-attachments/assets/6bb74d83-2139-4745-a3a2-ce2b87646146)

- [x] 1. Native環境でのWorkflow正常動作
  - [x] Mac or Ubuntu
  - [x] Windows
- [x] 2. Docker環境でのWorkflow正常動作

#### Testcase 2)

個別の修正箇所のテスト

- [x] 1. workflow.yaml の import に成功する
- [x] 2. Recordのrenameに成功する
- [x] 3. Recordのcopyに成功する
- [x] 4. Workflow実行後、RecordのData Sizeが適正値で更新されている
