### PR TITLE
CCA param added to wrong yaml section, caused error

### DIFF
--- a/studio/app/optinist/wrappers/optinist/dimension_reduction/cca.py
+++ b/studio/app/optinist/wrappers/optinist/dimension_reduction/cca.py
@@ -49,7 +49,7 @@ def CCA(
         X = X[:, ind]
 
     # Handle target_index as either a list, slice notation, or single index
-    target_idx = params["target_index"]
+    target_idx = IOparams["target_index"]
     if isinstance(target_idx, str):
         target_idx = target_idx.strip("[] ")
         if ":" in target_idx:

--- a/studio/app/optinist/wrappers/optinist/dimension_reduction/params/cca.yaml
+++ b/studio/app/optinist/wrappers/optinist/dimension_reduction/params/cca.yaml
@@ -1,4 +1,5 @@
 I/O:
+  target_index: [0, 1]
   transpose_x: True
   transpose_y: False
   standard_x_mean: True
@@ -7,7 +8,6 @@ I/O:
   standard_y_std: True
 
 CCA:
-  target_index: [0, 1]
   n_components: 2
   scale: True
   max_iter: 500


### PR DESCRIPTION
### Error message

>     cca = CCA(**params["CCA"])
> TypeError: __init__() got an unexpected keyword argument 'target_index'

### Error cause:
Adding target_index to CCA instead of "I/O" in yaml. The target_index was then read by CCA and caused an error. 

### Test case
Workflow containing CCA (use tutorial1 and change ETA for CCA)