### PR TITLE
Fix/run cluster for main hotfix

### DIFF
--- a/run_cluster.py
+++ b/run_cluster.py
@@ -4,6 +4,8 @@ import shutil
 
 from snakemake import snakemake
 
+from studio.app.common.core.experiment.experiment import ExptOutputPathIds
+from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.dir_path import DIRPATH
 
@@ -38,6 +40,7 @@ def main(args):
             )
             print(f"Config file copied from {config_file_path} to {temp_workdir}")
 
+        # Main snakemake execution
         snakemake_args = {
             "snakefile": DIRPATH.SNAKEMAKE_FILEPATH,
             "forceall": args.forceall,
@@ -61,32 +64,36 @@ def main(args):
             # Copy config file back to output directory for future reference
             try:
                 # Find the output directory from the last_output in config
-                from studio.app.common.core.utils.config_handler import ConfigReader
-
                 config_data = ConfigReader.read(config_file_path)
                 if config_data and "last_output" in config_data:
-                    # Extract workspace and unique_id from output path
-                    output_path_parts = config_data["last_output"][0].split("/")
-                    if len(output_path_parts) >= 3:
-                        workspace_id = output_path_parts[0]
-                        unique_id = output_path_parts[1]
+                    # Extract the last output path
+                    last_output_path = config_data["last_output"][0]
+                    # Construct absolute path and extract directory
+                    absolute_output_path = join_filepath(
+                        [DIRPATH.OUTPUT_DIR, last_output_path]
+                    )
+                    # Extract the workspace_id and unique_id
+                    path_ids = ExptOutputPathIds(os.path.dirname(absolute_output_path))
 
-                        output_config_dir = join_filepath(
-                            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id]
-                        )
-                        os.makedirs(output_config_dir, exist_ok=True)
-                        output_config_path = join_filepath(
-                            [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                        )
+                    # Create the output directory path to copy the config file
+                    output_config_dir = join_filepath(
+                        [
+                            DIRPATH.OUTPUT_DIR,
+                            path_ids.workspace_id,
+                            path_ids.unique_id,
+                        ]
+                    )
+                    os.makedirs(output_config_dir, exist_ok=True)
+                    output_config_path = join_filepath(
+                        [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                    )
 
-                        shutil.copyfile(config_file_path, output_config_path)
-                        print(
-                            f"Config copied to output directory: {output_config_path}"
-                        )
-                    else:
-                        print("Warning: Could not get output directory from config")
+                    shutil.copyfile(config_file_path, output_config_path)
+                    print(f"Config copied to output directory: {output_config_path}")
                 else:
-                    print("Warning: No output found in config, skipping config copy")
+                    print(
+                        "Warning: No output path found in config, skipping config copy"
+                    )
             except Exception as e:
                 print(f"Warning: Failed to copy config to output directory: {e}")
         else:

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 import shutil
+import tempfile
+from pathlib import Path
 
 from snakemake import snakemake
 
@@ -125,8 +127,12 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="optinist")
     parser.add_argument("--cores", type=int, default=2)
-    parser.add_argument("--forceall", action="store_true")
-    parser.add_argument("--use_conda", action="store_true")
+    parser.add_argument(  # Default true, use --no-forceall to disable forceall
+        "--forceall", default=True, action=argparse.BooleanOptionalAction
+    )
+    parser.add_argument(  # Default true, use --no-use_conda to disable conda usage
+        "--use_conda", default=True, action=argparse.BooleanOptionalAction
+    )
     parser.add_argument("--config", type=str, default=None)
 
     main(parser.parse_args())

--- a/run_cluster.py
+++ b/run_cluster.py
@@ -18,6 +18,7 @@ def main(args):
         print(f"Temporary work directory created at: {temp_workdir}")
 
         config_file_path = None
+        temp_config_file_path = None
 
         if args.config is None:
             raise FileNotFoundError(
@@ -34,11 +35,15 @@ def main(args):
             if not Path(config_file_path).exists():
                 raise FileNotFoundError(f"Config file not found: {args.config}")
 
-            shutil.copyfile(
-                config_file_path,
-                join_filepath([str(temp_workdir), str(Path(config_file_path).name)]),
+            temp_config_file_path = join_filepath(
+                [str(temp_workdir), Path(config_file_path).name]
             )
-            print(f"Config file copied from {config_file_path} to {temp_workdir}")
+
+            shutil.copyfile(config_file_path, temp_config_file_path)
+
+            print(
+                f"Config file copied from {config_file_path} to {temp_config_file_path}"
+            )
 
         # Main snakemake execution
         snakemake_args = {
@@ -50,54 +55,69 @@ def main(args):
         }
 
         if config_file_path is not None:
-            snakemake_args["configfiles"] = [str(config_file_path)]
+            snakemake_args["configfiles"] = [str(temp_config_file_path)]
 
         if args.use_conda:
             snakemake_args["conda_prefix"] = DIRPATH.SNAKEMAKE_CONDA_ENV_DIR
 
         print(f"Snakemake arguments: {snakemake_args}")
 
-        result = snakemake(**snakemake_args)
+        try:
+            result = snakemake(**snakemake_args)
 
-        if result:
-            print("snakemake execution succeeded.")
-            # Copy config file back to output directory for future reference
-            try:
-                # Find the output directory from the last_output in config
-                config_data = ConfigReader.read(config_file_path)
-                if config_data and "last_output" in config_data:
-                    # Extract the last output path
-                    last_output_path = config_data["last_output"][0]
-                    # Construct absolute path and extract directory
-                    absolute_output_path = join_filepath(
-                        [DIRPATH.OUTPUT_DIR, last_output_path]
-                    )
-                    # Extract the workspace_id and unique_id
-                    path_ids = ExptOutputPathIds(os.path.dirname(absolute_output_path))
+            if result:
+                print("snakemake execution succeeded.")
+                # Copy config file back to output directory for future reference
+                try:
+                    # Find the output directory from the last_output in config
+                    config_data = ConfigReader.read(config_file_path)
+                    if config_data and "last_output" in config_data:
+                        # Extract the last output path
+                        last_output_path = config_data["last_output"][0]
+                        # Construct absolute path and extract directory
+                        absolute_output_path = join_filepath(
+                            [DIRPATH.OUTPUT_DIR, last_output_path]
+                        )
+                        # Extract the workspace_id and unique_id
+                        path_ids = ExptOutputPathIds(
+                            os.path.dirname(absolute_output_path)
+                        )
 
-                    # Create the output directory path to copy the config file
-                    output_config_dir = join_filepath(
-                        [
-                            DIRPATH.OUTPUT_DIR,
-                            path_ids.workspace_id,
-                            path_ids.unique_id,
-                        ]
-                    )
-                    os.makedirs(output_config_dir, exist_ok=True)
-                    output_config_path = join_filepath(
-                        [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                    )
+                        # Create the output directory path to copy the config file
+                        output_config_dir = join_filepath(
+                            [
+                                DIRPATH.OUTPUT_DIR,
+                                path_ids.workspace_id,
+                                path_ids.unique_id,
+                            ]
+                        )
+                        os.makedirs(output_config_dir, exist_ok=True)
+                        output_config_path = join_filepath(
+                            [output_config_dir, DIRPATH.SNAKEMAKE_CONFIG_YML]
+                        )
 
-                    shutil.copyfile(config_file_path, output_config_path)
-                    print(f"Config copied to output directory: {output_config_path}")
-                else:
-                    print(
-                        "Warning: No output path found in config, skipping config copy"
-                    )
-            except Exception as e:
-                print(f"Warning: Failed to copy config to output directory: {e}")
-        else:
-            print("snakemake execution failed.")
+                        shutil.copyfile(config_file_path, output_config_path)
+                        print(
+                            f"Config copied to output directory: {output_config_path}"
+                        )
+                    else:
+                        print(
+                            "Warning: No output path found in config, "
+                            "skipping config copy"
+                        )
+                except Exception as e:
+                    print(f"Warning: Failed to copy config to output directory: {e}")
+            else:
+                print("snakemake execution failed.")
+                print("Check for errors above in the snakemake output.")
+
+        except Exception as e:
+            print(f"snakemake execution failed with exception: {e}")
+            import traceback
+
+            print("Full traceback:")
+            traceback.print_exc()
+            result = False
 
         return result
 

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -27,7 +27,7 @@ def main():
 
         rule_config = RuleConfigReader.read(snakemake.params.name)
 
-        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config)
+        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config, snakemake.config)
 
         if NodeTypeUtil.check_nodetype_from_filetype(rule_config.type) == NodeType.DATA:
             if rule_config.type in [FILETYPE.IMAGE]:

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -17,6 +17,7 @@ logger = AppLogger.get_logger()
 def main():
     try:
         from studio.app.common.core.rules.runner import Runner
+        from studio.app.common.core.snakemake.smk_utils import SmkUtils
         from studio.app.common.core.snakemake.snakemake_reader import RuleConfigReader
         from studio.app.common.core.utils.filepath_creater import join_filepath
         from studio.app.dir_path import DIRPATH
@@ -27,6 +28,8 @@ def main():
         ]
 
         rule_config = RuleConfigReader.read(snakemake.params.name)
+
+        rule_config = SmkUtils.resolve_nwbfile_reference(rule_config, snakemake.config)
 
         rule_config.input = snakemake.input
         rule_config.output = snakemake.output[0]

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -58,6 +58,10 @@ class SmkUtils:
         if NodeTypeUtil.check_nodetype_from_filetype(details["type"]) == NodeType.DATA:
             return None
 
+        path = details.get("path")
+        if not path:
+            return None
+
         wrapper = cls.dict2leaf(wrapper_dict, details["path"].split("/"))
 
         if "conda_name" in wrapper:

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.snakemake.smk import Rule
-from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
 from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
@@ -154,7 +154,7 @@ class SmkUtils:
                         ]
                     )
 
-                    config = ConfigReader.read(config_path)
+                    config = SmkConfigReader.read_from_path(config_path)
 
                     if config and "nwb_template" in config:
                         template = config["nwb_template"]

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict
 
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.snakemake.smk import Rule
 from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
 from studio.app.common.core.utils.filepath_finder import find_condaenv_filepath
@@ -127,24 +128,45 @@ class SmkUtils:
         return modified_params
 
     @staticmethod
-    def resolve_nwbfile_reference(rule_config):
+    def resolve_nwbfile_reference(rule_config: Rule, config: dict = None):
         """Resolve NWB template reference if necessary"""
         if hasattr(rule_config, "nwbfile"):
             if isinstance(rule_config.nwbfile, str) and rule_config.nwbfile.startswith(
                 "ref:"
             ):
-                workflow_dirpath = str(Path(rule_config.output).parent.parent)
-
-                config_path = join_filepath(
-                    [DIRPATH.OUTPUT_DIR, workflow_dirpath, DIRPATH.SNAKEMAKE_CONFIG_YML]
-                )
-
-                config = ConfigReader.read(config_path)
-                if "nwb_template" in config:
-                    template = config["nwb_template"]
-                    rule_config.nwbfile = template
+                # If config is provided (from snakemake context), use it directly
+                if config is not None:
+                    if "nwb_template" in config:
+                        template = config["nwb_template"]
+                        rule_config.nwbfile = template
+                    else:
+                        logger.error("NWB template not found in provided config")
+                        logger.error(f"Config keys available: {list(config.keys())}")
                 else:
-                    logger.error(f"NWB template not found in config: {config_path}")
+                    # Fallback to file reading for backwards compatibility
+                    workflow_dirpath = str(Path(rule_config.output).parent.parent)
+
+                    config_path = join_filepath(
+                        [
+                            DIRPATH.OUTPUT_DIR,
+                            workflow_dirpath,
+                            DIRPATH.SNAKEMAKE_CONFIG_YML,
+                        ]
+                    )
+
+                    config = ConfigReader.read(config_path)
+
+                    if config and "nwb_template" in config:
+                        template = config["nwb_template"]
+                        rule_config.nwbfile = template
+                    else:
+                        logger.error(f"NWB template not found in config: {config_path}")
+                        config_keys = list(config.keys()) if config else "None"
+                        logger.error(f"Config keys available: {config_keys}")
+                        config_exists = (
+                            os.path.exists(config_path) if config_path else False
+                        )
+                        logger.error(f"Config exists: {config_exists}")
 
         return rule_config
 

--- a/studio/app/common/core/snakemake/snakemake_reader.py
+++ b/studio/app/common/core/snakemake/snakemake_reader.py
@@ -1,4 +1,10 @@
+import os
+
+from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.snakemake.smk import Rule, SmkParam
+from studio.app.common.core.utils.config_handler import ConfigReader
+from studio.app.common.core.utils.filepath_creater import join_filepath
+from studio.app.dir_path import DIRPATH
 
 
 class RuleConfigReader:
@@ -28,3 +34,25 @@ class SmkParamReader:
             lock=params["lock"],
             forcerun=params["forcerun"] if "forcerun" in params else [],
         )
+
+
+class SmkConfigReader:
+    @classmethod
+    def get_config_yaml_path(cls, workspace_id: str, unique_id: str) -> str:
+        path = join_filepath(
+            [DIRPATH.OUTPUT_DIR, workspace_id, unique_id, DIRPATH.SNAKEMAKE_CONFIG_YML]
+        )
+        return path
+
+    @classmethod
+    def read(cls, workspace_id: str, unique_id: str) -> dict:
+        filepath = cls.get_config_yaml_path(workspace_id, unique_id)
+        config = ConfigReader.read(filepath)
+        assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
+
+        return config
+
+    @classmethod
+    def read_from_path(cls, filepath: str) -> dict:
+        ids = ExptOutputPathIds(os.path.dirname(filepath))
+        return cls.read(ids.workspace_id, ids.unique_id)

--- a/studio/app/common/core/snakemake/snakemake_rule.py
+++ b/studio/app/common/core/snakemake/snakemake_rule.py
@@ -9,6 +9,8 @@ from studio.app.const import FILETYPE
 
 
 class SmkRule:
+    RETURN_ARG_KEY_DELIMITER = "@"
+
     def __init__(
         self,
         workspace_id: str,

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -1,5 +1,4 @@
 import os
-from typing import Union
 
 import yaml
 from filelock import FileLock
@@ -13,7 +12,7 @@ from studio.app.common.core.utils.filepath_creater import (
 
 class ConfigReader:
     @classmethod
-    def read(cls, file: Union[str, bytes]):
+    def read(cls, filepath: str) -> dict:
         config = {}
 
         if filepath is not None and os.path.exists(filepath):

--- a/studio/app/common/core/utils/config_handler.py
+++ b/studio/app/common/core/utils/config_handler.py
@@ -16,16 +16,11 @@ class ConfigReader:
     def read(cls, file: Union[str, bytes]):
         config = {}
 
-        if file is None:
-            return config
-
-        if isinstance(file, bytes):
-            config = yaml.safe_load(file)
-        elif isinstance(file, str) and os.path.exists(file):
-            with open(file) as f:
-                config = yaml.safe_load(f)
-        else:
-            assert False, f"Invalid file [{file}]"
+        if filepath is not None and os.path.exists(filepath):
+            with open(filepath) as f:
+                loaded_config = yaml.safe_load(f)
+                if loaded_config is not None:
+                    config = loaded_config
 
         return config
 

--- a/studio/app/dir_path.py
+++ b/studio/app/dir_path.py
@@ -4,12 +4,8 @@ from enum import Enum
 
 from dotenv import load_dotenv
 
-_TEMP_DIR = (
-    os.environ.get("TEMP", os.environ.get("TMP", "C:\\temp"))
-    if platform.system() == "Windows"
-    else "/tmp"
-)
-_DEFAULT_DIR = f"{_TEMP_DIR}/studio"
+_TMP_DIR = "C:\\temp" if platform.system() == "Windows" else "/tmp"
+_DEFAULT_DIR = os.path.join(_TMP_DIR, "studio")
 _ENV_DIR = os.environ.get("OPTINIST_DIR")
 
 


### PR DESCRIPTION
### Content

Adding fixes to solve error in using run_cluster.py to run snakemake.yaml files, in particular with new nwb_template format
https://github.com/arayabrain/barebone-studio/pull/895
https://github.com/arayabrain/barebone-studio/pull/899

Some additional functions were taken from develop-main.
`__align_input_info_content_keys` and `class SmkConfigReader:`

### Testcase

- [x] Tutorial 1
- [x] [snakemake_no_template.yaml.txt](https://github.com/user-attachments/files/21658470/snakemake_no_template.yaml.txt)
- [x] [snakemake_error_sample.yaml.txt](https://github.com/user-attachments/files/21658747/snakemake_error_sample.yaml.txt)

- [x] [snakemake_nwb_template_corrected.yaml.txt](https://github.com/user-attachments/files/21661773/snakemake_nwb_template_corrected.yaml.txt)


