### PR TITLE
Refactor config handle modules

### DIFF
--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -23,14 +23,14 @@ logger = AppLogger.get_logger()
 
 class ExptConfigReader:
     @classmethod
-    def get_experiment_yaml_path(cls, workspace_id: str, unique_id: str) -> str:
+    def get_config_yaml_path(cls, workspace_id: str, unique_id: str) -> str:
         path = join_filepath(
             [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
         )
         return path
 
     @classmethod
-    def get_experiment_yaml_wild_path(cls, workspace_id: str) -> str:
+    def get_config_yaml_wild_path(cls, workspace_id: str) -> str:
         path = join_filepath(
             [DIRPATH.OUTPUT_DIR, workspace_id, "*", DIRPATH.EXPERIMENT_YML]
         )
@@ -38,7 +38,7 @@ class ExptConfigReader:
 
     @classmethod
     def read(cls, workspace_id: str, unique_id: str) -> ExptConfig:
-        filepath = cls.get_experiment_yaml_path(workspace_id, unique_id)
+        filepath = cls.get_config_yaml_path(workspace_id, unique_id)
         config = ConfigReader.read(filepath)
         assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
 
@@ -63,7 +63,7 @@ class ExptConfigReader:
 
     @classmethod
     def read_raw(cls, workspace_id: str, unique_id: str) -> dict:
-        config_path = cls.get_experiment_yaml_path(workspace_id, unique_id)
+        config_path = cls.get_config_yaml_path(workspace_id, unique_id)
 
         if not os.path.exists(config_path):
             return None

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -42,19 +42,7 @@ class ExptConfigReader:
         config = ConfigReader.read(filepath)
         assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
 
-        return ExptConfig(
-            workspace_id=config["workspace_id"],
-            unique_id=config["unique_id"],
-            name=config["name"],
-            started_at=config["started_at"],
-            finished_at=config.get("finished_at"),
-            success=config.get("success", NodeRunStatus.RUNNING.value),
-            hasNWB=config["hasNWB"],
-            function=cls.read_function(config["function"]),
-            nwb=config.get("nwb"),
-            snakemake=config.get("snakemake"),
-            data_usage=config.get("data_usage"),
-        )
+        return cls._create_workflow_config(config)
 
     @classmethod
     def read_from_path(cls, filepath: str) -> ExptConfig:
@@ -70,6 +58,22 @@ class ExptConfigReader:
         config = ConfigReader.read(config_path)
 
         return config
+
+    @classmethod
+    def _create_workflow_config(cls, config: dict) -> ExptConfig:
+        return ExptConfig(
+            workspace_id=config["workspace_id"],
+            unique_id=config["unique_id"],
+            name=config["name"],
+            started_at=config["started_at"],
+            finished_at=config.get("finished_at"),
+            success=config.get("success", NodeRunStatus.RUNNING.value),
+            hasNWB=config["hasNWB"],
+            function=cls.read_function(config["function"]),
+            nwb=config.get("nwb"),
+            snakemake=config.get("snakemake"),
+            data_usage=config.get("data_usage"),
+        )
 
     @classmethod
     def read_function(cls, config) -> Dict[str, ExptFunction]:

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 import yaml
 
@@ -19,7 +19,7 @@ logger = AppLogger.get_logger()
 
 class ExptConfigReader:
     @classmethod
-    def read(cls, file: Union[str, bytes]) -> ExptConfig:
+    def read(cls, file: str) -> ExptConfig:
         config = ConfigReader.read(file)
         assert config, f"Invalid config yaml file: [{file}] [{config}]"
 

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -42,7 +42,7 @@ class ExptConfigReader:
         config = ConfigReader.read(filepath)
         assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
 
-        return cls._create_workflow_config(config)
+        return cls._create_experiments_config(config)
 
     @classmethod
     def read_from_path(cls, filepath: str) -> ExptConfig:
@@ -60,7 +60,7 @@ class ExptConfigReader:
         return config
 
     @classmethod
-    def _create_workflow_config(cls, config: dict) -> ExptConfig:
+    def _create_experiments_config(cls, config: dict) -> ExptConfig:
         return ExptConfig(
             workspace_id=config["workspace_id"],
             unique_id=config["unique_id"],

--- a/studio/app/common/core/experiment/experiment_utils.py
+++ b/studio/app/common/core/experiment/experiment_utils.py
@@ -11,9 +11,7 @@ class ExptUtils:
     @classmethod
     def get_last_experiment(cls, workspace_id: str):
         last_expt_config: Optional[ExptConfig] = None
-        config_paths = glob(
-            ExptConfigReader.get_experiment_yaml_wild_path(workspace_id)
-        )
+        config_paths = glob(ExptConfigReader.get_config_yaml_wild_path(workspace_id))
 
         for path in config_paths:
             config = ExptConfigReader.read_from_path(path)

--- a/studio/app/common/core/experiment/experiment_utils.py
+++ b/studio/app/common/core/experiment/experiment_utils.py
@@ -4,9 +4,7 @@ from typing import Optional
 
 from studio.app.common.core.experiment.experiment import ExptConfig
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
-from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.const import DATE_FORMAT
-from studio.app.dir_path import DIRPATH
 
 
 class ExptUtils:
@@ -14,17 +12,16 @@ class ExptUtils:
     def get_last_experiment(cls, workspace_id: str):
         last_expt_config: Optional[ExptConfig] = None
         config_paths = glob(
-            join_filepath(
-                [DIRPATH.OUTPUT_DIR, workspace_id, "*", DIRPATH.EXPERIMENT_YML]
-            )
+            ExptConfigReader.get_experiment_yaml_wild_path(workspace_id)
         )
 
         for path in config_paths:
-            config = ExptConfigReader.read(path)
+            config = ExptConfigReader.read_from_path(path)
             if not last_expt_config:
                 last_expt_config = config
             elif datetime.strptime(config.started_at, DATE_FORMAT) > datetime.strptime(
                 last_expt_config.started_at, DATE_FORMAT
             ):
                 last_expt_config = config
+
         return last_expt_config

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -40,7 +40,7 @@ class ExptConfigWriter:
         self.builder = ExptConfigBuilder()
 
     def write(self) -> None:
-        expt_filepath = ExptConfigReader.get_experiment_yaml_path(
+        expt_filepath = ExptConfigReader.get_config_yaml_path(
             self.workspace_id, self.unique_id
         )
         if os.path.exists(expt_filepath):

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -40,16 +40,11 @@ class ExptConfigWriter:
         self.builder = ExptConfigBuilder()
 
     def write(self) -> None:
-        expt_filepath = join_filepath(
-            [
-                DIRPATH.OUTPUT_DIR,
-                self.workspace_id,
-                self.unique_id,
-                DIRPATH.EXPERIMENT_YML,
-            ]
+        expt_filepath = ExptConfigReader.get_experiment_yaml_path(
+            self.workspace_id, self.unique_id
         )
         if os.path.exists(expt_filepath):
-            expt_config = ExptConfigReader.read(expt_filepath)
+            expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
             self.builder.set_config(expt_config)
             self.add_run_info()
         else:
@@ -136,7 +131,7 @@ class ExptDataWriter:
 
         try:
             # Check the expt is running or if don't have status it will return None
-            status = ExptConfigReader.load_experiment_success_status(
+            status = ExptConfigReader.read_experiment_status(
                 self.workspace_id, self.unique_id
             )
             # If the experiment is running or has no status, skip deletion
@@ -177,15 +172,7 @@ class ExptDataWriter:
         # Update & Write config
         ExptConfigWriter.write_raw(self.workspace_id, self.unique_id, config)
 
-        config_path = join_filepath(
-            [
-                DIRPATH.OUTPUT_DIR,
-                self.workspace_id,
-                self.unique_id,
-                DIRPATH.EXPERIMENT_YML,
-            ]
-        )
-        return ExptConfigReader.read(config_path)
+        return ExptConfigReader.read(self.workspace_id, self.unique_id)
 
     def copy_data(self, new_unique_id: str) -> bool:
         logger = AppLogger.get_logger()

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -89,14 +89,8 @@ class ExptConfigWriter:
     def build_function_from_nodeDict(self) -> ExptConfig:
         func_dict: Dict[str, ExptFunction] = {}
         node_dict = WorkflowConfigReader.read(
-            join_filepath(
-                [
-                    DIRPATH.OUTPUT_DIR,
-                    self.workspace_id,
-                    self.unique_id,
-                    DIRPATH.WORKFLOW_YML,
-                ]
-            )
+            self.workspace_id,
+            self.unique_id,
         ).nodeDict
 
         for node in node_dict.values():

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import Dict
 
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.snakemake.smk import Rule
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
@@ -127,7 +128,7 @@ class SmkUtils:
         return modified_params
 
     @staticmethod
-    def resolve_nwbfile_reference(rule_config):
+    def resolve_nwbfile_reference(rule_config: Rule):
         """Resolve NWB template reference if necessary"""
         if hasattr(rule_config, "nwbfile"):
             if isinstance(rule_config.nwbfile, str) and rule_config.nwbfile.startswith(
@@ -138,8 +139,8 @@ class SmkUtils:
                 config_path = join_filepath(
                     [DIRPATH.OUTPUT_DIR, workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
                 )
+                config = SmkConfigReader.read_from_path(config_path)
 
-                config = ConfigReader.read(config_path)
                 if "nwb_template" in config:
                     template = config["nwb_template"]
                     rule_config.nwbfile = template

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -8,6 +8,7 @@ from snakemake import snakemake
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import get_pickle_file, join_filepath
 from studio.app.common.core.workflow.workflow import Edge, Node
 from studio.app.dir_path import DIRPATH
@@ -50,14 +51,7 @@ def _snakemake_execute_process(
         use_conda=params.use_conda,
         conda_prefix=DIRPATH.SNAKEMAKE_CONDA_ENV_DIR,
         workdir=smk_workdir,
-        configfiles=[
-            join_filepath(
-                [
-                    smk_workdir,
-                    DIRPATH.SNAKEMAKE_CONFIG_YML,
-                ]
-            )
-        ],
+        configfiles=[SmkConfigReader.get_config_yaml_path(workspace_id, unique_id)],
         log_handler=[smk_logger.log_handler],
     )
 

--- a/studio/app/common/core/snakemake/snakemake_reader.py
+++ b/studio/app/common/core/snakemake/snakemake_reader.py
@@ -1,4 +1,10 @@
+import os
+
+from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.snakemake.smk import Rule, SmkParam
+from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.dir_path import DIRPATH
 
 
 class RuleConfigReader:
@@ -28,3 +34,25 @@ class SmkParamReader:
             lock=params["lock"],
             forcerun=params["forcerun"] if "forcerun" in params else [],
         )
+
+
+class SmkConfigReader:
+    @classmethod
+    def get_config_yaml_path(cls, workspace_id: str, unique_id: str) -> str:
+        path = join_filepath(
+            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.SNAKEMAKE_CONFIG_YML]
+        )
+        return path
+
+    @classmethod
+    def read(cls, workspace_id: str, unique_id: str) -> dict:
+        filepath = cls.get_config_yaml_path(workspace_id, unique_id)
+        config = ConfigReader.read(filepath)
+        assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
+
+        return config
+
+    @classmethod
+    def read_from_path(cls, filepath: str) -> dict:
+        ids = ExptOutputPathIds(os.path.dirname(filepath))
+        return cls.read(ids.workspace_id, ids.unique_id)

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -1,5 +1,4 @@
 import os
-from typing import Union
 
 import yaml
 from filelock import FileLock
@@ -13,20 +12,18 @@ from studio.app.common.core.utils.filepath_creater import (
 
 class ConfigReader:
     @classmethod
-    def read(cls, file: Union[str, bytes]):
+    def read(cls, filepath: str) -> dict:
         config = {}
 
-        if file is None:
-            return config
-
-        if isinstance(file, bytes):
-            config = yaml.safe_load(file)
-        elif isinstance(file, str) and os.path.exists(file):
-            with open(file) as f:
+        if filepath is not None and os.path.exists(filepath):
+            with open(filepath) as f:
                 config = yaml.safe_load(f)
-        else:
-            assert False, f"Invalid file [{file}]"
 
+        return config
+
+    @classmethod
+    def read_from_bytes(cls, content: bytes) -> dict:
+        config = yaml.safe_load(content)
         return config
 
 

--- a/studio/app/common/core/workflow/workflow_filter.py
+++ b/studio/app/common/core/workflow/workflow_filter.py
@@ -57,13 +57,7 @@ class WorkflowNodeDataFilter:
         )
 
     def _check_data_filter(self):
-        expt_filepath = join_filepath(
-            [
-                self.workflow_dirpath,
-                DIRPATH.EXPERIMENT_YML,
-            ]
-        )
-        exp_config = ExptConfigReader.read(expt_filepath)
+        exp_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
 
         assert (
             exp_config.function[self.node_id].success == WorkflowRunStatus.SUCCESS.value

--- a/studio/app/common/core/workflow/workflow_filter.py
+++ b/studio/app/common/core/workflow/workflow_filter.py
@@ -31,9 +31,7 @@ class WorkflowNodeDataFilter:
         self.workflow_dirpath = join_filepath(
             [DIRPATH.OUTPUT_DIR, workspace_id, unique_id]
         )
-        self.workflow_config = WorkflowConfigReader.read(
-            join_filepath([self.workflow_dirpath, DIRPATH.WORKFLOW_YML])
-        )
+        self.workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
         self.node_dirpath = join_filepath([self.workflow_dirpath, node_id])
 
         # current output data path

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict
 
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.workflow.workflow import (
@@ -13,17 +13,28 @@ from studio.app.common.schemas.workflow import WorkflowConfig
 
 class WorkflowConfigReader:
     @classmethod
-    def read(cls, file: Union[str, bytes]) -> WorkflowConfig:
+    def read(cls, file: str) -> WorkflowConfig:
         config = ConfigReader.read(file)
         assert config, f"Invalid config yaml file: [{file}] [{config}]"
 
+        return cls._create_workflow_config(config)
+
+    @classmethod
+    def read_from_bytes(cls, content: bytes) -> WorkflowConfig:
+        config = ConfigReader.read_from_bytes(content)
+        assert config, f"Invalid config yaml: [{config}]"
+
+        return cls._create_workflow_config(config)
+
+    @classmethod
+    def _create_workflow_config(cls, config: dict) -> WorkflowConfig:
         return WorkflowConfig(
             nodeDict=cls.read_nodeDict(config["nodeDict"]),
             edgeDict=cls.read_edgeDict(config["edgeDict"]),
         )
 
     @classmethod
-    def read_nodeDict(cls, config) -> Dict[str, Node]:
+    def read_nodeDict(cls, config: dict) -> Dict[str, Node]:
         return {
             key: Node(
                 id=key,
@@ -36,7 +47,7 @@ class WorkflowConfigReader:
         }
 
     @classmethod
-    def read_edgeDict(cls, config) -> Dict[str, Edge]:
+    def read_edgeDict(cls, config: dict) -> Dict[str, Edge]:
         return {
             key: Edge(
                 id=key,

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -41,9 +41,6 @@ class WorkflowResult:
                 self.unique_id,
             ]
         )
-        self.expt_filepath = join_filepath(
-            [self.workflow_dirpath, DIRPATH.EXPERIMENT_YML]
-        )
         self.monitor = WorkflowMonitor(workspace_id, unique_id)
 
     def observe(self, nodeIdList: List[str]) -> Dict:
@@ -158,7 +155,7 @@ class WorkflowResult:
 
         for nwb_filepath in nwb_filepath_list:
             if os.path.exists(nwb_filepath):
-                config = ExptConfigReader.read(self.expt_filepath)
+                config = ExptConfigReader.read(self.workspace_id, self.unique_id)
 
                 if target_whole_nwb:
                     config.hasNWB = True
@@ -191,9 +188,6 @@ class NodeResult:
         )
         self.node_id = node_id
         self.node_dirpath = join_filepath([self.workflow_dirpath, self.node_id])
-        self.expt_filepath = join_filepath(
-            [self.workflow_dirpath, DIRPATH.EXPERIMENT_YML]
-        )
         self.workflow_has_error = workflow_error.has_error if workflow_error else False
         self.workflow_error_log = workflow_error.error_log if workflow_error else None
 
@@ -210,7 +204,10 @@ class NodeResult:
             self.info = None
 
     def observe(self) -> Message:
-        expt_config = ExptConfigReader.read(self.expt_filepath)
+        expt_config = ExptConfigReader.read(
+            self.workspace_id,
+            self.unique_id,
+        )
 
         # case) error throughout workflow
         if self.workflow_has_error:
@@ -291,14 +288,6 @@ class WorkflowMonitor:
     def __init__(self, workspace_id: str, unique_id: str):
         self.workspace_id = workspace_id
         self.unique_id = unique_id
-        self.expt_filepath = join_filepath(
-            [
-                DIRPATH.OUTPUT_DIR,
-                self.workspace_id,
-                self.unique_id,
-                DIRPATH.EXPERIMENT_YML,
-            ]
-        )
 
     def search_process(self) -> WorkflowProcessInfo:
         pid_data = Runner.read_pid_file(self.workspace_id, self.unique_id)
@@ -311,7 +300,7 @@ class WorkflowMonitor:
             # )
 
             # Refer experiment_data instead of pid_data
-            expt_config = ExptConfigReader.read(self.expt_filepath)
+            expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
             try:
                 expt_started_time = datetime.strptime(
                     expt_config.started_at, DATE_FORMAT

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -10,7 +10,7 @@ from studio.app.common.core.experiment.experiment import ExptConfig
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_writer import ExptDataWriter
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
     is_workspace_owner,
@@ -18,7 +18,6 @@ from studio.app.common.core.workspace.workspace_dependencies import (
 from studio.app.common.core.workspace.workspace_services import WorkspaceService
 from studio.app.common.db.database import get_db
 from studio.app.common.schemas.experiment import CopyItem, DeleteItem, RenameItem
-from studio.app.dir_path import DIRPATH
 
 router = APIRouter(prefix="/experiments", tags=["experiments"])
 
@@ -139,9 +138,7 @@ async def copy_experiment_list(
     dependencies=[Depends(is_workspace_available)],
 )
 async def download_config_experiment(workspace_id: str, unique_id: str):
-    config_filepath = join_filepath(
-        [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.SNAKEMAKE_CONFIG_YML]
-    )
+    config_filepath = SmkConfigReader.get_config_yaml_path(workspace_id, unique_id)
     if os.path.exists(config_filepath):
         return FileResponse(config_filepath)
     else:

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -32,7 +32,7 @@ logger = AppLogger.get_logger()
 )
 async def get_experiments(workspace_id: str):
     exp_config = {}
-    config_paths = glob(ExptConfigReader.get_experiment_yaml_wild_path(workspace_id))
+    config_paths = glob(ExptConfigReader.get_config_yaml_wild_path(workspace_id))
     for path in config_paths:
         try:
             config = ExptConfigReader.read_from_path(path)

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -32,12 +32,10 @@ logger = AppLogger.get_logger()
 )
 async def get_experiments(workspace_id: str):
     exp_config = {}
-    config_paths = glob(
-        join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, "*", DIRPATH.EXPERIMENT_YML])
-    )
+    config_paths = glob(ExptConfigReader.get_experiment_yaml_wild_path(workspace_id))
     for path in config_paths:
         try:
-            config = ExptConfigReader.read(path)
+            config = ExptConfigReader.read_from_path(path)
             exp_config[config.unique_id] = config
         except Exception as e:
             logger.error(e, exc_info=True)

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -118,7 +118,7 @@ async def download_workspace_config(workspace_id: str, unique_id: str):
 @router.post("/import")
 async def import_workflow_config(file: UploadFile = File(...)):
     try:
-        contents = WorkflowConfigReader.read(await file.read())
+        contents = WorkflowConfigReader.read_from_bytes(await file.read())
         return contents
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -36,15 +36,7 @@ async def fetch_last_experiment(workspace_id: str):
             unique_id = last_expt_config.unique_id
 
             # fetch workflow
-            workflow_config_path = join_filepath(
-                [
-                    DIRPATH.OUTPUT_DIR,
-                    workspace_id,
-                    unique_id,
-                    DIRPATH.WORKFLOW_YML,
-                ]
-            )
-            workflow_config = WorkflowConfigReader.read(workflow_config_path)
+            workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
             return WorkflowWithResults(
                 **asdict(last_expt_config), **asdict(workflow_config)
             )
@@ -72,14 +64,14 @@ async def reproduce_experiment(workspace_id: str, unique_id: str):
         experiment_config_path = ExptConfigReader.get_config_yaml_path(
             workspace_id, unique_id
         )
-        workflow_config_path = join_filepath(
-            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.WORKFLOW_YML]
+        workflow_config_path = WorkflowConfigReader.get_config_yaml_path(
+            workspace_id, unique_id
         )
         if os.path.exists(experiment_config_path) and os.path.exists(
             workflow_config_path
         ):
             experiment_config = ExptConfigReader.read(workspace_id, unique_id)
-            workflow_config = WorkflowConfigReader.read(workflow_config_path)
+            workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
             return WorkflowWithResults(
                 **asdict(experiment_config), **asdict(workflow_config)
             )
@@ -104,9 +96,7 @@ async def reproduce_experiment(workspace_id: str, unique_id: str):
     dependencies=[Depends(is_workspace_available)],
 )
 async def download_workspace_config(workspace_id: str, unique_id: str):
-    config_filepath = join_filepath(
-        [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.WORKFLOW_YML]
-    )
+    config_filepath = WorkflowConfigReader.get_config_yaml_path(workspace_id, unique_id)
     if os.path.exists(config_filepath):
         return FileResponse(config_filepath, filename=DIRPATH.WORKFLOW_YML)
     else:

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -69,8 +69,8 @@ async def fetch_last_experiment(workspace_id: str):
 )
 async def reproduce_experiment(workspace_id: str, unique_id: str):
     try:
-        experiment_config_path = join_filepath(
-            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.EXPERIMENT_YML]
+        experiment_config_path = ExptConfigReader.get_experiment_yaml_path(
+            workspace_id, unique_id
         )
         workflow_config_path = join_filepath(
             [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.WORKFLOW_YML]
@@ -78,7 +78,7 @@ async def reproduce_experiment(workspace_id: str, unique_id: str):
         if os.path.exists(experiment_config_path) and os.path.exists(
             workflow_config_path
         ):
-            experiment_config = ExptConfigReader.read(experiment_config_path)
+            experiment_config = ExptConfigReader.read(workspace_id, unique_id)
             workflow_config = WorkflowConfigReader.read(workflow_config_path)
             return WorkflowWithResults(
                 **asdict(experiment_config), **asdict(workflow_config)

--- a/studio/app/common/routers/workflow.py
+++ b/studio/app/common/routers/workflow.py
@@ -69,7 +69,7 @@ async def fetch_last_experiment(workspace_id: str):
 )
 async def reproduce_experiment(workspace_id: str, unique_id: str):
     try:
-        experiment_config_path = ExptConfigReader.get_experiment_yaml_path(
+        experiment_config_path = ExptConfigReader.get_config_yaml_path(
             workspace_id, unique_id
         )
         workflow_config_path = join_filepath(

--- a/studio/app/common/routers/workspace.py
+++ b/studio/app/common/routers/workspace.py
@@ -80,7 +80,8 @@ def search_workspaces(
                     experiment_path = join_filepath([workspace_dir, experiment_id])
                     if not os.path.isdir(experiment_path):
                         continue
-                    status = ExptConfigReader.load_experiment_success_status(
+
+                    status = ExptConfigReader.read_experiment_status(
                         str(ws.id), experiment_id
                     )
                     if status is None:

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -11,7 +11,7 @@ from snakemake import snakemake
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.rules.runner import Runner
-from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.utils.pickle_handler import PickleReader, PickleWriter
@@ -90,7 +90,8 @@ class EditROI:
     def __init__(self, file_path):
         self.node_dirpath = os.path.dirname(file_path)
         self.workflow_dirpath = os.path.dirname(self.node_dirpath)
-        self.function_id = ExptOutputPathIds(self.node_dirpath).function_id
+        self.workflow_ids = ExptOutputPathIds(self.node_dirpath)
+        self.function_id = self.workflow_ids.function_id
 
         self.output_info: Dict = PickleReader.read(self.pickle_file_path)
         self.tmp_output_info: Dict = (
@@ -293,10 +294,9 @@ class EditROI:
         )
 
     def __update_whole_nwb(self, output_info):
-        smk_config_file = join_filepath(
-            [self.workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
+        smk_config = SmkConfigReader.read(
+            self.workflow_ids.workspace_id, self.workflow_ids.unique_id
         )
-        smk_config = ConfigReader.read(smk_config_file)
         last_outputs = smk_config.get("last_output")
 
         for last_output in last_outputs:

--- a/studio/tests/app/common/core/experiment/test_expt_reader.py
+++ b/studio/tests/app/common/core/experiment/test_expt_reader.py
@@ -1,18 +1,13 @@
 from studio.app.common.core.experiment.experiment import ExptConfig, ExptFunction
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.workflow.workflow import NodeRunStatus
-from studio.app.dir_path import DIRPATH
 
 workspace_id = "default"
 unique_id = "0123"
 
-expt_filepath = (
-    f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}/experiment.yaml"
-)
-
 
 def test_read():
-    exp_config = ExptConfigReader.read(expt_filepath)
+    exp_config = ExptConfigReader.read(workspace_id, unique_id)
 
     assert isinstance(exp_config, ExptConfig)
     assert isinstance(exp_config.workspace_id, str)

--- a/studio/tests/app/common/core/workflow/test_workflow_reader.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_reader.py
@@ -7,18 +7,13 @@ from studio.app.common.core.workflow.workflow import (
 )
 from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.schemas.workflow import WorkflowConfig
-from studio.app.dir_path import DIRPATH
 
 workspace_id = "default"
 unique_id = "0123"
 
-workflow_filepath = (
-    f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}/workflow.yaml"
-)
-
 
 def test_read():
-    workflow_config = WorkflowConfigReader.read(workflow_filepath)
+    workflow_config = WorkflowConfigReader.read(workspace_id, unique_id)
 
     assert isinstance(workflow_config, WorkflowConfig)
     assert isinstance(workflow_config.nodeDict, dict)

--- a/studio/tests/app/common/routers/test_experiment.py
+++ b/studio/tests/app/common/routers/test_experiment.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.dir_path import DIRPATH
 
@@ -31,7 +32,8 @@ def test_delete(client):
     os.makedirs(dirpath, exist_ok=True)
 
     # Add dummy experiment.yaml
-    with open(os.path.join(dirpath, DIRPATH.EXPERIMENT_YML), "w") as f:
+    config_path = ExptConfigReader.get_experiment_yaml_path(workspace_id, dirname)
+    with open(config_path, "w") as f:
         f.write("name: Dummy Experiment\nsuccess: success")
 
     assert os.path.exists(dirpath)
@@ -47,7 +49,8 @@ def test_delete_list(client):
         os.makedirs(dirpath, exist_ok=True)
 
         # Add dummy experiment.yaml
-        with open(os.path.join(dirpath, DIRPATH.EXPERIMENT_YML), "w") as f:
+        config_path = ExptConfigReader.get_experiment_yaml_path(workspace_id, name)
+        with open(config_path, "w") as f:
             f.write("name: Dummy Experiment\nsuccess: success")
 
         assert os.path.exists(dirpath)

--- a/studio/tests/app/common/routers/test_experiment.py
+++ b/studio/tests/app/common/routers/test_experiment.py
@@ -32,7 +32,7 @@ def test_delete(client):
     os.makedirs(dirpath, exist_ok=True)
 
     # Add dummy experiment.yaml
-    config_path = ExptConfigReader.get_experiment_yaml_path(workspace_id, dirname)
+    config_path = ExptConfigReader.get_config_yaml_path(workspace_id, dirname)
     with open(config_path, "w") as f:
         f.write("name: Dummy Experiment\nsuccess: success")
 
@@ -49,7 +49,7 @@ def test_delete_list(client):
         os.makedirs(dirpath, exist_ok=True)
 
         # Add dummy experiment.yaml
-        config_path = ExptConfigReader.get_experiment_yaml_path(workspace_id, name)
+        config_path = ExptConfigReader.get_config_yaml_path(workspace_id, name)
         with open(config_path, "w") as f:
             f.write("name: Dummy Experiment\nsuccess: success")
 


### PR DESCRIPTION
### Content

Refactoring of config handle modules to improve code maintainability.
*With support for parallel processing and AWS, there is an increasing need to centrally manage file resource access.

- Target modules
  - ExptConfigReader
  - WorkflowConfigReader
  - SmkConfigReader

- Main changes
  - Unification of read() method: unification of accessing config file with workspace_id, unique_id (experiment_id)
  - Unified config file path acquisition to a dedicated method

### References

- Related
  - #796

### Testcase

- Testcases
  - *Check the following operations:
  - Workflow Screen
  	- [x] Run workflow (tutorial 1-3)
  	- [x] data filter
  	- [x] Run edit roi
  - Record Screen
    - [x] *Operation of each function on the record screen

- Platforms
  - [x] Mac or Linux
  - [x] Docker
