### PR TITLE
Update nwb saving style of roi_list to dict, for consistency with other nwb savin

### DIFF
--- a/studio/app/optinist/core/edit_ROI/wrappers/caiman_edit_roi/utils.py
+++ b/studio/app/optinist/core/edit_ROI/wrappers/caiman_edit_roi/utils.py
@@ -21,7 +21,7 @@ def set_nwbfile(edit_roi_data: EditRoiData, iscell, function_id, fluorescence=No
             kargs["image_mask"] = edit_roi_data.im[i, :]
             roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     nwbfile[NWBDATASET.COLUMN] = {
         function_id: {

--- a/studio/app/optinist/core/edit_ROI/wrappers/lccd_edit_roi/utils.py
+++ b/studio/app/optinist/core/edit_ROI/wrappers/lccd_edit_roi/utils.py
@@ -22,7 +22,7 @@ def set_nwbfile(edit_roi_data: EditRoiData, iscell, function_id, fluorescence=No
             kargs["image_mask"] = edit_roi_data.im[i, :]
             roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     nwbfile[NWBDATASET.FLUORESCENCE] = {
         function_id: {

--- a/studio/app/optinist/core/edit_ROI/wrappers/suite2p_edit_roi/utils.py
+++ b/studio/app/optinist/core/edit_ROI/wrappers/suite2p_edit_roi/utils.py
@@ -144,7 +144,7 @@ def set_nwbfile(ops, iscell, edit_roi_data: EditRoiData, function_id):
             roi_list.append(kargs)
     nwbfile = {}
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     # iscellを追加
     nwbfile[NWBDATASET.COLUMN] = {

--- a/studio/app/optinist/core/edit_ROI/wrappers/vacant_roi_edit_roi/utils.py
+++ b/studio/app/optinist/core/edit_ROI/wrappers/vacant_roi_edit_roi/utils.py
@@ -22,7 +22,7 @@ def set_nwbfile(edit_roi_data: EditRoiData, iscell, function_id, fluorescence=No
             kargs["image_mask"] = edit_roi_data.im[i, :]
             roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     nwbfile[NWBDATASET.FLUORESCENCE] = {
         function_id: {

--- a/studio/app/optinist/core/nwb/nwb_creater.py
+++ b/studio/app/optinist/core/nwb/nwb_creater.py
@@ -426,7 +426,7 @@ def set_nwbconfig(nwbfile, config):
     if NWBDATASET.ROI in config:
         for function_key in config[NWBDATASET.ROI]:
             nwbfile = NWBCreater.roi(
-                nwbfile, function_key, config[NWBDATASET.ROI][function_key]
+                nwbfile, function_key, config[NWBDATASET.ROI][function_key]["roi_list"]
             )
 
     if NWBDATASET.COLUMN in config:

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -314,7 +314,7 @@ def caiman_cnmf(
                 kargs["rejected"] = i in rejected_list
             roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
     nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": im}}
 
     # Add iscell to NWB

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -178,7 +178,7 @@ def caiman_cnmf_multisession(
         kargs["image_mask"] = spatial_filtered.T[i].T.toarray().reshape(dims)
         roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
     nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": cell_ims}}
 
     # iscellを追加

--- a/studio/app/optinist/wrappers/custom/custom_node.py
+++ b/studio/app/optinist/wrappers/custom/custom_node.py
@@ -100,7 +100,7 @@ def my_function(
     # Add ROIs if your analysis creates them
     roi_list = [{"accepted": i} for i in range(1, 5)]  # List of accepted ROIs
     roi_list.extend({"rejected": i} for i in range(6, 11))  # And rejected ROIs
-    nwb_output[NWBDATASET.ROI] = {function_id: roi_list}
+    nwb_output[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     # Example of adding processing results
     nwb_output[NWBDATASET.POSTPROCESS] = {

--- a/studio/app/optinist/wrappers/lccd/lccd_detection.py
+++ b/studio/app/optinist/wrappers/lccd/lccd_detection.py
@@ -80,7 +80,7 @@ def lccd_detect(
     roi_list = [{"image_mask": roi[:, i].reshape(D.shape[:2])} for i in range(num_cell)]
 
     nwbfile = {}
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
     nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": im}}
 
     nwbfile[NWBDATASET.COLUMN] = {

--- a/studio/app/optinist/wrappers/optinist/visualize_utils/vacant_roi.py
+++ b/studio/app/optinist/wrappers/optinist/visualize_utils/vacant_roi.py
@@ -40,7 +40,7 @@ def vacant_roi(
     roi_list = [{"image_mask": roi[:, i].reshape(D.shape[:2])} for i in range(num_cell)]
 
     nwbfile = {}
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
     nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": im}}
 
     nwbfile[NWBDATASET.COLUMN] = {

--- a/studio/app/optinist/wrappers/suite2p/roi.py
+++ b/studio/app/optinist/wrappers/suite2p/roi.py
@@ -109,7 +109,7 @@ def suite2p_roi(
 
     # Prepare NWB output
     nwbfile = {}
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
     nwbfile[NWBDATASET.POSTPROCESS] = {function_id: {"all_roi_img": im}}
     nwbfile[NWBDATASET.COLUMN] = {
         function_id: {

--- a/studio/app/optinist/wrappers/suite2p/spike_deconv.py
+++ b/studio/app/optinist/wrappers/suite2p/spike_deconv.py
@@ -52,7 +52,7 @@ def suite2p_spike_deconv(
         ).T
         roi_list.append(kargs)
 
-    nwbfile[NWBDATASET.ROI] = {function_id: roi_list}
+    nwbfile[NWBDATASET.ROI] = {function_id: {"roi_list": roi_list}}
 
     # Fluorenceを追加
     nwbfile[NWBDATASET.FLUORESCENCE] = {


### PR DESCRIPTION
Update nwb saving style of roi_list to dict, for consistency with other nwb saving styles

### Content
Previously all NWB saving was done in dict format, except for roi_list, which was saved directly as a list. This could cause errors when using nwb_merge, which expects dict format. 
This updates to a list, and then updates nwb_creater to read the dict so that the output in the nwb file is the same. 

### Testcase
#### Tutorial 1
- [x] Check NWB file before and after change 
- [x] Edit ROI
- [x] Check NWB after Edit ROI
#### Tutorial 2
- [x] Check NWB file before and after change 
- [x] Edit ROI
- [x] Check NWB after Edit ROI
#### Other
- [x] Vacant ROI
#### Batch
Tests also performed on batch on optinist-for-server
- [x] https://github.com/arayabrain/optinist-for-server/pull/434


#### Evidence
<img width="1079" alt="Screenshot 2025-05-20 at 10 26 52" src="https://github.com/user-attachments/assets/43e274fa-f331-4436-8128-4fa4a986dcdf" />
