### PR TITLE
Apply some tweaks (Adjusted logging, etc)

### DIFF
--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -35,14 +35,29 @@ from studio.app.common.routers import (
 )
 from studio.app.dir_path import DIRPATH
 from studio.app.optinist.routers import hdf5, mat, nwb, roi
+from studio.app.version import Version
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Startup event
+    """
+    Startup event
+    """
+    import platform
+    import sys
+
+    sys_version = sys.version.replace("\n", " ")
     mode = "standalone" if MODE.IS_STANDALONE else "multiuser"
+
     logger = AppLogger.get_logger()
-    logger.info(f'"Studio" application startup complete. [mode: {mode}]')
+    logger.info(
+        f'"Studio" application startup complete.\n'
+        f"    # Platform: {platform.platform()}\n"
+        f"    # Python Version: {sys_version}\n"
+        f"    # App Version: {Version.APP_VERSION}\n"
+        f"    # Env:DATA_DIR: {DIRPATH.DATA_DIR}\n"
+        f"    # Mode: {mode}\n"
+    )
 
     yield
 


### PR DESCRIPTION
### Content

Apply some tweaks.

1. Adjusted app startup logging
    - Example
      ```
      2025-06-17 12:53:19 2025-06-17 12:53:19,160 INFO:     [optinist] (310) lifespan():53 - "Studio" application startup complete.
      2025-06-17 12:53:19     # Platform: Linux-6.10.14-linuxkit-x86_64-with-glibc2.36
      2025-06-17 12:53:19     # Python Version: 3.9.21 (main, Apr  8 2025, 01:36:10)  [GCC 12.2.0]
      2025-06-17 12:53:19     # App Version: 2.2.0
      2025-06-17 12:53:19     # Env:DATA_DIR: /app/studio_data
      2025-06-17 12:53:19     # Mode: multiuser
      ```

2. The small size sample image data has been made a little larger.
    - *so that an error does not occur in the tutorial workflow.

### Testcase

1. Adjusted app startup logging
    - [x] The log at backend startup is output in the sample format.

2. The small size sample image data has been made a little larger.
    - [x] Each ROI node (suite2p_roi, caiman_cnmf, lccd) is successfully processed using sample data.
