### PR TITLE
Fixing an error in combining roiplot and plotly

### DIFF
--- a/frontend/src/components/Workspace/Visualize/Plot/RoiPlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/RoiPlot.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect, useMemo } from "react"
+import { memo, useContext, useEffect, useMemo, useRef, useState } from "react"
 import PlotlyChart from "react-plotlyjs-ts"
 import { useSelector, useDispatch } from "react-redux"
 
@@ -68,11 +68,20 @@ const RoiPlotImple = memo(function RoiPlotImple() {
   const { dialogFilterNodeId } = useContext(DialogContext)
   const timeDataMaxIndex = useSelector(selectRoiItemIndex(itemId, path))
   const { setRoiSelected, roisSelected, setMaxRoi } = useRoisSelected()
+  const [isMounted, setIsMounted] = useState(false)
+  const plotRef = useRef<HTMLDivElement>(null)
 
   const { filterParam } = useBoxFilter()
   const { setRoisClickWithGetTime, roisClick, isVisualize } = useVisualize()
 
   const roiVisualSelected = roisClick[itemId]
+
+  useEffect(() => {
+    setIsMounted(true)
+    return () => {
+      setIsMounted(false)
+    }
+  }, [])
 
   useEffect(() => {
     const maxv =
@@ -203,22 +212,32 @@ const RoiPlotImple = memo(function RoiPlotImple() {
   const saveFileName = useSelector(selectVisualizeSaveFilename(itemId))
   const saveFormat = useSelector(selectVisualizeSaveFormat(itemId))
 
-  const config = {
-    displayModeBar: true,
-    // scrollZoom: true,
-    responsive: true,
-    toImageButtonOptions: {
-      format: saveFormat,
-      filename: saveFileName,
-    },
+  const config = useMemo(
+    () => ({
+      displayModeBar: true,
+      // scrollZoom: true,
+      responsive: true,
+      toImageButtonOptions: {
+        format: saveFormat,
+        filename: saveFileName,
+      },
+    }),
+    [saveFormat, saveFileName],
+  )
+
+  if (!isMounted) {
+    return <div ref={plotRef} style={{ width: "100%", height: "100%" }} />
   }
+
   return (
-    <PlotlyChart
-      onClick={onChartClick}
-      data={data}
-      layout={layout}
-      config={config}
-    />
+    <div ref={plotRef} style={{ width: "100%", height: "100%" }}>
+      <PlotlyChart
+        onClick={onChartClick}
+        data={data}
+        layout={layout}
+        config={config}
+      />
+    </div>
   )
 })
 


### PR DESCRIPTION
### Content
Fixed a React error that occurred when displaying RoiPlot.tsx.

#### Ploblems

When displaying RoiPlot.tsx, changing the browser width causes the following React error.

```
ERROR
Resize must be passed a displayed plot div element.
    at http://localhost:3001/static/js/bundle.js:316176:14
    at new Promise (<anonymous>)
    at __webpack_modules__../node_modules/plotly.js/src/plots/plots.js.plots.resize 
(http://localhost:3001/static/js/bundle.js:316174:11)
    at PlotlyChart._this.resize (http://localhost:3001/static/js/bundle.js:454980:22)
```

#### Solution

Added a check to ensure the target DOM is mounted before drawing PlotlyChart.

### Test Case

1. Verify normal operation
    - Visualize Screen
      - [x] Display ROI in Visualize Item
      - [x] Edit ROI in Visualize Item
    - Workflow Screen
      - [x] Display ROI in Output

2. Verify that the error has been resolved
    - Workflow Screen
      - [x] Display ROI in Output and confirm that no react errors occur even when changing the Windows width.
      - [x] Close Output, display ROI again, and confirm that no react errors occur even when changing the Windows width.
