### PR TITLE
FIX Workspace Invalid API to loop.

### DIFF
--- a/frontend/src/pages/Workspace/Workspace.tsx
+++ b/frontend/src/pages/Workspace/Workspace.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useEffect } from "react"
+import { FC, ReactNode, useEffect, useState } from "react"
 import { useSelector, useDispatch } from "react-redux"
 
 import { Box } from "@mui/material"
@@ -23,12 +23,19 @@ const Workspace: FC = () => {
 
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const experiments = useSelector(selectExperiments)
+  const [hasFetched, setHasFetched] = useState(false)
 
   useEffect(() => {
-    if (!activeTab && workspaceId && experiments?.status !== "fulfilled") {
+    if (
+      !hasFetched &&
+      !activeTab &&
+      workspaceId &&
+      experiments?.status !== "fulfilled"
+    ) {
       dispatch(getExperiments())
+      setHasFetched(true)
     }
-  }, [dispatch, activeTab, workspaceId, experiments?.status])
+  }, [dispatch, activeTab, workspaceId, experiments?.status, hasFetched])
 
   return (
     <RootDiv>


### PR DESCRIPTION
### Content
When backend shut down while running workflow. Get workspace api if in infinite loop.

### References
https://github.com/arayabrain/barebone-studio/issues/800

### Testcase

1. Run Tutorial 1. While running shutdown your backend system and check the network log to see the api access.
2. Test if Visualize state reset when changing workspace
　・You can test this by running tutorial 1 and wait to finish
　・Access Visualize and create any plot you want
　・Change Workspace and access Visualize Screen

### Others
Tested in

- [x] Mac Native
- [x] Mac Docker
