### PR TITLE
Improve runner parameter passing

### DIFF
--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -40,24 +40,24 @@ class Runner:
         try:
             logger.info("start rule runner")
 
-            # write pid file
+            # Write pid file
             workflow_dirpath = str(Path(__rule.output).parent.parent)
             cls.write_pid_file(workflow_dirpath, __rule.type, run_script_path)
 
-            # read & construct input_info
+            # Read & construct input_info
             orig_input_info = cls.__read_input_info(__rule.input)
             input_info = cls.__align_input_info_content_keys(orig_input_info, __rule)
             del orig_input_info
 
             nwbfile = input_info["nwbfile"]
 
-            # construct input_info
+            # Construct input_info
             # - Remove data that will not be used later here
             for key in list(input_info):
                 if key not in __rule.return_arg.values():
                     input_info.pop(key)
 
-            # construct output_info
+            # Construct output_info
             output_info = cls.__execute_function(
                 __rule.path,
                 __rule.params,
@@ -66,7 +66,7 @@ class Runner:
                 input_info,
             )
 
-            # nwbfileの設定
+            # Save NWB data of Function(Node)
             output_info["nwbfile"] = cls.__save_func_nwb(
                 f"{__rule.output.split('.')[0]}.nwb",
                 __rule.type,
@@ -74,18 +74,18 @@ class Runner:
                 output_info,
             )
 
-            # 各関数での結果を保存
+            # Save the processing result of the Function(Node) (.pkl)
             PickleWriter.write(__rule.output, output_info)
 
-            # NWB全体保存
+            # Save NWB data through Workflow
             if __rule.output in last_output:
-                # 全体の結果を保存する
                 path = join_filepath(os.path.dirname(os.path.dirname(__rule.output)))
                 path = join_filepath([path, "whole.nwb"])
                 cls.save_all_nwb(path, output_info["nwbfile"])
 
             logger.info("rule output: %s", __rule.output)
 
+            # Free up resources
             del input_info, output_info
             gc.collect()
 

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -264,10 +264,23 @@ class Runner:
         merged_nwb = {}
 
         for return_arg_key, arg_name in rule_config.return_arg.items():
-            return_name, function_id = return_arg_key.split(
-                SmkRule.RETURN_ARG_KEY_DELIMITER
-            )
-            single_input_info = orig_input_info[function_id]
+            # RETURN_ARG_KEY includes key delimiter (standard)
+            if SmkRule.RETURN_ARG_KEY_DELIMITER in return_arg_key:
+                return_name, function_id = return_arg_key.split(
+                    SmkRule.RETURN_ARG_KEY_DELIMITER
+                )
+
+                # Get input_info corresponding to function_id
+                single_input_info = orig_input_info[function_id]
+            # RETURN_ARG_KEY does not include a delimiter (old version: v2.3 or earlier)
+            else:
+                return_name, function_id = (return_arg_key, None)
+
+                # Merge input_info for all function_ids
+                single_input_info = {}
+                for tmp_value in orig_input_info.values():
+                    single_input_info.update(tmp_value)
+                del tmp_value
 
             if return_name in single_input_info:
                 # Rename the key of the matching element and store it again

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -9,7 +9,7 @@ from studio.app.const import FILETYPE
 
 
 class SmkRule:
-    RETURN_ARG_KEY_DELIMITER = ":"
+    RETURN_ARG_KEY_DELIMITER = "@"
 
     def __init__(
         self,


### PR DESCRIPTION
### Content

In the existing workflow runner process, there was a flaw in which if multiple node parameters with the same name were entered into one node, the duplicated parameters would be overwritten. (Discovered in #809)

The solution to this problem was implemented in #820, but there were still cases that needed to be considered, so additional measures were added to #878 and #879.

In this PR, the contents of #878 and #879 will be ported to the common branch (develop-main).

### Testcase

- [x] Tutorial Workflow(1-3) works normally
- [x] Run Edit Roi works normally
- *The problem has already been verified in #809, so skip it
  (and the develop-main branch does not have the Node that causes the problem).