### PR TITLE
Runner improvements for data manipulators (#2)

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -264,10 +264,23 @@ class Runner:
         merged_nwb = {}
 
         for return_arg_key, arg_name in rule_config.return_arg.items():
-            return_name, function_id = return_arg_key.split(
-                SmkRule.RETURN_ARG_KEY_DELIMITER
-            )
-            single_input_info = orig_input_info[function_id]
+            # RETURN_ARG_KEY includes key delimiter (standard)
+            if SmkRule.RETURN_ARG_KEY_DELIMITER in return_arg_key:
+                return_name, function_id = return_arg_key.split(
+                    SmkRule.RETURN_ARG_KEY_DELIMITER
+                )
+
+                # Get input_info corresponding to function_id
+                single_input_info = orig_input_info[function_id]
+            # RETURN_ARG_KEY does not include a delimiter (old version: v2.3 or earlier)
+            else:
+                return_name, function_id = (return_arg_key, None)
+
+                # Merge input_info for all function_ids
+                single_input_info = {}
+                for tmp_value in orig_input_info.values():
+                    single_input_info.update(tmp_value)
+                del tmp_value
 
             if return_name in single_input_info:
                 # Rename the key of the matching element and store it again

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -9,7 +9,7 @@ from studio.app.const import FILETYPE
 
 
 class SmkRule:
-    RETURN_ARG_KEY_DELIMITER = ":"
+    RETURN_ARG_KEY_DELIMITER = "@"
 
     def __init__(
         self,


### PR DESCRIPTION
### Content

- Runner improvements for data manipulators
  - Additional support for #878

- Contents
    - Changed delimiter of return_arg key
    - Support old version of return_arg key


### Testcase

*Same as test case #878
