### PR TITLE
Added version info module

### DIFF
--- a/studio/app/optinist/core/nwb/nwb_spec_utils.py
+++ b/studio/app/optinist/core/nwb/nwb_spec_utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 import time
 from typing import List, Union
 
@@ -8,6 +7,7 @@ from pynwb.spec import NWBGroupSpec, NWBNamespaceBuilder
 
 from studio.app.common.core.utils.filelock_handler import FileLockUtils
 from studio.app.dir_path import DIRPATH
+from studio.app.version import Version
 
 NWB_SPEC_FILE_EXPORT_DIR = os.path.join(os.path.dirname(__file__), "specs")
 root_dir = DIRPATH.ROOT_DIR
@@ -46,7 +46,7 @@ def export_spec_files(
         if (not os.path.exists(ns_path)) or (
             flle_update_elapsed_time > file_cache_interval
         ):
-            current_version = get_version_from_pyproject()
+            current_version = Version.APP_VERSION
             ns_builder = NWBNamespaceBuilder(
                 f"{ns_name} extensions", ns_name, version=current_version
             )
@@ -75,21 +75,3 @@ def export_spec_files(
             finally:
                 # Return current directory
                 os.chdir(previous_dir)
-
-
-def get_version_from_pyproject() -> str:
-    """Extract version from pyproject.toml."""
-    # Look for pyproject.toml in parent directories
-    pyproject_path = os.path.join(root_dir, "pyproject.toml")
-
-    # Read and parse the version from pyproject.toml
-    with open(pyproject_path, "r") as f:
-        content = f.read()
-
-    # Use regex to extract version
-    version_match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
-    if version_match:
-        version = version_match.group(1)
-        return version
-    else:
-        return "2.0.0"

--- a/studio/app/version.py
+++ b/studio/app/version.py
@@ -1,0 +1,26 @@
+import os
+import re
+
+from studio.app.dir_path import DIRPATH
+
+
+def get_app_version_from_pyproject() -> str:
+    """Extract version from pyproject.toml."""
+    # Look for pyproject.toml in parent directories
+    pyproject_path = os.path.join(DIRPATH.ROOT_DIR, "pyproject.toml")
+
+    # Read and parse the version from pyproject.toml
+    with open(pyproject_path, "r") as f:
+        content = f.read()
+
+    # Use regex to extract version
+    version_match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+    if version_match:
+        version = version_match.group(1)
+        return version
+    else:
+        return "1.0.0"
+
+
+class Version:
+    APP_VERSION = get_app_version_from_pyproject()


### PR DESCRIPTION
### Content

Added optinist(backend) version information acquisition module

### Testcase

- [x] Check the operation at the version information acquisition point (export_spec_files)
  1. Run the target script
      ```
      conda activate {your-optinist-env}
      python studio/app/optinist/core/nwb/specs/export_spec_files.py
      ```
  2. Verify that the version information of pyproject.toml is recorded in the processing result file.
      - optinist.namespace.yaml
        `version: x.x.x`
