### PR TITLE
Feature/improve caiman node concurrency

### DIFF
--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -73,7 +73,7 @@ def get_roi(A, roi_thr, thr_method, swap_dim, dims):
     return ims
 
 
-def util_get_memmap(images: np.ndarray, file_path: str):
+def util_get_image_memmap(function_id: str, images: np.ndarray, file_path: str):
     """
     convert np.ndarray to mmap
     """
@@ -86,8 +86,9 @@ def util_get_memmap(images: np.ndarray, file_path: str):
     shape_mov = (np.prod(dims), T)
 
     dir_path = join_filepath(file_path.split("/")[:-1])
-    basename = file_path.split("/")[-1]
-    fname_tot = memmap_frames_filename(basename, dims, T, order)
+    file_basename = file_path.split("/")[-1]
+    mmap_basename = f"{file_basename}.{function_id}"
+    fname_tot = memmap_frames_filename(mmap_basename, dims, T, order)
     mmap_path = join_filepath([dir_path, fname_tot])
 
     mmap_images = np.memmap(
@@ -165,7 +166,7 @@ def caiman_cnmf(
         file_path = file_path[0]
 
     images = images.data
-    mmap_images, dims, mmap_path = util_get_memmap(images, file_path)
+    mmap_images, dims, mmap_path = util_get_image_memmap(function_id, images, file_path)
 
     del images
     gc.collect()

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -11,7 +11,7 @@ from studio.app.optinist.dataclass import EditRoiData, FluoData, IscellData, Roi
 from studio.app.optinist.wrappers.caiman.cnmf import (
     get_roi,
     util_download_model_files,
-    util_get_memmap,
+    util_get_image_memmap,
 )
 from studio.app.optinist.wrappers.optinist.utils import recursive_flatten_params
 
@@ -93,7 +93,9 @@ def caiman_cnmf_multisession(
     templates = []
     for split_image_path in split_image_paths:
         split_image = imageio.volread(split_image_path)
-        split_image_mmap, _, _ = util_get_memmap(split_image, split_image_path)
+        split_image_mmap, _, _ = util_get_image_memmap(
+            function_id, split_image, split_image_path
+        )
         del split_image
         gc.collect()
 
@@ -204,7 +206,7 @@ def caiman_cnmf_multisession(
     if isinstance(file_path, list):
         file_path = file_path[0]
     images = images.data
-    mmap_images, dims, _ = util_get_memmap(images.data, file_path)
+    mmap_images, dims, _ = util_get_image_memmap(function_id, images.data, file_path)
 
     Cn = local_correlations(mmap_images.transpose(1, 2, 0))
     Cn[np.isnan(Cn)] = 0


### PR DESCRIPTION
### Content

Workflowで各caiman cnmf nodeを並列で実行中（snakemake cores>1）に、mmap fileへのアクセスでconflictする課題があったため、修正した。

#### 課題

- caiman cnmf/cnmfe/cnmf_multisession で利用される mmap ファイル名が、各node type間で、重複しうる命名ルールとなっていた。
  - そのため、Workflow内にnodeを複数配置した場合、mmapファイルのアクセスでconflict（例外）が発生するケースがあった。
- また、mmap fileはtemporary fileであるが、処理後も残存しており、容量を消費していた。（file sizeは input image とほぼ同サイズのため、容量を消費する）

#### 対策

- caiman cnmf/cnmfe/cnmf_multisession で利用される mmap ファイル名は、重複させないルールとした。（ファイル名に node_id を追加）
- また caiman mc/cnmf/cnmfe/cnmf_multisession の処理完了後、mmap ファイルを cleanup するようにした。

### Testcase

添付のWorkflowを各Platformで実行し、Workflowが正常に完了することを確認する

- 条件
  - snakemake cores=8
  - 以下のnodeを配置
    1. caiman_cmnf を cores と同数配置
    2. cnmf_multisession を cores と同数配置

- 実際の設定例
  - workflow.yaml (importしてテスト利用可能)
    - [workflow.yaml.zip](https://github.com/user-attachments/files/20154754/workflow.yaml.zip)
  - workflow image
    - ![image](https://github.com/user-attachments/assets/78530b87-2841-41b3-a4d3-0ac8dcdcf952)


#### Testcase

  - [x] 1. Native環境でのWorkflow正常動作
    - [x] Mac or Ubuntu
    - [x] Windows
  - [x] 2. Docker環境でのWorkflow正常動作
