### PR TITLE
Fixed error handling for record deletion

### DIFF
--- a/studio/app/common/core/experiment/experiment_services.py
+++ b/studio/app/common/core/experiment/experiment_services.py
@@ -20,13 +20,13 @@ class ExperimentService:
         cls, db: Session, workspace_id: str, unique_id: str, auto_commit: bool = False
     ) -> bool:
         # Delete experiment data
-        deleted = ExptDataWriter(workspace_id, unique_id).delete_data()
+        result = ExptDataWriter(workspace_id, unique_id).delete_data()
 
         # Delete experiment database record
         if WorkspaceDataCapacityService.is_available():
             cls._delete_experiment_db(db, workspace_id, unique_id, auto_commit)
 
-        return deleted
+        return result
 
     @classmethod
     def _delete_experiment_db(

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -24,7 +24,7 @@ class WorkspaceService:
         logger.info(f"Deleting workspace data for workspace '{workspace_id}'")
 
         workspace_dir = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
-        hasDeleteDataArr = []
+        deleted_statuses = []
 
         # Delete experiment folders under workspace
         if os.path.exists(workspace_dir):
@@ -33,15 +33,15 @@ class WorkspaceService:
                 if experiment_id.startswith("."):
                     continue
 
-                deleted = ExperimentService.delete_experiment(
+                deleted_status = ExperimentService.delete_experiment(
                     db, workspace_id, experiment_id, auto_commit=False
                 )
 
-                hasDeleteDataArr.append(deleted)
+                deleted_statuses.append(deleted_status)
         else:
             logger.warning(f"Workspace directory '{workspace_dir}' does not exist")
 
-        if all(hasDeleteDataArr):
+        if all(deleted_statuses):
             # Delete the workspace directory itself
             cls.delete_workspace_files(workspace_id=workspace_id)
 

--- a/studio/app/common/routers/experiment.py
+++ b/studio/app/common/routers/experiment.py
@@ -76,12 +76,21 @@ async def delete_experiment(
     workspace_id: str, unique_id: str, db: Session = Depends(get_db)
 ):
     try:
-        ExperimentService.delete_experiment(
+        result = ExperimentService.delete_experiment(
             db, workspace_id, unique_id, auto_commit=True
         )
 
-        return True
+        if not result:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to delete experiment [{workspace_id}/{unique_id}]",
+            )
 
+        return result
+
+    except HTTPException as e:
+        logger.error(e, exc_info=True)
+        raise e
     except Exception as e:
         logger.error("Deletion failed: %s", e, exc_info=True)
         raise HTTPException(
@@ -99,12 +108,32 @@ async def delete_experiment_list(
     workspace_id: str, deleteItem: DeleteItem, db: Session = Depends(get_db)
 ):
     try:
+        deleted_statuses = {}
+
         for unique_id in deleteItem.uidList:
-            ExperimentService.delete_experiment(
+            result = ExperimentService.delete_experiment(
                 db, workspace_id, unique_id, auto_commit=True
+            )
+            deleted_statuses[unique_id] = result
+
+        deleted_failed_statuses = [
+            id for id, res in deleted_statuses.items() if not res
+        ]
+
+        if deleted_failed_statuses:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Failed to delete some experiments "
+                    f"[{workspace_id}] / {deleted_failed_statuses}"
+                ),
             )
 
         return True
+
+    except HTTPException as e:
+        logger.error(e, exc_info=True)
+        raise e
     except Exception as e:
         logger.error(e, exc_info=True)
         raise HTTPException(


### PR DESCRIPTION
### Content

Fixed error handling for record deletion
- If an error occurred while deleting a record, the process would appear to be successful in the frontend even though the record was not actually deleted.
- Appropriate error handling has been added for the above.

### References

- Problems with the following:
  - #790 

### Testcase

- Verify that if there is a record (status=running, etc.) that cannot be deleted by the following operation, an error is displayed on the frontend.
  - [x] Delete record
  - [x] Delete multiple records
