### PR TITLE
Improved overwrite processing of ExptConfig

### DIFF
--- a/studio/app/common/core/experiment/experiment.py
+++ b/studio/app/common/core/experiment/experiment.py
@@ -34,6 +34,19 @@ class ExptConfig:
     snakemake: SmkParam
     data_usage: Optional[int]
 
+    @staticmethod
+    def required_fields():
+        return [
+            "workspace_id",
+            "unique_id",
+            "name",
+            "started_at",
+            "hasNWB",
+            "function",
+            "nwb",
+            "snakemake",
+        ]
+
 
 @dataclass
 class ExptOutputPathIds:

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -41,7 +41,7 @@ class ConfigReader:
 
 
 class ConfigWriter:
-    FILE_LOCK_TIMEOUT = 10
+    FILE_LOCK_TIMEOUT = 60
 
     @classmethod
     def write(cls, dirname: str, filename: str, config: dict, auto_file_lock=True):

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -10,6 +10,19 @@ from studio.app.common.core.utils.filepath_creater import (
 )
 
 
+def differential_deep_merge(d1: dict, d2: dict) -> dict:
+    """
+    Deep merge only the differences to avoid destroying existing elements
+    """
+    result = d1.copy()
+    for key, value in d2.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = differential_deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
 class ConfigReader:
     @classmethod
     def read(cls, filepath: str) -> dict:

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import re
 import signal
@@ -10,6 +11,7 @@ from typing import Dict, List
 from fastapi import HTTPException, status
 from psutil import AccessDenied, NoSuchProcess, Process, ZombieProcess, process_iter
 
+from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
 from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
 from studio.app.common.core.logger import AppLogger
@@ -155,16 +157,32 @@ class WorkflowResult:
 
         for nwb_filepath in nwb_filepath_list:
             if os.path.exists(nwb_filepath):
-                config = ExptConfigReader.read(self.workspace_id, self.unique_id)
+                update_expt_config = ExptConfigReader.create_empty_experiment_config()
+                update_config_function: ExptFunction = None
 
                 if target_whole_nwb:
-                    config.hasNWB = True
+                    update_expt_config.hasNWB = True
                 else:
-                    config.function[node_id].hasNWB = True
+                    original_config = ExptConfigReader.read(
+                        self.workspace_id, self.unique_id
+                    )
+                    update_config_function = copy.deepcopy(
+                        original_config.function[node_id]
+                    )
+                    update_config_function.hasNWB = True
 
-                # Update EXPERIMENT_YML
-                ExptConfigWriter.write_raw(
-                    self.workspace_id, self.unique_id, asdict(config)
+                # Make overwrite params
+                update_expt_config_dict = {}
+                if update_config_function is not None:
+                    update_expt_config_dict["function"] = {
+                        update_config_function.unique_id: asdict(update_config_function)
+                    }
+                if update_expt_config.hasNWB is not None:
+                    update_expt_config_dict["hasNWB"] = update_expt_config.hasNWB
+
+                # Overwrite experiment config
+                ExptConfigWriter(self.workspace_id, self.unique_id).overwrite(
+                    update_expt_config_dict
                 )
 
 
@@ -204,9 +222,13 @@ class NodeResult:
             self.info = None
 
     def observe(self) -> Message:
-        expt_config = ExptConfigReader.read(
+        original_expt_config = ExptConfigReader.read(
             self.workspace_id,
             self.unique_id,
+        )
+        update_expt_config = ExptConfigReader.create_empty_experiment_config()
+        update_config_function: ExptFunction = copy.deepcopy(
+            original_expt_config.function[self.node_id]
         )
 
         # case) error throughout workflow
@@ -218,33 +240,53 @@ class NodeResult:
         # case) success in node
         else:
             message = self.success()
-            expt_config.function[self.node_id].outputPaths = message.outputPaths
+            update_config_function.outputPaths = message.outputPaths
 
-        expt_config.function[self.node_id].success = message.status
+        update_config_function.success = message.status
 
         # TODO: Set started_at on the node
         #   At the moment, there is insufficient data to obtain an accurate started_at,
         #  so set it to None.
         #   separate modification is required to record running info for each node.
-        expt_config.function[self.node_id].started_at = None
+        update_config_function.started_at = None
 
         now = datetime.now().strftime(DATE_FORMAT)
-        expt_config.function[self.node_id].finished_at = now
-        expt_config.function[self.node_id].message = message.message
+        update_config_function.finished_at = now
+        update_config_function.message = message.message
 
-        statuses = list(map(lambda x: x.success, expt_config.function.values()))
+        latest_statuses = [
+            (
+                update_config_function.success
+                if k == update_config_function.unique_id
+                else v.success
+            )
+            for k, v in original_expt_config.function.items()
+        ]
 
-        if NodeRunStatus.RUNNING.value not in statuses:
-            expt_config.finished_at = now
-            if NodeRunStatus.ERROR.value in statuses:
-                expt_config.success = NodeRunStatus.ERROR.value
+        # Status check of each node
+        if NodeRunStatus.RUNNING.value not in latest_statuses:
+            update_expt_config.finished_at = now
+            if NodeRunStatus.ERROR.value in latest_statuses:
+                update_expt_config.success = NodeRunStatus.ERROR.value
             else:
-                expt_config.success = NodeRunStatus.SUCCESS.value
+                update_expt_config.success = NodeRunStatus.SUCCESS.value
 
-        # Update EXPERIMENT_YML
-        ExptConfigWriter.write_raw(
-            self.workspace_id, self.unique_id, asdict(expt_config)
+        # Make overwrite params
+        update_expt_config_dict = {}
+        if update_config_function is not None:
+            update_expt_config_dict["function"] = {
+                update_config_function.unique_id: asdict(update_config_function)
+            }
+        if update_expt_config.success is not None:
+            update_expt_config_dict["success"] = update_expt_config.success
+        if update_expt_config.finished_at is not None:
+            update_expt_config_dict["finished_at"] = update_expt_config.finished_at
+
+        # Overwrite experiment config
+        ExptConfigWriter(self.workspace_id, self.unique_id).overwrite(
+            update_expt_config_dict
         )
+
         return message
 
     def success(self) -> Message:

--- a/studio/app/common/core/workflow/workflow_writer.py
+++ b/studio/app/common/core/workflow/workflow_writer.py
@@ -24,17 +24,17 @@ class WorkflowConfigWriter:
         self.builder = WorkflowConfigBuilder()
         self.create_config()
 
-    @staticmethod
-    def write_raw(workspace_id: str, unique_id: str, config: dict) -> None:
+    def write(self) -> None:
+        self._write_raw(
+            self.workspace_id, self.unique_id, config=asdict(self.builder.build())
+        )
+
+    @classmethod
+    def _write_raw(cls, workspace_id: str, unique_id: str, config: dict) -> None:
         ConfigWriter.write(
             dirname=join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id]),
             filename=DIRPATH.WORKFLOW_YML,
             config=config,
-        )
-
-    def write(self) -> None:
-        self.write_raw(
-            self.workspace_id, self.unique_id, config=asdict(self.builder.build())
         )
 
     def create_config(self) -> WorkflowConfig:

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -28,16 +28,17 @@ logger = AppLogger.get_logger()
 class WorkspaceService:
     @classmethod
     def _update_exp_data_usage_yaml(cls, workspace_id: str, unique_id: str, data_usage):
-        # Read config
-        config = ExptConfigReader.read_raw(workspace_id, unique_id)
+        # Read experiment config
+        config = ExptConfigReader.read(workspace_id, unique_id)
         if not config:
             logger.error(f"[{workspace_id}/{unique_id}] does not exist")
             return
 
-        config["data_usage"] = data_usage
+        # Make overwrite params
+        update_params = {"data_usage": data_usage}
 
-        # Update & Write config
-        ExptConfigWriter.write_raw(workspace_id, unique_id, config)
+        # Overwrite experiment config
+        ExptConfigWriter(workspace_id, unique_id).overwrite(update_params)
 
     @classmethod
     def _update_exp_data_usage_db(

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -35,7 +35,8 @@ async def get_experiments(workspace_id: str):
     for path in config_paths:
         try:
             config = ExptConfigReader.read_from_path(path)
-            exp_config[config.unique_id] = config
+            if ExptConfigReader.validate_experiment_config(config):
+                exp_config[config.unique_id] = config
         except Exception as e:
             logger.error(e, exc_info=True)
             pass

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -4,12 +4,12 @@ from enum import Enum
 
 from dotenv import load_dotenv
 
-_TEMP_DIR = (
+_TMP_DIR = (
     os.environ.get("TEMP", os.environ.get("TMP", "C:\\temp"))
     if platform.system() == "Windows"
     else "/tmp"
 )
-_DEFAULT_DIR = f"{_TEMP_DIR}/studio"
+_DEFAULT_DIR = f"{_TMP_DIR}/studio"
 _ENV_DIR = os.environ.get("OPTINIST_DIR")
 
 

--- a/studio/tests/app/common/routers/test_experiment.py
+++ b/studio/tests/app/common/routers/test_experiment.py
@@ -2,7 +2,9 @@ import os
 import shutil
 
 from studio.app.common.core.experiment.experiment_reader import ExptConfigReader
+from studio.app.common.core.experiment.experiment_writer import ExptConfigWriter
 from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.common.core.workflow.workflow import NodeRunStatus
 from studio.app.dir_path import DIRPATH
 
 workspace_id = "default"
@@ -15,6 +17,19 @@ shutil.copytree(
     f"{DIRPATH.OUTPUT_DIR}/{workspace_id}/{unique_id}",
     dirs_exist_ok=True,
 )
+
+
+def __create_dummy_experiment_config(workspace_id: str, unique_id: str) -> dict:
+    return {
+        "workspace_id": workspace_id,
+        "unique_id": unique_id,
+        "name": "Dummy Experiment",
+        "started_at": None,
+        "finished_at": None,
+        "success": NodeRunStatus.SUCCESS.value,
+        "hasNWB": None,
+        "function": {},
+    }
 
 
 def test_get(client):
@@ -32,11 +47,13 @@ def test_delete(client):
     os.makedirs(dirpath, exist_ok=True)
 
     # Add dummy experiment.yaml
+    expt_config_dict = __create_dummy_experiment_config(workspace_id, dirname)
+    ExptConfigWriter._write_raw(workspace_id, dirname, expt_config_dict)
     config_path = ExptConfigReader.get_config_yaml_path(workspace_id, dirname)
-    with open(config_path, "w") as f:
-        f.write("name: Dummy Experiment\nsuccess: success")
 
     assert os.path.exists(dirpath)
+    assert os.path.exists(config_path)
+
     response = client.delete(f"/experiments/{workspace_id}/{dirname}")
     assert response.status_code == 200
     assert not os.path.exists(dirpath)
@@ -49,11 +66,12 @@ def test_delete_list(client):
         os.makedirs(dirpath, exist_ok=True)
 
         # Add dummy experiment.yaml
+        expt_config_dict = __create_dummy_experiment_config(workspace_id, name)
+        ExptConfigWriter._write_raw(workspace_id, name, expt_config_dict)
         config_path = ExptConfigReader.get_config_yaml_path(workspace_id, name)
-        with open(config_path, "w") as f:
-            f.write("name: Dummy Experiment\nsuccess: success")
 
         assert os.path.exists(dirpath)
+        assert os.path.exists(config_path)
 
     response = client.post(
         f"/experiments/delete/{workspace_id}", json={"uidList": uidList}


### PR DESCRIPTION
### Content

Improved overwrite processing of ExptConfig

- Main target modules
  - ExptConfigReader, ExptConfigWriter
  - And all the places where ExptConfigWriter.overwrite() is used

- Main changes
  - Basic update
    - Added a dedicated method for overwrite
    - Avoided unnecessary overwrite processing
      - *Due to the impact of unnecessary updates, depending on the timing of the update, there was the potential for files to be updated with invalid content.
  - Stabilization of parallel processing
    - Using FileLock with ExptConfigWriter.overwrite()
    - ConfigWriter.write() now writes via a temporary file to avoid conflicts.

### References

- Related
  - #821

### Testcase

- Testcases
  - *Check the following operations:
  - Workflow Screen
  	- [x] Run workflow (tutorial 1-3)
  	- [x] data filter
  	- [x] Run edit roi
    - [x] Check that YAML files are generated correctly
      - *compare with the files before and after the correction to ensure that there are no missing fields, etc.
      - [x] experiment.yaml
  - Highly parallel workflow execution
    - [x] #795
      - `snakemake cores=8, suite2p_roi*8`
    - [x] #798
      - `snakemake cores=8, caiman_cnmf*8`
  - Record Screen
    - [x] *Operation of each function on the record screen

- Platforms
  - Native
    - [x] Mac or Linux
    - [x] Windows
  - [x] Docker
