### PR TITLE
Add ExperimentRecordService

### DIFF
--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -1,0 +1,95 @@
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, delete
+
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.mode import MODE
+from studio.app.common.db.database import session_scope
+from studio.app.common.models.experiment import ExperimentRecord
+
+logger = AppLogger.get_logger()
+
+
+class ExperimentRecordService:
+    @classmethod
+    def is_available(cls) -> bool:
+        # ExperimentRecordService is available in multiuser mode
+        available = MODE.IS_MULTIUSER
+        return available
+
+    @classmethod
+    def regist_record_on_workflow_completed(cls, workspace_id: str, unique_id: str):
+        """
+        Processing upon workflow completion
+        """
+
+        # Update ExperimentRecord to database
+        with session_scope() as db:
+            try:
+                exp = (
+                    db.query(ExperimentRecord)
+                    .filter(
+                        ExperimentRecord.workspace_id == workspace_id,
+                        ExperimentRecord.uid == unique_id,
+                    )
+                    .one()
+                )
+
+                # Currently nothing
+                # *Add data to be registered in the future as needed
+                pass
+
+            except NoResultFound:
+                exp = ExperimentRecord(
+                    workspace_id=workspace_id,
+                    uid=unique_id,
+                    # *Add data to be registered in the future as needed
+                )
+                db.add(exp)
+
+    @classmethod
+    def delete_record(
+        cls, db: Session, workspace_id: str, unique_id: str, auto_commit: bool = False
+    ):
+        db.execute(
+            delete(ExperimentRecord).where(
+                ExperimentRecord.workspace_id == workspace_id,
+                ExperimentRecord.uid == unique_id,
+            )
+        )
+
+        if auto_commit:
+            db.commit()
+
+    @classmethod
+    def copy_record(
+        cls,
+        db: Session,
+        workspace_id: str,
+        unique_id: str,
+        new_unique_id: str,
+        auto_commit: bool = False,
+    ):
+        try:
+            exp = (
+                db.query(ExperimentRecord)
+                .filter(
+                    ExperimentRecord.workspace_id == workspace_id,
+                    ExperimentRecord.uid == unique_id,
+                )
+                .one()
+            )
+            new_exp = ExperimentRecord(
+                workspace_id=workspace_id,
+                uid=new_unique_id,
+                data_usage=exp.data_usage,
+            )
+            db.add(new_exp)
+
+            if auto_commit:
+                db.commit()
+
+        except NoResultFound:
+            # If it fails roll back the transaction
+            logger.error(
+                f"Experiment {unique_id} not found in workspace {workspace_id}"
+            )

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -5,6 +5,9 @@ from typing import Dict
 
 from snakemake import snakemake
 
+from studio.app.common.core.experiment.experiment_record_services import (
+    ExperimentRecordService,
+)
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
@@ -74,6 +77,12 @@ def _snakemake_execute_process(
 
     # Update workflow processing results
     WorkflowResult(workspace_id, unique_id).observe_overall()
+
+    # Update experiment database record
+    if ExperimentRecordService.is_available():
+        ExperimentRecordService.regist_record_on_workflow_completed(
+            workspace_id, unique_id
+        )
 
     # Data usage calculation
     WorkspaceDataCapacityService.update_experiment_data_usage(workspace_id, unique_id)


### PR DESCRIPTION
### Content

Before the update, ExperimentRecord operations were defined indirectly using the ExperimentService and WorkspaceDataCapacityService services.

To clarify the processing and ensure future extensibility, I've separated them into a separate module (ExperimentRecordService).

### References

- arayabrain/optinist-for-cloud#81
  - This is necessary for the development of the above functions, etc.

### Testcase

\*Platform (OS, Docker, etc.) does not matter.

- Standalone mode
  - Workflow execution
    - [x] The operation completes successfully
  - Workflow deletion
    - [x] The operation completes successfully
  - Workflow copy
    - [x] The operation completes successfully

- MultiUser mode
  - Workflow execution
    - [x] Records added to the table (experiment_records)
  - Workflow deletion
    - [x] Records added to the table (experiment_records)
  - Workflow copy
    - [x] Records added to the table (experiment_records)
