### PR TITLE
Fix Visualize state not resetting

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -407,6 +407,7 @@ const Workspaces = () => {
   }
 
   const handleNavRecords = (id: number) => {
+    dispatch(resetVisualizeLayout())
     navigate(`/console/workspaces/${id}`, { state: { tab: 2 } })
   }
 


### PR DESCRIPTION
### Content
When I access other workspace by clicking "Records" button. Visualize state is not reset.
Reason for this is the function to reset Visualize is not being called when "Record" button is clicked.

### References
The same implementation before -> https://github.com/arayabrain/barebone-studio/pull/668

### Testcase

- Create Workflow 1 and Workflow 2.
- Open Workflow 1. Run any workflow and create any plot with Workflow 1
- Return to Workspaces Page and Open Workflow 2 by clicking "Record"
- Access Visualize. There should be no Visualize state showing
