### PR TITLE
Fix for run_cluster using snakemake.yaml with nwb_template

### DIFF
--- a/run_cluster.py
+++ b/run_cluster.py
@@ -20,6 +20,7 @@ def main(args):
         print(f"Temporary work directory created at: {temp_workdir}")
 
         config_file_path = None
+        temp_config_file_path = None
 
         if args.config is None:
             raise FileNotFoundError(
@@ -36,11 +37,15 @@ def main(args):
             if not Path(config_file_path).exists():
                 raise FileNotFoundError(f"Config file not found: {args.config}")
 
-            shutil.copyfile(
-                config_file_path,
-                join_filepath([str(temp_workdir), str(Path(config_file_path).name)]),
+            temp_config_file_path = join_filepath(
+                [str(temp_workdir), Path(config_file_path).name]
             )
-            print(f"Config file copied from {config_file_path} to {temp_workdir}")
+
+            shutil.copyfile(config_file_path, temp_config_file_path)
+
+            print(
+                f"Config file copied from {config_file_path} to {temp_config_file_path}"
+            )
 
         # Main snakemake execution
         snakemake_args = {
@@ -52,54 +57,69 @@ def main(args):
         }
 
         if config_file_path is not None:
-            snakemake_args["configfiles"] = [str(config_file_path)]
+            snakemake_args["configfiles"] = [str(temp_config_file_path)]
 
         if args.use_conda:
             snakemake_args["conda_prefix"] = DIRPATH.SNAKEMAKE_CONDA_ENV_DIR
 
         print(f"Snakemake arguments: {snakemake_args}")
 
-        result = snakemake(**snakemake_args)
+        try:
+            result = snakemake(**snakemake_args)
 
-        if result:
-            print("snakemake execution succeeded.")
-            # Copy config file back to output directory for future reference
-            try:
-                # Find the output directory from the last_output in config
-                config_data = ConfigReader.read(config_file_path)
-                if config_data and "last_output" in config_data:
-                    # Extract the last output path
-                    last_output_path = config_data["last_output"][0]
-                    # Construct absolute path and extract directory
-                    absolute_output_path = join_filepath(
-                        [DIRPATH.OUTPUT_DIR, last_output_path]
-                    )
-                    # Extract the workspace_id and unique_id
-                    path_ids = ExptOutputPathIds(os.path.dirname(absolute_output_path))
+            if result:
+                print("snakemake execution succeeded.")
+                # Copy config file back to output directory for future reference
+                try:
+                    # Find the output directory from the last_output in config
+                    config_data = ConfigReader.read(config_file_path)
+                    if config_data and "last_output" in config_data:
+                        # Extract the last output path
+                        last_output_path = config_data["last_output"][0]
+                        # Construct absolute path and extract directory
+                        absolute_output_path = join_filepath(
+                            [DIRPATH.OUTPUT_DIR, last_output_path]
+                        )
+                        # Extract the workspace_id and unique_id
+                        path_ids = ExptOutputPathIds(
+                            os.path.dirname(absolute_output_path)
+                        )
 
-                    # Create the output directory path to copy the config file
-                    output_config_dir = join_filepath(
-                        [
-                            DIRPATH.OUTPUT_DIR,
-                            path_ids.workspace_id,
-                            path_ids.unique_id,
-                        ]
-                    )
-                    os.makedirs(output_config_dir, exist_ok=True)
-                    output_config_path = join_filepath(
-                        [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                    )
+                        # Create the output directory path to copy the config file
+                        output_config_dir = join_filepath(
+                            [
+                                DIRPATH.OUTPUT_DIR,
+                                path_ids.workspace_id,
+                                path_ids.unique_id,
+                            ]
+                        )
+                        os.makedirs(output_config_dir, exist_ok=True)
+                        output_config_path = join_filepath(
+                            [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                        )
 
-                    shutil.copyfile(config_file_path, output_config_path)
-                    print(f"Config copied to output directory: {output_config_path}")
-                else:
-                    print(
-                        "Warning: No output path found in config, skipping config copy"
-                    )
-            except Exception as e:
-                print(f"Warning: Failed to copy config to output directory: {e}")
-        else:
-            print("snakemake execution failed.")
+                        shutil.copyfile(config_file_path, output_config_path)
+                        print(
+                            f"Config copied to output directory: {output_config_path}"
+                        )
+                    else:
+                        print(
+                            "Warning: No output path found in config, "
+                            "skipping config copy"
+                        )
+                except Exception as e:
+                    print(f"Warning: Failed to copy config to output directory: {e}")
+            else:
+                print("snakemake execution failed.")
+                print("Check for errors above in the snakemake output.")
+
+        except Exception as e:
+            print(f"snakemake execution failed with exception: {e}")
+            import traceback
+
+            print("Full traceback:")
+            traceback.print_exc()
+            result = False
 
         return result
 

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from snakemake import snakemake
 
+from studio.app.common.core.experiment.experiment import ExptOutputPathIds
+from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.dir_path import DIRPATH
 
@@ -40,6 +42,7 @@ def main(args):
             )
             print(f"Config file copied from {config_file_path} to {temp_workdir}")
 
+        # Main snakemake execution
         snakemake_args = {
             "snakefile": DIRPATH.SNAKEMAKE_FILEPATH,
             "forceall": args.forceall,
@@ -63,32 +66,36 @@ def main(args):
             # Copy config file back to output directory for future reference
             try:
                 # Find the output directory from the last_output in config
-                from studio.app.common.core.utils.config_handler import ConfigReader
-
                 config_data = ConfigReader.read(config_file_path)
                 if config_data and "last_output" in config_data:
-                    # Extract workspace and unique_id from output path
-                    output_path_parts = config_data["last_output"][0].split("/")
-                    if len(output_path_parts) >= 3:
-                        workspace_id = output_path_parts[0]
-                        unique_id = output_path_parts[1]
+                    # Extract the last output path
+                    last_output_path = config_data["last_output"][0]
+                    # Construct absolute path and extract directory
+                    absolute_output_path = join_filepath(
+                        [DIRPATH.OUTPUT_DIR, last_output_path]
+                    )
+                    # Extract the workspace_id and unique_id
+                    path_ids = ExptOutputPathIds(os.path.dirname(absolute_output_path))
 
-                        output_config_dir = join_filepath(
-                            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id]
-                        )
-                        os.makedirs(output_config_dir, exist_ok=True)
-                        output_config_path = join_filepath(
-                            [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                        )
+                    # Create the output directory path to copy the config file
+                    output_config_dir = join_filepath(
+                        [
+                            DIRPATH.OUTPUT_DIR,
+                            path_ids.workspace_id,
+                            path_ids.unique_id,
+                        ]
+                    )
+                    os.makedirs(output_config_dir, exist_ok=True)
+                    output_config_path = join_filepath(
+                        [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                    )
 
-                        shutil.copyfile(config_file_path, output_config_path)
-                        print(
-                            f"Config copied to output directory: {output_config_path}"
-                        )
-                    else:
-                        print("Warning: Could not get output directory from config")
+                    shutil.copyfile(config_file_path, output_config_path)
+                    print(f"Config copied to output directory: {output_config_path}")
                 else:
-                    print("Warning: No output found in config, skipping config copy")
+                    print(
+                        "Warning: No output path found in config, skipping config copy"
+                    )
             except Exception as e:
                 print(f"Warning: Failed to copy config to output directory: {e}")
         else:

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -60,6 +60,37 @@ def main(args):
 
         if result:
             print("snakemake execution succeeded.")
+            # Copy config file back to output directory for future reference
+            try:
+                # Find the output directory from the last_output in config
+                from studio.app.common.core.utils.config_handler import ConfigReader
+
+                config_data = ConfigReader.read(config_file_path)
+                if config_data and "last_output" in config_data:
+                    # Extract workspace and unique_id from output path
+                    output_path_parts = config_data["last_output"][0].split("/")
+                    if len(output_path_parts) >= 3:
+                        workspace_id = output_path_parts[0]
+                        unique_id = output_path_parts[1]
+
+                        output_config_dir = join_filepath(
+                            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id]
+                        )
+                        os.makedirs(output_config_dir, exist_ok=True)
+                        output_config_path = join_filepath(
+                            [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                        )
+
+                        shutil.copyfile(config_file_path, output_config_path)
+                        print(
+                            f"Config copied to output directory: {output_config_path}"
+                        )
+                    else:
+                        print("Warning: Could not get output directory from config")
+                else:
+                    print("Warning: No output found in config, skipping config copy")
+            except Exception as e:
+                print(f"Warning: Failed to copy config to output directory: {e}")
         else:
             print("snakemake execution failed.")
 

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -27,7 +27,7 @@ def main():
 
         rule_config = RuleConfigReader.read(snakemake.params.name)
 
-        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config)
+        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config, snakemake.config)
 
         if NodeTypeUtil.check_nodetype_from_filetype(rule_config.type) == NodeType.DATA:
             if rule_config.type in [FILETYPE.IMAGE]:

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -17,6 +17,7 @@ logger = AppLogger.get_logger()
 def main():
     try:
         from studio.app.common.core.rules.runner import Runner
+        from studio.app.common.core.snakemake.smk_utils import SmkUtils
         from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
         from studio.app.common.core.utils.filepath_creater import join_filepath
         from studio.app.dir_path import DIRPATH
@@ -27,6 +28,8 @@ def main():
         ]
 
         rule_config = RuleConfigReader.read(snakemake.params.name)
+
+        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config, snakemake.config)
 
         rule_config.input = snakemake.input
         rule_config.output = snakemake.output[0]

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -58,6 +58,10 @@ class SmkUtils:
         if NodeTypeUtil.check_nodetype_from_filetype(details["type"]) == NodeType.DATA:
             return None
 
+        path = details.get("path")
+        if not path:
+            return None
+
         wrapper = cls.dict2leaf(wrapper_dict, details["path"].split("/"))
 
         if "conda_name" in wrapper:

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import Rule
-from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
@@ -154,7 +154,7 @@ class SmkUtils:
                         ]
                     )
 
-                    config = ConfigReader.read(config_path)
+                    config = SmkConfigReader.read_from_path(config_path)
 
                     if config and "nwb_template" in config:
                         template = config["nwb_template"]

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import Rule
-from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
+from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
@@ -128,24 +128,45 @@ class SmkUtils:
         return modified_params
 
     @staticmethod
-    def resolve_nwbfile_reference(rule_config: Rule):
+    def resolve_nwbfile_reference(rule_config: Rule, config: dict = None):
         """Resolve NWB template reference if necessary"""
         if hasattr(rule_config, "nwbfile"):
             if isinstance(rule_config.nwbfile, str) and rule_config.nwbfile.startswith(
                 "ref:"
             ):
-                workflow_dirpath = str(Path(rule_config.output).parent.parent)
-
-                config_path = join_filepath(
-                    [DIRPATH.OUTPUT_DIR, workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                )
-                config = SmkConfigReader.read_from_path(config_path)
-
-                if "nwb_template" in config:
-                    template = config["nwb_template"]
-                    rule_config.nwbfile = template
+                # If config is provided (from snakemake context), use it directly
+                if config is not None:
+                    if "nwb_template" in config:
+                        template = config["nwb_template"]
+                        rule_config.nwbfile = template
+                    else:
+                        logger.error("NWB template not found in provided config")
+                        logger.error(f"Config keys available: {list(config.keys())}")
                 else:
-                    logger.error(f"NWB template not found in config: {config_path}")
+                    # Fallback to file reading for backwards compatibility
+                    workflow_dirpath = str(Path(rule_config.output).parent.parent)
+
+                    config_path = join_filepath(
+                        [
+                            DIRPATH.OUTPUT_DIR,
+                            workflow_dirpath,
+                            DIRPATH.SNAKEMAKE_CONFIG_YML,
+                        ]
+                    )
+
+                    config = ConfigReader.read(config_path)
+
+                    if config and "nwb_template" in config:
+                        template = config["nwb_template"]
+                        rule_config.nwbfile = template
+                    else:
+                        logger.error(f"NWB template not found in config: {config_path}")
+                        config_keys = list(config.keys()) if config else "None"
+                        logger.error(f"Config keys available: {config_keys}")
+                        config_exists = (
+                            os.path.exists(config_path) if config_path else False
+                        )
+                        logger.error(f"Config exists: {config_exists}")
 
         return rule_config
 

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -30,7 +30,9 @@ class ConfigReader:
 
         if filepath is not None and os.path.exists(filepath):
             with open(filepath) as f:
-                config = yaml.safe_load(f)
+                loaded_config = yaml.safe_load(f)
+                if loaded_config is not None:
+                    config = loaded_config
 
         return config
 

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -5,12 +5,8 @@ from types import SimpleNamespace
 
 from dotenv import load_dotenv
 
-_TMP_DIR = (
-    os.environ.get("TEMP", os.environ.get("TMP", "C:\\temp"))
-    if platform.system() == "Windows"
-    else "/tmp"
-)
-_DEFAULT_DIR = f"{_TMP_DIR}/studio"
+_TMP_DIR = "C:\\temp" if platform.system() == "Windows" else "/tmp"
+_DEFAULT_DIR = os.path.join(_TMP_DIR, "studio")
 _ENV_DIR = os.environ.get("OPTINIST_DIR")
 
 


### PR DESCRIPTION
Update to correctly read snakemake.yaml nwb_template format with run_cluster

### Content

Recently snakemake.yaml were updated to use a nwb_template instead of repeating the same template many times in the yaml file. However, when combined with run_cluster this caused path issues.

#### Main Issue:
  Circular Dependency in NWB Reference Resolution
  1. NWB Template References: Some snakemake.yaml files use nwbfile: ref:nwb_template instead of embedding
  the full NWB data inline
  2. Reference Resolution: During Snakemake execution, resolve_nwbfile_reference() tried to resolve these
  references by re-reading the config file
  3. Circular Path Logic: The function used SmkConfigReader.read_from_path() which:
    - Extracted workspace_id/unique_id from the provided path
    - Reconstructed a new path using get_config_yaml_path()
    - Called ConfigReader.read() which returned {} (empty dict) due to path issues
    - Failed assertion: assert config, f"Invalid config yaml file..."

#### Fix:
  File: studio/app/common/core/snakemake/smk_utils.py
  - Modified resolve_nwbfile_reference() to accept config parameter from Snakemake context
  - Direct Config Usage: Instead of re-reading files, use snakemake.config passed from rule execution
  - Fallback Logic: Maintained backwards compatibility with file reading for other use cases
  - Updated Call Sites: Modified func.py and data.py to pass snakemake.config

  ##### Before: Circular file reading
  config = SmkConfigReader.read_from_path(config_path)  # Failed with {}

 ##### After: Direct config usage  
  rule_config = SmkUtils.resolve_nwbfile_reference(rule_config, snakemake.config)
  
  
#### Secondary Issue: Windows Path Handling
  - Windows used user temp directories (C:\Users\...\AppData\Local\Temp) instead of system temp (C:\temp) for saving, even though the app and the input data was saved correctly in (C:\temp).  It seems best to keep Windows temp dir fixed at C:\temp because otherwise, the output of run_cluster is saved to \AppData\Local\Temp and then deleted on cleanup
  - Results saved to wrong location and got cleaned up
#### Fix:
  File: studio/app/dir_path.py
  - Consistent Defaults: Windows now defaults to C:\temp\studio instead of user temp directory
  - Proper Path Separators: Use os.path.join() instead of hardcoded / separators
  - Cross-Platform Consistency: Both Mac (/tmp/studio) and Windows (C:\temp\studio) use system-wide
  locations
 -----------------------

### References

[Link to nwb_template PR](https://github.com/arayabrain/barebone-studio/pull/793)
[Link to run_cluster PR](https://github.com/arayabrain/barebone-studio/pull/859)

-----------------------

### Testcase
- [x] Tutorial 1 RUN ALL
- [x] Check can be run with run_cluster
    - Download snakemake.yaml for this workflow after completion
    - Delete contents of the workflow output from optinist_dir
    - Set `$OPTINIST_DIR` and run run_cluster
      `python run_cluster.py --config="Downloads/snakemake_uniqueID.yaml"`
    

- [x] Mac
- [x] Windows
- [x] Docker 


- [x] [snakemake_nwb_template.yaml.txt](https://github.com/user-attachments/files/21571612/snakemake_nwb_template.yaml.txt)
- [x] [snakemake_no_template.yaml.txt](https://github.com/user-attachments/files/21594377/snakemake_no_template.yaml.txt)
- [x] [snakemake_error_sample.yaml.txt](https://github.com/user-attachments/files/21594384/snakemake_error_sample.yaml.txt)
