### PR TITLE
Improved error log handling in snakemake v9

### DIFF
--- a/studio/app/common/core/snakemake/smk_status_logger.py
+++ b/studio/app/common/core/snakemake/smk_status_logger.py
@@ -1,10 +1,6 @@
-import glob
 import logging
 import os
-from typing import Dict
 
-from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.rules.runner import Runner
 from studio.app.common.core.utils.file_reader import Reader
 from studio.app.common.core.utils.filepath_creater import (
     create_directory,
@@ -87,116 +83,8 @@ class SmkStatusLogger:
         self.unique_id = unique_id
         self.logger: logging.Logger = __class__.get_logger(workspace_id, unique_id)
 
-    def log_handler(self, msg: Dict[str, str] = None):
-        """
-        msg:
-            level:
-                "job_info": jobの始まりを通知。inputやoutputがある
-                "job_finished": jobの終了を通知。
-        """
-        # pass
-        # # has error.
-        # if "exception" in msg:
-        #     self.logger.error(msg)
-
-        # Inspect log contents
-        if "level" in msg and "debug" in msg["level"]:
-            level = msg["level"]
-            if "debug" in level and "msg" in msg:
-                # Inspects for error logs
-                if "Traceback" in msg["msg"]:
-                    # check if the message is thrown by killing process action
-                    if any(
-                        err in msg["msg"]
-                        for err in ["Signals.SIGTERM", "exit status 15"]
-                    ):
-                        pid_data = Runner.read_pid_file(
-                            self.workspace_id, self.unique_id
-                        )
-
-                        # since multiple running workflow share log data,
-                        # check if message really belongs to the current workflow
-                        if (
-                            pid_data is not None
-                            and pid_data.last_script_file in msg["msg"]
-                        ):
-                            self.logger.error("Workflow cancelled")
-                        else:
-                            self.logger.error(msg)
-
-                    # for any other errors
-                    else:
-                        self.logger.error(msg)
-
     def clean_up(self):
         """
         remove all handlers from this logger
         """
         self.logger.handlers.clear()
-
-    def extract_errors_from_snakemake_log(self, workdir: str):
-        """
-        Extract error information from Snakemake's log file and write to error.log
-        """
-
-        logger = AppLogger.get_logger()
-
-        try:
-            # Find the most recent Snakemake log file
-            log_pattern = os.path.join(workdir, ".snakemake", "log", "*.snakemake.log")
-            log_files = glob.glob(log_pattern)
-
-            if not log_files:
-                logger.warning("No Snakemake log files found")
-                return
-
-            # Check the log file for errors/tracebacks
-            latest_log = max(log_files, key=os.path.getctime)
-            logger.info(f"Reading Snakemake log file: {latest_log}")
-            with open(latest_log, "r") as f:
-                log_content = f.read()
-
-            # Look for traceback patterns that indicate errors
-            if "Traceback" in log_content or "Exception" in log_content:
-                # Extract only error-related sections
-                error_sections = self._extract_error_sections(log_content)
-
-                if error_sections:
-                    msg = {"level": "debug", "msg": error_sections}
-
-                    self.log_handler(msg)
-                    logger.info("Copied error sections from Snakemake log to error.log")
-                else:
-                    logger.info("No relevant error sections found after filtering")
-            else:
-                logger.info("No errors found in Snakemake log")
-
-        except Exception as e:
-            logger.error(f"Failed to extract errors from Snakemake log: {e}")
-
-    def _extract_error_sections(self, log_content: str) -> str:
-        """Extract error sections - much simpler approach"""
-        lines = log_content.split("\n")
-
-        # Find any line containing "Traceback"
-        for i, line in enumerate(lines):
-            if "Traceback" in line:
-                # Take everything from this point to start of non-error content
-                error_section = []
-                for j in range(i, len(lines)):
-                    current_line = lines[j]
-                    error_section.append(current_line)
-                    if (
-                        current_line.strip() == ""
-                        and j + 1 < len(lines)
-                        and lines[j + 1].strip()
-                        and not any(
-                            marker in lines[j + 1]
-                            for marker in ["Error in rule", "MissingOutputException"]
-                        )
-                    ):
-                        break
-
-                return "\n".join(error_section)
-
-        return ""  # No traceback found

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -83,30 +83,40 @@ def _snakemake_execute_process(
                 conda_prefix=DIRPATH.SNAKEMAKE_CONDA_ENV_DIR,
             ),
         )
+
         logger.info("Workflow API created successfully")
         logger.info("Creating DAG...")
 
         forceall = getattr(params, "forceall", False)
 
-        dag_settings = DAGSettings(
-            forceall=forceall,
+        dag_api = workflow_api.dag(
+            dag_settings=DAGSettings(
+                forceall=forceall,
+            )
         )
 
-        dag_api = workflow_api.dag(
-            dag_settings=dag_settings,
-        )
         logger.info("DAG created successfully")
         logger.info("Starting workflow execution...")
 
+        snakemake_result = False
+
         try:
             dag_api.execute_workflow()
-            result = True
+
+            snakemake_result = True
             logger.info("snakemake_execute succeeded.")
         except Exception as e:
-            result = False
+            snakemake_result = False
             logger.error(f"snakemake_execute failed: {e}")
-        finally:
-            smk_logger.extract_errors_from_snakemake_log(smk_workdir)
+
+            # Logging errors via SmkStatusLogger to notify
+            #   the monitoring process (WorkflowMonitor) of the error occurrence
+            smk_logger.logger.error(e)
+
+    if snakemake_result:
+        logger.info("snakemake_execute succeeded.")
+    else:
+        logger.error("snakemake_execute failed..")
 
     smk_logger.clean_up()
 
@@ -120,7 +130,7 @@ def _snakemake_execute_process(
     # Data usage calculation
     WorkspaceDataCapacityService.update_experiment_data_usage(workspace_id, unique_id)
 
-    return result
+    return snakemake_result
 
 
 def delete_dependencies(


### PR DESCRIPTION
### Content

Applying improvements to error log handling in snakemake version up
- Improved the part where error log was not output properly
- Deleted unnecessary code according to the above


### Testcase

- Normal Behavior
  - [x] Tutiroai 1
  - [x] Tutiroai 2

- Abnormal Behavior (the main test case for this PR)
  - [x] Snakemake layer error
    - Procedure: Losing input data ... Manually rename the input images just before running the workflow.
    - Expected: snakemake error is detected properly, and the following error is recorded in the first node (suite2p_file_conver).
      ```
      2025-07-24 xx:xx:xx,xxx : ERROR - snakemake_executor.py - Missing input files for rule input_ab1mmvt2ky:
          output: /app/studio_data/output/2/9140fa54/input_ab1mmvt2ky/sample_mouse2p_image.pkl
          affected files:
              /app/studio_data/input/2/sample_mouse2p_image.tiff
      ```
    - Note:
      - In previous versions (snakemake v7), error logs were recorded in JSON format, but in the updated version, they are recorded in normal text format as shown above.
  - [x] Wrapper Layer Error
    - Procedure: Generate an arbitrary error in the Wrapper ... `batch_size=0` in suite2p_file_convert, etc.
    - Expected: The error content is properly recorded in the target node

- Test platforms
  - [x] Mac Native
  - [x] Docker
