### PR TITLE
Refactoring run_sync_data_capacity.py etc

### DIFF
--- a/run_sync_data_capacity.py
+++ b/run_sync_data_capacity.py
@@ -2,33 +2,55 @@ import argparse
 
 from sqlmodel import select
 
+from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.workspace.workspace_data_capacity_services import (
     WorkspaceDataCapacityService,
 )
 from studio.app.common.db.database import session_scope
 from studio.app.common.models.workspace import Workspace
 
+logger = AppLogger.get_logger()
+
 
 def main(args):
     if WorkspaceDataCapacityService.is_available():
+        if args.delete_existing:
+            logger.info(
+                "Running with --delete-existing flag"
+                " - will delete and recreate all records"
+            )
+        else:
+            logger.info(
+                "Running without --delete-existing flag - will update existing records"
+            )
+
         with session_scope() as db:
             workspace_list = db.execute(
                 select(Workspace.id).filter(Workspace.deleted.is_(False))
             ).scalars()
             for workspace_id in workspace_list:
-                WorkspaceDataCapacityService.update_workspace_data_usage(
-                    db, str(workspace_id)
+                logger.info(
+                    f"Syncing workspace data capacity for workspace: [{workspace_id}]"
                 )
-                WorkspaceDataCapacityService.recalculate_workspace_data_capacity(
-                    db, str(workspace_id)
+                WorkspaceDataCapacityService.sync_workspace_data_capacity(
+                    db, str(workspace_id), delete_existing=args.delete_existing
                 )
     else:
+        # Single-user mode always uses delete_existing=True (default)
         WorkspaceDataCapacityService.recalculate_workspace_data_capacity(
-            db=None, workspace_id="1"
+            db=None, workspace_id="1", delete_existing=args.delete_existing
         )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Sync workspace data capacity for all workspaces"
+    )
+    parser.add_argument(
+        "--delete-existing",
+        action="store_true",
+        help="Delete all existing records before syncing. "
+        "Without this flag, existing records will be updated (upsert).",
+    )
 
     main(parser.parse_args())

--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -67,6 +67,7 @@ class ExperimentRecordService:
         workspace_id: str,
         unique_id: str,
         new_unique_id: str,
+        _new_name: str,
         auto_commit: bool = False,
     ):
         try:

--- a/studio/app/common/core/experiment/experiment_services.py
+++ b/studio/app/common/core/experiment/experiment_services.py
@@ -56,11 +56,16 @@ class ExperimentService:
         created_unique_ids = []
         try:
             for unique_id in copyItem.uidList:
+                config = ExptConfigReader.read(workspace_id, unique_id)
                 new_unique_id = WorkflowRunner.create_workflow_unique_id()
-                ExptDataWriter(
+                new_name = f"{config.name}_copy"
+                success = ExptDataWriter(
                     workspace_id,
                     unique_id,
-                ).copy_data(new_unique_id)
+                ).copy_data(new_unique_id, new_name)
+
+                if not success:
+                    raise Exception(f"Failed to copy data for unique_id: {unique_id}")
 
                 if ExperimentRecordService.is_available():
                     ExperimentRecordService.copy_record(
@@ -68,6 +73,7 @@ class ExperimentService:
                         workspace_id,
                         unique_id,
                         new_unique_id,
+                        new_name,
                         auto_commit=True,
                     )
 

--- a/studio/app/common/core/experiment/experiment_writer.py
+++ b/studio/app/common/core/experiment/experiment_writer.py
@@ -189,7 +189,7 @@ class ExptDataWriter:
 
         return ExptConfigReader.read(self.workspace_id, self.unique_id)
 
-    def copy_data(self, new_unique_id: str) -> bool:
+    def copy_data(self, new_unique_id: str, new_name: str) -> bool:
         logger = AppLogger.get_logger()
 
         try:
@@ -206,7 +206,7 @@ class ExptDataWriter:
 
             # Update experiment configuration and unique IDs
             if not self.__copy_data_update_experiment_config_name(
-                self.workspace_id, new_unique_id
+                self.workspace_id, new_unique_id, new_name
             ):
                 logger.error("Failed to update experiment.yml after copying.")
                 return False
@@ -365,15 +365,13 @@ class ExptDataWriter:
             return obj
 
     def __copy_data_update_experiment_config_name(
-        self, workspace_id: str, unique_id: str
+        self, workspace_id: str, unique_id: str, new_name: str
     ) -> bool:
         logger = AppLogger.get_logger()
 
         try:
-            config = ExptConfigReader.read(workspace_id, unique_id)
-
             # Overwrite experiment config
-            update_params = {"name": f"{config.name}_copy"}
+            update_params = {"name": new_name}
             ExptConfigWriter(workspace_id, unique_id).overwrite(update_params)
 
             logger.info(f"Updated experiment.yml: {workspace_id}/{unique_id}")


### PR DESCRIPTION
### Content

#### 1. Refactoring run_sync_data_capacity.py

- Commonized processing functions
  - Modifying the module to assume it will be called from another module
- Added startup parameter (--delete-existing)

#### 2. Refactoring ExperimentService.copy_experiment

- Considering future modifications, the logic for creating record new names has been extracted externally.

### Testcase

#### 1. Refactoring run_sync_data_capacity.py

- [x] 1. `python run_sync_data_capacity.py`
  - Capacity recalculation is performed successfully (records under existing workspaces are preserved).
- [x] 2. `python run_sync_data_capacity.py --delete-existing`
  - Capacity recalculation is performed successfully (all records under existing workspaces are recreated).

#### 2. Refactoring ExperimentService.copy_experiment

Verifying proper record copying from the Record screen
- [x] 1. Copying a single record
- [x] 2. Copying multiple records