### PR TITLE
Update run_cluster

### DIFF
--- a/docs/other/cli_execution.md
+++ b/docs/other/cli_execution.md
@@ -1,7 +1,7 @@
 (cli-execution)=
 CLI Usage
 =================
-This section describes how to run a workflow created in GUI on a cluster or in Command Line Interface (CLI).
+This section describes how to run a workflow created in GUI on a cluster or in Command Line Interface (CLI), such as Terminal.
 
 - [CLI execution](#cli-execution)
   - [1. Config file settings](#1-config-file-settings)
@@ -28,7 +28,7 @@ Input files are stored under `/{OPTINIST_DIR}/input/`.
 For example, if there is `mouse_123.tiff`, it is stored as `/{OPTINIST_DIR}/input/mouse_123.tiff`.
 
 ## 4. Execution
-It can be executed in CLI by running `run_cluster.py`.
+It can be executed in the CLI by running `run_cluster.py`.
 
 The parameter arguments are as follows.
 - **config** [string, required]: Path of config.yaml file set in step 1

--- a/docs/other/cli_execution.md
+++ b/docs/other/cli_execution.md
@@ -1,9 +1,9 @@
-(cui-execution)=
-Cluster Usage
+(cli-execution)=
+CLI Usage
 =================
-This section describes how to run a workflow created in GUI on a cluster or in CUI.
+This section describes how to run a workflow created in GUI on a cluster or in Command Line Interface (CLI).
 
-- [CUI execution](#cui-execution)
+- [CLI execution](#cli-execution)
   - [1. Config file settings](#1-config-file-settings)
   - [2. Set environment variables for save paths](#2-set-environment-variables-for-save-paths)
   - [3. Input File Settings](#3-input-file-settings)
@@ -11,8 +11,9 @@ This section describes how to run a workflow created in GUI on a cluster or in C
   - [5.Output result](#5output-result)
 
 ## 1. Config File Settings
-Place the config file required by Snakemake at the appropriate location.
-The config file can be downloaded from **Record** on the GUI.
+Config files can be downloaded from **Record** on the GUI.
+Config files may be edited, such as duplicating and changing parameters.
+Place the config file required by Snakemake in the desired location for running with the CLI.
 
 ## 2. Set Environment Variables for Save Paths
 Change environment variables. Change the environment variable as follows, because the default setting refers to the directory under `/tmp/studio`.
@@ -24,21 +25,20 @@ With environment variables set, input refers to `{OPTINIST_DIR}/input/` and resu
 
 ## 3. Input File Settings
 Input files are stored under `/{OPTINIST_DIR}/input/`.
-For example, if there is `mouse2p_2_donotouse.tiff`, it is stored as `/{OPTINIST_DIR}/input/mouse2p_2_donotouse.tiff`.
+For example, if there is `mouse_123.tiff`, it is stored as `/{OPTINIST_DIR}/input/mouse_123.tiff`.
 
 ## 4. Execution
-It can be executed in CUI by running `run_cluster.py`.
+It can be executed in CLI by running `run_cluster.py`.
 
 The parameter arguments are as follows.
-- config(string): path of config.yaml file set in step 1
-- cores(int): Specifies the number of CPU cores. (default: 2, cores >= 2)
-- forceall(bool): Whether to overwrite existing results or not. (default: false)
-- use_conda(bool): Whether to use the conda virtual environment or not. If not, it is necessary to have caiman, suite2p, etc. INSTALL the current environment into the execution environment.
-
+- **config** [string, required]: Path of config.yaml file set in step 1
+- **cores** [int, optional, default: 2]: Specifies the number of CPU cores.
+- **forceall** [bool, optional, default: false]: Whether to overwrite existing results or not.
+- **use_conda** [bool, optional, default: true]: Whether to use the conda virtual environment or not. If not, it is necessary to have caiman, suite2p, etc. installed in the execution environment.
 
 The command executes the following
 ```bash
-python run_cluster.py --config="{config.yaml file path}"
+python run_cluster.py --config="{snakemake.yaml file path}"
 ```
 
 ## 5.Output Result

--- a/docs/other/index.rst
+++ b/docs/other/index.rst
@@ -7,5 +7,5 @@ Other
   :caption: OTHER:
 
   host_for_multiuser/index
-  cui_execution
+  cli_execution
   debugging

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -19,17 +19,26 @@ def main(args):
 
         config_file_path = None
 
-        if args.config is not None:
-            if args.config.endswith(".yml") or args.config.endswith(".yaml"):
-                if not Path(args.config).exists():
-                    raise FileNotFoundError(f"Config file not found: {args.config}")
+        if args.config is None:
+            raise FileNotFoundError(
+                "Please provide snakemake file path --config='my/path/snakemake.yaml'"
+            )
+
+        else:
+            if not (args.config.endswith(".yml") or args.config.endswith(".yaml")):
                 config_file_path = join_filepath(
-                    [str(temp_workdir), DIRPATH.SNAKEMAKE_CONFIG_YML]
+                    [args.config, DIRPATH.SNAKEMAKE_CONFIG_YML]
                 )
-                shutil.copyfile(args.config, config_file_path)
-                print(f"Config file copied from {args.config} to {config_file_path}")
             else:
-                print(f"Please provide a valid YAML config file, got: {args.config}")
+                config_file_path = args.config
+            if not Path(config_file_path).exists():
+                raise FileNotFoundError(f"Config file not found: {args.config}")
+
+            shutil.copyfile(
+                config_file_path,
+                join_filepath([str(temp_workdir), str(Path(config_file_path).name)]),
+            )
+            print(f"Config file copied from {config_file_path} to {temp_workdir}")
 
         snakemake_args = {
             "snakefile": DIRPATH.SNAKEMAKE_FILEPATH,

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 import shutil
+import tempfile
+from pathlib import Path
 
 from snakemake import snakemake
 
@@ -9,27 +11,74 @@ from studio.app.dir_path import DIRPATH
 
 
 def main(args):
-    # copy config file
-    if args.config is not None:
-        shutil.copyfile(
-            args.config,
-            join_filepath([DIRPATH.STUDIO_DIR, DIRPATH.SNAKEMAKE_CONFIG_YML]),
-        )
+    # Create a temporary directory for snakemake execution
+    # Output files saved to config file path
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_workdir = Path(temp_dir)
+        print(f"Temporary work directory created at: {temp_workdir}")
 
-    snakemake(
-        DIRPATH.SNAKEMAKE_FILEPATH,
-        forceall=args.forceall,
-        cores=args.cores,
-        use_conda=args.use_conda,
-        workdir=f"{os.path.dirname(DIRPATH.STUDIO_DIR)}",
-    )
+        config_file_path = None
+
+        if args.config is not None:
+            if args.config.endswith(".yml") or args.config.endswith(".yaml"):
+                if not Path(args.config).exists():
+                    raise FileNotFoundError(f"Config file not found: {args.config}")
+                config_file_path = join_filepath(
+                    [str(temp_workdir), DIRPATH.SNAKEMAKE_CONFIG_YML]
+                )
+                shutil.copyfile(args.config, config_file_path)
+                print(f"Config file copied from {args.config} to {config_file_path}")
+            else:
+                source_config_path = join_filepath(
+                    [args.config, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                )
+                if not Path(source_config_path).exists():
+                    raise FileNotFoundError(
+                        f"Config file not found: {source_config_path}"
+                    )
+                config_file_path = join_filepath(
+                    [str(temp_workdir), DIRPATH.SNAKEMAKE_CONFIG_YML]
+                )
+                shutil.copyfile(source_config_path, config_file_path)
+                print(f"Config copied from {source_config_path} to {config_file_path}")
+
+            print(f"Config file copied to temporary directory: {temp_workdir}")
+
+        snakemake_args = {
+            "snakefile": DIRPATH.SNAKEMAKE_FILEPATH,
+            "forceall": args.forceall,
+            "cores": args.cores,
+            "use_conda": args.use_conda,
+            "workdir": f"{os.path.dirname(DIRPATH.STUDIO_DIR)}",
+        }
+
+        if config_file_path is not None:
+            snakemake_args["configfiles"] = [str(config_file_path)]
+
+        if args.use_conda:
+            snakemake_args["conda_prefix"] = DIRPATH.SNAKEMAKE_CONDA_ENV_DIR
+
+        print(f"Snakemake arguments: {snakemake_args}")
+
+        result = snakemake(**snakemake_args)
+
+        if result:
+            print("snakemake execution succeeded.")
+        else:
+            print("snakemake execution failed.")
+
+        return result
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="optinist")
     parser.add_argument("--cores", type=int, default=2)
-    parser.add_argument("--forceall", action="store_true")
-    parser.add_argument("--use_conda", action="store_true")
+    parser.add_argument(  # Default true, use --no-forceall to disable forceall
+        "--forceall", default=True, action=argparse.BooleanOptionalAction
+    )
+    parser.add_argument(  # Default true, use --no-use_conda to disable conda usage
+        "--use_conda", default=True, action=argparse.BooleanOptionalAction
+    )
     parser.add_argument("--config", type=str, default=None)
 
     main(parser.parse_args())

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -11,7 +11,7 @@ from studio.app.dir_path import DIRPATH
 
 
 def main(args):
-    # Create a temporary directory for snakemake execution
+    # Temp dir for snakemake config in case of permission errors on cluster.
     # Output files saved to config file path
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_workdir = Path(temp_dir)
@@ -29,20 +29,7 @@ def main(args):
                 shutil.copyfile(args.config, config_file_path)
                 print(f"Config file copied from {args.config} to {config_file_path}")
             else:
-                source_config_path = join_filepath(
-                    [args.config, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                )
-                if not Path(source_config_path).exists():
-                    raise FileNotFoundError(
-                        f"Config file not found: {source_config_path}"
-                    )
-                config_file_path = join_filepath(
-                    [str(temp_workdir), DIRPATH.SNAKEMAKE_CONFIG_YML]
-                )
-                shutil.copyfile(source_config_path, config_file_path)
-                print(f"Config copied from {source_config_path} to {config_file_path}")
-
-            print(f"Config file copied to temporary directory: {temp_workdir}")
+                print(f"Please provide a valid YAML config file, got: {args.config}")
 
         snakemake_args = {
             "snakefile": DIRPATH.SNAKEMAKE_FILEPATH,


### PR DESCRIPTION

### Content
Update run_cluster with 
- error handling, 
  - Inputs now accept folder path or file path
  - Errors in input cause error message
- temp dir usage
  - Previously snakemake.yaml file was left remaining in studio folder
- default flags on
  - use_conda needed to be turned on, however, this should be default 

### Testcase
Delete any output data folders in  `/tmp/studio/output/1/tutorial1`
run
`python run_cluster.py --config=/tmp/studio/output/1/tutorial1/snakemake.yaml`

-----------------------------------------------------------------------
### Documentation should be updated to reflect change in flag usage
