### PR TITLE
Make BaseData class abstract

### DIFF
--- a/studio/app/common/dataclass/base.py
+++ b/studio/app/common/dataclass/base.py
@@ -1,13 +1,15 @@
 import gc
+from abc import ABC, abstractmethod
 from typing import Optional
 
 from studio.app.common.core.workflow.workflow import OutputPath
 
 
-class BaseData:
+class BaseData(ABC):
     def __init__(self, file_name):
         self.file_name = file_name
 
+    @abstractmethod
     def save_json(self, json_dir):
         pass
 

--- a/studio/app/optinist/dataclass/iscell.py
+++ b/studio/app/optinist/dataclass/iscell.py
@@ -5,3 +5,6 @@ class IscellData(BaseData):
     def __init__(self, data, file_name="iscell"):
         super().__init__(file_name)
         self.data = data
+
+    def save_json(self, json_dir):
+        pass

--- a/studio/app/optinist/dataclass/microscope.py
+++ b/studio/app/optinist/dataclass/microscope.py
@@ -13,6 +13,9 @@ class MicroscopeData(BaseData):
         self.path = path
         self.json_path = None
 
+    def save_json(self, json_dir):
+        pass
+
     @property
     def reader(self):
         ext = os.path.splitext(self.path)[1]

--- a/studio/app/optinist/dataclass/roi.py
+++ b/studio/app/optinist/dataclass/roi.py
@@ -69,6 +69,9 @@ class EditRoiData(BaseData):
         self.merge_roi = []
         self.delete_roi = []
 
+    def save_json(self, json_dir):
+        pass
+
     @property
     def temp_merge_roi_list(self) -> list:
         merge_roi = [(k, *v, -1.0) for k, v in self.temp_merge_roi.items()]


### PR DESCRIPTION
### Content

Explicitly abstract dataclass.BaseData.

In the PR below, there are cases where BaseClass is defined as an argument type (Generic, Any type), but this PR clearly defines that BaseClass is abstract (template).
- #809

### Testcase

- Platform: Any Platform
- Testcases
  - [x] Run Tutorial 1
  - [x] Run Tutorial 2
  - [x] Run Tutorial 3
  - [x] Run Edit Roi
  - [x] Run microscope node