### PR TITLE
Refactoring frontend stores etc

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/CsvFileNode.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/CsvFileNode.tsx
@@ -99,11 +99,13 @@ const CsvFileNodeImple = memo(function CsvFileNodeImple({
 
 interface ParamSettingDialogProps extends NodeIdProps {
   filePath: string
+  disabled?: boolean
 }
 
 export const ParamSettingDialog = memo(function ParamSettingDialog({
   nodeId,
   filePath,
+  disabled = false,
 }: ParamSettingDialogProps) {
   const [open, setOpen] = useState(false)
   // OK時のみStoreに反映させるため一時的な値をuseStateで保持しておく。
@@ -135,8 +137,9 @@ export const ParamSettingDialog = memo(function ParamSettingDialog({
     <>
       <IconButton
         onClick={() => setOpen(true)}
-        sx={{ padding: 0 }}
         color={"primary"}
+        disabled={disabled}
+        size="small"
       >
         <SettingsIcon />
       </IconButton>

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
@@ -246,12 +246,11 @@ export const FileSelectImple = memo(function FileSelectImple({
         {fileTreeType === FILE_TREE_TYPE_SET.CSV && !!filePath && !!nodeId && (
           <Tooltip title={"Settings"}>
             <span>
-              <IconButton disabled={!!isPending}>
-                <ParamSettingDialog
-                  nodeId={nodeId}
-                  filePath={filePath as string}
-                />
-              </IconButton>
+              <ParamSettingDialog
+                nodeId={nodeId}
+                filePath={filePath as string}
+                disabled={!!isPending}
+              />
             </span>
           </Tooltip>
         )}

--- a/frontend/src/components/Workspace/Visualize/Editor/CsvItemEditor.tsx
+++ b/frontend/src/components/Workspace/Visualize/Editor/CsvItemEditor.tsx
@@ -68,7 +68,7 @@ const SetHeader: FC = () => {
   return (
     <ParamTextField
       label="Header"
-      value={setHeader}
+      value={setHeader ?? ""}
       type="number"
       onChange={onChangeSetHeader}
     />

--- a/frontend/src/components/Workspace/Visualize/Editor/TimeSeriesItemEditor.tsx
+++ b/frontend/src/components/Workspace/Visualize/Editor/TimeSeriesItemEditor.tsx
@@ -99,7 +99,7 @@ const Span: FC = () => {
     <ParamTextField
       type="number"
       label="vertical offset"
-      value={span}
+      value={span ?? ""}
       onChange={onChange}
     />
   )

--- a/frontend/src/store/slice/DisplayData/DisplayDataSelectors.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataSelectors.ts
@@ -10,20 +10,30 @@ export const selectLoading = (state: RootState) => state.displayData.loading
 export const selectIsEditRoiCommitting = (state: RootState) =>
   state.displayData.isEditRoiCommitting
 
-export const selectTimeSeriesData =
-  (filePath: string | null) => (state: RootState) => {
-    if (!filePath) return {}
-    return selectDisplayData(state).timeSeries[filePath]?.data || {}
-  }
+export const selectTimeSeriesData = (filePath: string | null) =>
+  createSelector(
+    [
+      (state: RootState) =>
+        filePath
+          ? selectDisplayData(state).timeSeries[filePath]?.data
+          : undefined,
+    ],
+    (data) => data || {},
+  )
 
 export const selectTimesSeriesMeta = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).timeSeries[filePath].meta
 
-export const selectTimeSeriesXrange =
-  (filePath: string | null) => (state: RootState) => {
-    if (!filePath) return []
-    return selectDisplayData(state).timeSeries[filePath]?.xrange || []
-  }
+export const selectTimeSeriesXrange = (filePath: string | null) =>
+  createSelector(
+    [
+      (state: RootState) =>
+        filePath
+          ? selectDisplayData(state).timeSeries[filePath]?.xrange
+          : undefined,
+    ],
+    (xrange) => xrange || [],
+  )
 
 export const selectTimeSeriesStd = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).timeSeries[filePath].std
@@ -144,8 +154,11 @@ export const selectCsvDataIsFulfilled =
     selectCsvDataIsInitialized(filePath)(state) &&
     selectDisplayData(state).csv[filePath].fulfilled
 
-export const selectRoiData = (filePath: string) => (state: RootState) =>
-  selectDisplayData(state).roi[filePath]?.data[0] ?? []
+export const selectRoiData = (filePath: string) =>
+  createSelector(
+    [(state: RootState) => selectDisplayData(state).roi[filePath]?.data[0]],
+    (data) => data ?? [],
+  )
 
 export const selectRoiMeta = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).roi[filePath].meta
@@ -176,8 +189,11 @@ export const selectRoiUniqueList = (filePath: string) => (state: RootState) => {
   return null
 }
 
-export const selectScatterData = (filePath: string) => (state: RootState) =>
-  selectDisplayData(state).scatter[filePath]?.data ?? []
+export const selectScatterData = (filePath: string) =>
+  createSelector(
+    [(state: RootState) => selectDisplayData(state).scatter[filePath]?.data],
+    (data) => data ?? [],
+  )
 
 export const selectScatterMeta = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).scatter[filePath]?.meta
@@ -202,14 +218,20 @@ export const selectScatterDataIsFulfilled =
     selectScatterDataIsInitialized(filePath)(state) &&
     selectDisplayData(state).scatter[filePath].fulfilled
 
-export const selectBarData = (filePath: string) => (state: RootState) =>
-  selectDisplayData(state).bar[filePath]?.data ?? []
+export const selectBarData = (filePath: string) =>
+  createSelector(
+    [(state: RootState) => selectDisplayData(state).bar[filePath]?.data],
+    (data) => data ?? [],
+  )
 
 export const selectBarMeta = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).bar[filePath]?.meta
 
-export const selectBarIndex = (filePath: string) => (state: RootState) =>
-  selectDisplayData(state).bar[filePath]?.index ?? []
+export const selectBarIndex = (filePath: string) =>
+  createSelector(
+    [(state: RootState) => selectDisplayData(state).bar[filePath]?.index],
+    (index) => index ?? [],
+  )
 
 export const selectBarDataIsInitialized =
   (filePath: string) => (state: RootState) =>
@@ -230,8 +252,11 @@ export const selectBarDataIsFulfilled =
     selectBarDataIsInitialized(filePath)(state) &&
     selectDisplayData(state).bar[filePath].fulfilled
 
-export const selectHTMLData = (filePath: string) => (state: RootState) =>
-  selectDisplayData(state).html[filePath]?.data ?? ""
+export const selectHTMLData = (filePath: string) =>
+  createSelector(
+    [(state: RootState) => selectDisplayData(state).html[filePath]?.data],
+    (data) => data ?? "",
+  )
 
 export const selectHTMLMeta = (filePath: string) => (state: RootState) =>
   selectDisplayData(state).html[filePath].meta

--- a/frontend/src/store/slice/Experiments/ExperimentsSelectors.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsSelectors.ts
@@ -106,6 +106,10 @@ export const selectExperimentFunctionHasNWB =
 
 export const selectFrameRate =
   (currentPipelineUid?: string) => (state: RootState) => {
-    if (!currentPipelineUid) return 50
-    return selectExperiment(currentPipelineUid)(state).frameRate || 50
+    // Check if experiments have been acquired
+    if (currentPipelineUid && selectExperimentsStatusIsFulfilled(state)) {
+      return selectExperiment(currentPipelineUid)(state).frameRate || 50
+    } else {
+      return 50
+    }
   }


### PR DESCRIPTION
### Content

#### (1) FE store selector warnings

- Problem
  - When a constant was returned as the default value in selector, it prevented React from memoizing the data, resulting in a warning in the console log (potentially causing unnecessary rendering).
- Target files
  - frontend/src/store/slice/DisplayData/DisplayDataSelectors.ts
  - frontend/src/store/slice/VisualizeItem/VisualizeItemSelectors.ts
- Solution
  - Wrap the affected section in createSelector.

#### (2) Improved store selector validation

- Problem
  - ExperimentsSelectors.selectFrameRate should work even if the experiment state is "not fulfilled," but the logic depended on the experiment being fulfilled (this issue was identified when adding other features).
- Target files
  - frontend/src/store/slice/Experiments/ExperimentsSelectors.ts
- Solution
  - Added validation and adjusted the selector so that it can be used even when the experiment state is "not fulfilled."

#### (3) FE component warnings

- Problem
  - There were multiple instances of errors recorded in the console log in the frontend.
- Target files
  - frontend/src/components/Workspace/FlowChart/FlowChartNode/CsvFileNode.tsx
    > Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>. Error Component Stack
  - frontend/src/components/Workspace/Visualize/Editor/CsvItemEditor.tsx
  - frontend/src/components/Workspace/Visualize/Editor/TimeSeriesItemEditor.tsx
    > hook.js:608 Warning: `value` prop on `input` should not be null.
- Solution
  - Applied a fix to avoid the error in an appropriate manner.

### Testcase

- [x] Check using the Tutorial Workflow
  1. Reproduce Tutorial 1
  2. In the Workflow screen, confirm that no error logs are recorded in the frontend console log (although known warnings may still be displayed, confirm that there are no errors).
  3. In the Visualize screen, plot each node output and confirm that no error logs are recorded in the frontend console log.
