### PR TITLE
Update to use clang to avoid error caused by package conflicts

### DIFF
--- a/studio/config/docker/Dockerfile
+++ b/studio/config/docker/Dockerfile
@@ -7,8 +7,12 @@ RUN apt-get --allow-releaseinfo-change update && \
     apt-get install --no-install-recommends -y sudo procps iproute2 iputils-ping telnet wget curl unzip less vim
 
 # install conda & packages
-RUN apt-get install --no-install-recommends -y gcc g++ libgl1 libgl1-mesa-dev libopencv-dev && \
+RUN apt-get install --no-install-recommends -y gcc g++ clang libgl1 libgl1-mesa-dev libopencv-dev && \
     apt-get autoremove -y && apt-get clean
+
+# Specify compiler (use clang)
+ENV CC=clang CXX=clang++
+
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \

--- a/studio/config/docker/Dockerfile.dev
+++ b/studio/config/docker/Dockerfile.dev
@@ -7,8 +7,12 @@ RUN apt-get --allow-releaseinfo-change update && \
     apt-get install --no-install-recommends -y sudo procps iproute2 iputils-ping telnet wget curl unzip less vim
 
 # install conda & packages
-RUN apt-get install --no-install-recommends -y gcc g++ libgl1 libgl1-mesa-dev libopencv-dev && \
+RUN apt-get install --no-install-recommends -y gcc g++ clang libgl1 libgl1-mesa-dev libopencv-dev && \
     apt-get autoremove -y && apt-get clean
+
+# Specify compiler (use clang)
+ENV CC=clang CXX=clang++
+
 RUN mkdir -p /opt/miniforge && \
     curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -o /opt/miniforge/Miniforge3.sh && \
     bash /opt/miniforge/Miniforge3.sh -b -u -p /opt/miniforge && \


### PR DESCRIPTION
### Content

Update Dockerfile to have the same `clang` usage update as is working correctly in Dockerfile.test

See https://github.com/arayabrain/barebone-studio/issues/909 for more details

### Testcases

#### Procedure

1. docker build
    - [ ] production
      `docker compose -f docker-compose.yml build studio`
    - [ ] development
       `docker compose -f docker-compose.dev.yml build studio-dev-be`
2. docker run & run workflow
    - [ ] production
    - [ ] development

#### Platforms

- [x] Mac
- [ ] Windows
- [ ] Ubuntu