### PR TITLE
Supports automatic completion of workflow

### DIFF
--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -11,6 +11,7 @@ from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import get_pickle_file, join_filepath
 from studio.app.common.core.workflow.workflow import Edge, Node
+from studio.app.common.core.workflow.workflow_result import WorkflowResult
 from studio.app.common.core.workspace.workspace_data_capacity_services import (
     WorkspaceDataCapacityService,
 )
@@ -36,6 +37,10 @@ def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
 def _snakemake_execute_process(
     workspace_id: str, unique_id: str, params: SmkParam
 ) -> bool:
+    # ------------------------------------------------------------
+    # Snakemake execution process
+    # ------------------------------------------------------------
+
     smk_logger = SmkStatusLogger(workspace_id, unique_id)
     smk_workdir = join_filepath(
         [
@@ -61,9 +66,17 @@ def _snakemake_execute_process(
     else:
         logger.error("snakemake_execute failed..")
 
-    WorkspaceDataCapacityService.update_experiment_data_usage(workspace_id, unique_id)
-
     smk_logger.clean_up()
+
+    # ------------------------------------------------------------
+    # Snakemake execution post process
+    # ------------------------------------------------------------
+
+    # Update workflow processing results
+    WorkflowResult(workspace_id, unique_id).observe_overall()
+
+    # Data usage calculation
+    WorkspaceDataCapacityService.update_experiment_data_usage(workspace_id, unique_id)
 
     return result
 

--- a/studio/app/common/core/utils/pickle_handler.py
+++ b/studio/app/common/core/utils/pickle_handler.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import traceback
+from glob import glob
 
 from studio.app.common.core.utils.filepath_creater import (
     create_directory,
@@ -13,6 +14,16 @@ class PickleReader:
     def read(cls, filepath):
         with open(filepath, "rb") as f:
             return pickle.load(f)
+
+    @classmethod
+    def search_node_pickle_path(cls, search_path: str) -> str:
+        paths = list(
+            set(glob(join_filepath([search_path, "*.pkl"])))
+            - set(glob(join_filepath([search_path, "tmp_*.pkl"])))
+        )
+        path = paths[0] if paths else None
+
+        return path
 
     @staticmethod
     def check_is_valid_node_pickle(data):

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -68,13 +68,13 @@ class WorkflowResult:
         )
 
         # check workflow status
-        is_workflow_status_running = self.__is_workflow_status_running(
+        is_workflow_observation_ongoing = self.__is_workflow_observation_ongoing(
             observe_node_ids, node_results
         )
 
-        # If the workflow status is running (workflow is incomplete),
+        # If the workflow status observation is ongoing (maybe workflow is incomplete),
         # check whether the actual process exists.
-        if is_workflow_status_running:
+        if is_workflow_observation_ongoing:
             # check workflow process exists
             current_process = self.monitor.search_process()
 
@@ -90,6 +90,17 @@ class WorkflowResult:
             )
 
         return node_results
+
+    def observe_overall(self) -> Dict[str, Message]:
+        """
+        Automatically observe all nodes
+        """
+        expt_config = ExptConfigReader.read(self.workspace_id, self.unique_id)
+
+        # Observe all nodes
+        observe_node_ids = expt_config.function.keys()
+
+        return self.observe(observe_node_ids)
 
     def __observe_nodes(
         self,
@@ -136,22 +147,22 @@ class WorkflowResult:
 
         return node_results
 
-    def __is_workflow_status_running(
+    def __is_workflow_observation_ongoing(
         self, observe_node_ids: List[str], messages: Dict[str, Message]
     ) -> bool:
         """
-        By comparing the number of nodeIdList waiting for processing completion
-        with the number of nodeIdList that has completed processing immediately before,
-        is_running is determined.
+        By comparing the number of observe_node_ids waiting for processing completion
+        with the number of observe_node_ids that has completed processing immediately
+        before, is_running is determined.
         """
-        is_running = len(observe_node_ids) != len(messages.keys())
+        is_ongoing = len(observe_node_ids) != len(messages.keys())
 
         # logger.debug(
-        #     "check wornflow running status "
-        #     f"[{self.workspace_id}/{self.unique_id}] [is_running: {is_running}]"
+        #     "check wornflow ongoing status "
+        #     f"[{self.workspace_id}/{self.unique_id}] [is_ongoing: {is_ongoing}]"
         # )
 
-        return is_running
+        return is_ongoing
 
     def __check_has_whole_nwb(self, node_id=None) -> None:
         nwb_filepath_list = glob(join_filepath([self.workflow_dirpath, "*.nwb"]))

--- a/studio/tests/app/common/core/workflow/test_workflow_result.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_result.py
@@ -43,7 +43,7 @@ def test_NodeResult_get():
         workspace_id=workspace_id,
         unique_id=unique_id,
         node_id="func1",
-        pickle_filepath=pickle_path,
+        node_pickle_path=pickle_path,
     ).observe()
 
     assert isinstance(output, Message)

--- a/studio/tests/app/common/core/workflow/test_workflow_result.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_result.py
@@ -1,8 +1,9 @@
 import os
 import shutil
 
+from studio.app.common.core.experiment.experiment import ExptFunction
 from studio.app.common.core.rules.runner import Runner
-from studio.app.common.core.workflow.workflow import Message
+from studio.app.common.core.workflow.workflow import Message, NodeRunStatus
 from studio.app.common.core.workflow.workflow_result import NodeResult, WorkflowResult
 from studio.app.dir_path import DIRPATH
 
@@ -39,11 +40,19 @@ def test_WorkflowResult_get():
 
 def test_NodeResult_get():
     assert os.path.exists(pickle_path)
+
+    expt_function = ExptFunction(
+        unique_id=unique_id,
+        name=node_id_list[0],
+        success=NodeRunStatus.RUNNING.value,
+        hasNWB=False,
+    )
+
     output = NodeResult(
         workspace_id=workspace_id,
         unique_id=unique_id,
         node_id="func1",
         node_pickle_path=pickle_path,
-    ).observe()
+    ).observe(expt_function)
 
     assert isinstance(output, Message)

--- a/studio/tests/app/common/core/workflow/test_workflow_result.py
+++ b/studio/tests/app/common/core/workflow/test_workflow_result.py
@@ -10,11 +10,12 @@ from studio.app.dir_path import DIRPATH
 workspace_id = "default"
 unique_id = "result_test"
 node_id_list = ["func1", "func2"]
+node_1st = node_id_list[0]
 
 workflow_dirpath = f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}"
 output_dirpath = f"{DIRPATH.OUTPUT_DIR}/{workspace_id}/{unique_id}"
 pickle_path = (
-    f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}/func1/func1.pkl"
+    f"{DIRPATH.DATA_DIR}/output_test/{workspace_id}/{unique_id}/{node_1st}/func1.pkl"
 )
 
 
@@ -43,7 +44,7 @@ def test_NodeResult_get():
 
     expt_function = ExptFunction(
         unique_id=unique_id,
-        name=node_id_list[0],
+        name=node_1st,
         success=NodeRunStatus.RUNNING.value,
         hasNWB=False,
     )
@@ -51,8 +52,7 @@ def test_NodeResult_get():
     output = NodeResult(
         workspace_id=workspace_id,
         unique_id=unique_id,
-        node_id="func1",
-        node_pickle_path=pickle_path,
+        node_id=node_1st,
     ).observe(expt_function)
 
     assert isinstance(output, Message)


### PR DESCRIPTION
### Content

現時点のoptinist (v2.2) では、Workflow実行の完了処理は、client(browser) からの完了確認リクエスト（`POST /run/result`）を経由し行われている。 その仕様のため、以下のような課題が存在していた。
```
clientからの完了確認リクエストが届かなかった場合（browserを閉じた場合など）、workflowの最終完了処理が実施されない
```

このPRでは、上記の課題への対策を行っている。

#### Countermeasure

- Workflow完了処理（WorkflowResult）をrefactoring
  - Workflowの実行プロセス（snakemake_execute）からも、上記 完了処理をcall可能とした
  - 上記の対応に関連する、細かなコード修正の適用

### Testcase

#### Testcases

- 期待結果（全テストケース共通）
  - Workflowが正常に終了する。ログにもExceptionがないこと
  - experiment.yaml のファイル内容を確認する (Finder など Filter から)
    - ステータスが終了となっていること
      - 正常Worflowケース … `success=success`
      - エラーWorflowケース … `success=error`
    - 修正前のバージョンと、変動値（ID, 時刻, data_usage）以外は、差異がないこと
  - experiment.yamlの確認完了後、対象のRecordを、Record Screenから確認する
    - ステータスが終了となっていること

##### 1. browserからの完了確認と、workflow process からの完了確認が、同時に発生するケース

- [x] 正常Worflowケース
  - 手順
    1. Tutorial 1を利用
    2. Workflowを開始
    3. ブラウザはそのまま
    4. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認
- [x] エラーWorflowケース
  - 手順
    1. Tutorial 1を利用
    2. Workflowでエラーが発生するように設定
        - `suite2p_registration > Param > I/O > frames_include = 0` など
    3. Workflowを開始
    4. ブラウザはそのまま
    5. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認

##### 2. workflow process からの完了確認のみが、実行されるケース

- [x] 正常Worflowケース
  - 手順
    1. Tutorial 1を利用
    2. Workflowを開始
    3. 直後、ブラウザのタブを閉じる
    4. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認
- [x] エラーWorflowケース
  - 手順
    1. Tutorial 1を利用
    2. Workflowでエラーが発生するように設定
        - `suite2p_registration > Param > I/O > frames_include = 0` など
    3. Workflowを開始
    4. 直後、ブラウザのタブを閉じる
    5. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認

##### 3. 大きめのWorkflowの動作確認

- [x] 正常Worflowケース
  - 手順
    1. 以下のworkflowを利用
        - #795 
        - `snakemake cores=8, suite2p_roi*8`
    2. Workflowを開始
    3. ブラウザはそのまま
    4. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認
- [x] エラーWorflowケース
  - 手順
    1. 以下のworkflowを利用
        - #795 
        - `snakemake cores=8, suite2p_roi*8`
    2. Workflow でエラーが発生するように設定
        - `suite2p_registration > Param > I/O > frames_include = 0` など
    3. Workflowを開始
    4. ブラウザはそのまま
    5. Workflow が終了
  - 期待結果
    - [x] 「期待結果（全テストケース共通）」の確認

#### Platformas

上記の Testcases を、以下のPlatformas分 確認する

- Native
  - [x] Mac or Linux
  - [x] Windows
- [x] Docker
