### PR TITLE
Improved node input data construction process

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -219,7 +219,8 @@ class Runner:
 
     @classmethod
     def __change_dict_key_exist(cls, input_info, rule_config: Rule):
-        for return_name, arg_name in rule_config.return_arg.items():
+        for return_arg_key, arg_name in rule_config.return_arg.items():
+            (return_name, _) = return_arg_key.split(":")
             if return_name in input_info:
                 input_info[arg_name] = input_info.pop(return_name)
 

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -12,6 +12,7 @@ from filelock import FileLock
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import Rule
+from studio.app.common.core.snakemake.snakemake_rule import SmkRule
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.file_reader import JsonReader
 from studio.app.common.core.utils.filelock_handler import FileLockUtils
@@ -220,7 +221,7 @@ class Runner:
     @classmethod
     def __change_dict_key_exist(cls, input_info, rule_config: Rule):
         for return_arg_key, arg_name in rule_config.return_arg.items():
-            (return_name, _) = return_arg_key.split(":")
+            return_name = return_arg_key.split(SmkRule.RETURN_ARG_KEY_DELIMITER)[0]
             if return_name in input_info:
                 input_info[arg_name] = input_info.pop(return_name)
 

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -9,6 +9,8 @@ from studio.app.const import FILETYPE
 
 
 class SmkRule:
+    RETURN_ARG_KEY_DELIMITER = ":"
+
     def __init__(
         self,
         workspace_id: str,
@@ -89,9 +91,9 @@ class SmkRule:
                     algo_input.append(input_file)
 
                 # Register input information from the source node
-                return_arg_key = (
-                    f"{return_name}:{sourceNode.id}"  # Generate a unique key
-                )
+                return_arg_key = __class__.RETURN_ARG_KEY_DELIMITER.join(
+                    return_name, sourceNode.id
+                )  # Generate a unique key
                 return_arg_names[return_arg_key] = arg_name
 
         params = get_typecheck_params(self._node.data.param, self._node.data.label)

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -92,7 +92,7 @@ class SmkRule:
 
                 # Register input information from the source node
                 return_arg_key = __class__.RETURN_ARG_KEY_DELIMITER.join(
-                    return_name, sourceNode.id
+                    [return_name, sourceNode.id]
                 )  # Generate a unique key
                 return_arg_names[return_arg_key] = arg_name
 

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -88,7 +88,11 @@ class SmkRule:
                 if input_file not in algo_input:
                     algo_input.append(input_file)
 
-                return_arg_names[return_name] = arg_name
+                # Register input information from the source node
+                return_arg_key = (
+                    f"{return_name}:{sourceNode.id}"  # Generate a unique key
+                )
+                return_arg_names[return_arg_key] = arg_name
 
         params = get_typecheck_params(self._node.data.param, self._node.data.label)
         algo_output = get_pickle_file(

--- a/studio/tests/app/common/core/snakemake/test_snakemake_setfile.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_setfile.py
@@ -5,7 +5,7 @@ from studio.app.const import FILETYPE
 workspace_id = "default"
 unique_id = "smk_test"
 
-node = Node(
+node_input = Node(
     id="input_0",
     type="type",
     data=NodeData(
@@ -23,7 +23,23 @@ node = Node(
     style={},
 )
 
-nodeDict = {"node1": node}
+node_algo = Node(
+    id="algo_0",
+    type="type",
+    data=NodeData(
+        label="label",
+        param={},
+        path="path",
+        type="type",
+    ),
+    position=NodePosition(
+        x=0,
+        y=0,
+    ),
+    style={},
+)
+
+nodeDict = {node_input.id: node_input, node_algo.id: node_algo}
 
 edgeDict = {
     "edge1": Edge(
@@ -32,8 +48,8 @@ edgeDict = {
         animated=False,
         source="input_0",
         sourceHandle="input_0--image--ImageData",
-        target="suite2p",
-        targetHandle="suite2p--image--ImageData",
+        target="algo_0",
+        targetHandle="algo_0--image--ImageData",
         style={},
     ),
 }
@@ -43,7 +59,7 @@ def test_SmkSetfile_image():
     rule = SmkRule(
         workspace_id=workspace_id,
         unique_id=unique_id,
-        node=node,
+        node=node_input,
         edgeDict=edgeDict,
         nwbfile={},
     ).image()
@@ -55,7 +71,7 @@ def test_SmkSetfile_csv():
     rule = SmkRule(
         workspace_id=workspace_id,
         unique_id=unique_id,
-        node=node,
+        node=node_input,
         edgeDict=edgeDict,
         nwbfile={},
     ).csv()
@@ -66,7 +82,7 @@ def test_SmkSetfile_hdf5():
     rule = SmkRule(
         workspace_id=workspace_id,
         unique_id=unique_id,
-        node=node,
+        node=node_input,
         edgeDict=edgeDict,
         nwbfile={},
     ).hdf5()
@@ -78,9 +94,9 @@ def test_SmkSetfile_algo():
     rule = SmkRule(
         workspace_id=workspace_id,
         unique_id=unique_id,
-        node=node,
+        node=node_algo,
         edgeDict=edgeDict,
     ).algo(nodeDict=nodeDict)
 
-    assert rule.type == node.data.label
-    assert rule.path == node.data.path
+    assert rule.type == node_input.data.label
+    assert rule.path == node_input.data.path


### PR DESCRIPTION
### Content

- Problem
  - There was a potential problem where the destination node could not receive all input params if the input param keys sent from multiple source nodes had the same name.

- Countermeasure
  - Adjusted so that the input param keys sent from the source node are not duplicated. Specifically, the key name now includes the source node ID (which is guaranteed to be unique).

### Testcase

- [x] Tutorial Workflow(1-3) works normally
- [x] Merge with the following PR and confirm that the workflow works properly.
  - #809  
