### PR TITLE
Create NWB if not present, allows saving of file_converter settings t…

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -186,6 +186,9 @@ class Runner:
         try:
             # Initialize CONFIG dictionary structure
             function_id = ExptOutputPathIds(output_dir).function_id
+            if "nwbfile" not in output_info:
+                output_info["nwbfile"] = {}
+
             if NWBDATASET.CONFIG not in output_info["nwbfile"]:
                 output_info["nwbfile"][NWBDATASET.CONFIG] = {}
             if function_id not in output_info["nwbfile"][NWBDATASET.CONFIG]:


### PR DESCRIPTION
### Content
Update to create the NWB file if not created, to allow for storage of config. This only effected suite2p_convert as this file did not create an nwb file during the output, which resulted in issue not saving parameters and this warning

> 2025-06-10 17:40:01,070 WARNING:  [optinist] (50703) __execute_function():194 - Failed to initialize CONFIG dataset forsuite2p_registration_xq4pexs8o7:'nwbfile'
> 2025-06-10 17:40:01,079 INFO:     [optinist] (50703) __execute_function():208 - Failed to add conda environment config to NWB file: 'nwbfile'
> 2025-06-10 17:40:01,080 WARNING:  [optinist] (50703) __execute_function():217 - Failed to add node parameters to NWB file: 'nwbfile'


### Testcase

- [ ] Tutorial 1
Check log to see warning disappear
Check NWB before and after change to see the addition of suite2p_convert to processing/config

- [ ] Tutorial 2: no change from normal

