### PR TITLE
Copy Record Implemented into Database Copy

### DIFF
--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -10,7 +10,6 @@ from studio.app.common.core.snakemake.smk import SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
 from studio.app.common.core.utils.filepath_creater import get_pickle_file, join_filepath
 from studio.app.common.core.workflow.workflow import Edge, Node
-from studio.app.common.core.workspace.workspace_services import WorkspaceService
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -33,6 +32,8 @@ def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
 def _snakemake_execute_process(
     workspace_id: str, unique_id: str, params: SmkParam
 ) -> bool:
+    from studio.app.common.core.workspace.workspace_services import WorkspaceService
+
     smk_logger = SmkStatusLogger(workspace_id, unique_id)
     smk_workdir = join_filepath(
         [

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -207,8 +207,6 @@ class WorkspaceService:
             logger.error(
                 f"Experiment {unique_id} not found in workspace {workspace_id}"
             )
-            if auto_commit:
-                db.rollback()
 
     @classmethod
     def sync_workspace_experiment(cls, db: Session, workspace_id: str):

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -203,7 +203,7 @@ class WorkspaceService:
             if auto_commit:
                 db.commit()
         except NoResultFound:
-            # If it failes roll back the transaction
+            # If it fails roll back the transaction
             logger.error(
                 f"Experiment {unique_id} not found in workspace {workspace_id}"
             )

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -129,6 +129,38 @@ class WorkspaceService:
             db.commit()
 
     @classmethod
+    def copy_workspace_experiment(
+        cls,
+        db: Session,
+        workspace_id: int,
+        unique_id: str,
+        new_unique_id: str,
+        auto_commit: bool = False,
+    ):
+        # Use ORM to fetch the original experiment record
+        exp = (
+            db.query(ExperimentRecord)
+            .filter(
+                ExperimentRecord.workspace_id == workspace_id,
+                ExperimentRecord.uid == unique_id,
+            )
+            .one()
+        )
+
+        # Create a new experiment record instance
+        new_exp = ExperimentRecord(
+            workspace_id=workspace_id,
+            uid=new_unique_id,
+            data_usage=exp.data_usage,
+        )
+
+        # Add and optionally commit
+        db.add(new_exp)
+
+        if auto_commit:
+            db.commit()
+
+    @classmethod
     def sync_workspace_experiment(cls, db: Session, workspace_id: str):
         folder = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
         if not os.path.exists(folder):

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -15,9 +15,11 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.file_reader import get_folder_size
 from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.common.core.workflow.workflow_runner import WorkflowRunner
 from studio.app.common.db.database import session_scope
 from studio.app.common.models.experiment import ExperimentRecord
 from studio.app.common.models.workspace import Workspace
+from studio.app.common.schemas.experiment import CopyItem
 from studio.app.dir_path import DIRPATH
 
 logger = AppLogger.get_logger()
@@ -130,35 +132,83 @@ class WorkspaceService:
 
     @classmethod
     def copy_workspace_experiment(
+        cls, db: Session, workspace_id: int, copyItem: CopyItem
+    ):
+        created_unique_ids = []
+        try:
+            for unique_id in copyItem.uidList:
+                new_unique_id = WorkflowRunner.create_workflow_unique_id()
+                ExptDataWriter(
+                    workspace_id,
+                    unique_id,
+                ).copy_data(new_unique_id)
+
+                if cls.is_data_usage_available():
+                    cls._copy_workspace_experiment_db(
+                        db,
+                        workspace_id,
+                        unique_id,
+                        new_unique_id,
+                    )
+                    db.commit()
+
+                created_unique_ids.append(new_unique_id)
+                logger.info(f"Copied experiment {unique_id} to {new_unique_id}")
+            return True
+        except Exception as e:
+            if cls.is_data_usage_available():
+                db.rollback()
+            logger.error(e, exc_info=True)
+
+            # Clean up partially created data
+            for created_unique_id in created_unique_ids:
+                try:
+                    ExptDataWriter(
+                        workspace_id,
+                        created_unique_id,
+                    ).delete_data()
+                    logger.info(f"Cleaned up data for unique_id: {created_unique_id}")
+                except Exception as cleanup_error:
+                    logger.error(cleanup_error, exc_info=True)
+                    logger.error(
+                        f"Failed to clean up data for unique_id: {created_unique_id}",
+                        exc_info=True,
+                    )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to copy record. created files have been removed.",
+            )
+
+    @classmethod
+    def _copy_workspace_experiment_db(
         cls,
         db: Session,
-        workspace_id: int,
+        workspace_id: str,
         unique_id: str,
         new_unique_id: str,
         auto_commit: bool = False,
     ):
-        # Use ORM to fetch the original experiment record
-        exp = (
-            db.query(ExperimentRecord)
-            .filter(
-                ExperimentRecord.workspace_id == workspace_id,
-                ExperimentRecord.uid == unique_id,
+        try:
+            exp = (
+                db.query(ExperimentRecord)
+                .filter(
+                    ExperimentRecord.workspace_id == workspace_id,
+                    ExperimentRecord.uid == unique_id,
+                )
+                .one()
             )
-            .one()
-        )
-
-        # Create a new experiment record instance
-        new_exp = ExperimentRecord(
-            workspace_id=workspace_id,
-            uid=new_unique_id,
-            data_usage=exp.data_usage,
-        )
-
-        # Add and optionally commit
-        db.add(new_exp)
-
-        if auto_commit:
-            db.commit()
+            new_exp = ExperimentRecord(
+                workspace_id=workspace_id,
+                uid=new_unique_id,
+                data_usage=exp.data_usage,
+            )
+            db.add(new_exp)
+            if auto_commit:
+                db.commit()
+        except NoResultFound:
+            logger.error(
+                f"Experiment {unique_id} not found in workspace {workspace_id}"
+            )
 
     @classmethod
     def sync_workspace_experiment(cls, db: Session, workspace_id: str):


### PR DESCRIPTION
### Content
In OpTiniSt there is a copy feature for records. But it wasn't copying into database when multi-user mode is activated.
Therefor, I enhanced it to create a record for copy records too. 

### References
https://github.com/arayabrain/barebone-studio/issues/808

### Testcase

- [x] multiuser mode
  - [x] Copy Workflow. Check if its copied into storage (output directory) and database (mysql).
  - [x] Data Usage for workspace and account is correct after copying.
  - [x] If copy fails it will rollback and delete the created files.
  - [x] copied workflow can be run.
  - [x] log shows fails if it fails
  - [x] log shows when it pass/success
- [x] standalone mode
  - [x] Copy Workflow. Check if its copied to storage
  - [x] If copy fails. created copy data halfway will be deleted.
  - [x] Multiple record copy
- Platforms
  - [x] Mac Native
  - [x] Docker

