### PR TITLE
Snakemake unused params

### DIFF
--- a/studio/app/common/core/snakemake/smk.py
+++ b/studio/app/common/core/snakemake/smk.py
@@ -34,6 +34,7 @@ class SmkParam:
     use_conda: bool
     cores: int
     forceall: bool
-    forcetargets: bool
-    lock: bool
+    # These are currently (v2.3.0) not used, but kept for future compatibility
+    # forcetargets: bool
+    # lock: bool
     forcerun: List[ForceRun] = field(default_factory=list)

--- a/studio/app/common/core/snakemake/snakemake_reader.py
+++ b/studio/app/common/core/snakemake/snakemake_reader.py
@@ -30,9 +30,9 @@ class SmkParamReader:
             use_conda=params["use_conda"],
             cores=params["cores"],
             forceall=params["forceall"],
-            forcetargets=params["forcetargets"],
-            lock=params["lock"],
             forcerun=params["forcerun"] if "forcerun" in params else [],
+            # forcetargets=params["forcetargets"],
+            # lock=params["lock"],
         )
 
 

--- a/studio/app/common/schemas/params.py
+++ b/studio/app/common/schemas/params.py
@@ -5,5 +5,6 @@ class SnakemakeParams(BaseModel):
     use_conda: bool
     cores: int
     forceall: bool
-    forcetargets: bool
-    lock: bool
+    # These are currently (v2.3.0) not used, but kept for future compatibility
+    # forcetargets: bool
+    # lock: bool

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py
@@ -26,8 +26,8 @@ smk_param = SmkParam(
     use_conda=True,
     cores=2,
     forceall=True,
-    forcetargets=True,
-    lock=False,
+    # forcetargets=True,
+    # lock=False,
 )
 
 shutil.copytree(

--- a/studio/tests/app/common/core/snakemake/test_snakemake_executor_suite2p.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_executor_suite2p.py
@@ -26,8 +26,8 @@ smk_param = SmkParam(
     use_conda=True,
     cores=2,
     forceall=True,
-    forcetargets=True,
-    lock=False,
+    # forcetargets=True,
+    # lock=False,
 )
 
 shutil.copytree(

--- a/studio/tests/app/common/core/snakemake/test_snakemake_reader.py
+++ b/studio/tests/app/common/core/snakemake/test_snakemake_reader.py
@@ -28,8 +28,8 @@ smk_config = {
     "use_conda": False,
     "cores": 2,
     "forceall": True,
-    "forcetargets": True,
-    "lock": False,
+    # "forcetargets": True,
+    # "lock": False,
 }
 
 


### PR DESCRIPTION
### Content
Currently **forcetargets** and **lock** are empty parameters. These are not used in OptiNiSt. This is confusing for users and developers. Therefore until these parameters are implemented, they should be commented out. 

forcetargets could maybe have some use cases
-  if the user is able to input List[ForceRun], however, currently this is not possible. Then the user could select which nodes should always be run, regardless of whether there is a result data or not. 
- For developers maybe.

By default "lock" is set to True. Deep wiki says:
> The locking mechanism is essential for preventing data corruption and race conditions when multiple Snakemake processes might access the same files. It's recommended to only disable locking (--nolock) when you're certain no other Snakemake instances are running on the same directory.

It is unclear if there is a use case for setting --nolock. However, currently the "lock" parameter is not implemented, and is on by default. 

### Testcase
https://docs.google.com/spreadsheets/d/1oPqm7X5bCOZKW1EeOAOJYLRizX9lcHcM/edit?gid=1111313687#gid=1111313687
