### PR TITLE
Update pyproject toml to include pulp to avoid cbc cwd error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4702,4 +4702,4 @@ pyyaml = ">=6.0,<7.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c213e0d616af790ae2066191a28b112a803a7ca02fc311a11f09d158e9f2386e"
+content-hash = "13548c44d68f501362b45ad5484b28f0c717a4ca1e2a3e16027c8834879f3c81"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4702,4 +4702,4 @@ pyyaml = ">=6.0,<7.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "95c7b17700ac5f26f608b81747688d8a690a0064bbe05dcddab2435ce457bd21"
+content-hash = "c213e0d616af790ae2066191a28b112a803a7ca02fc311a11f09d158e9f2386e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ concurrent-log-handler = "^0.9.25"
 numpydoc = "*"
 yapf = "*"
 setuptools = "<70"
-pulp = "2.9.0"
+pulp = {extras = ["cbc"], version = "*"}
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ concurrent-log-handler = "^0.9.25"
 numpydoc = "*"
 yapf = "*"
 setuptools = "<70"
+pulp = "2.9.0"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
### Content

Error caused by lack of cbc package. Pulp seems to be imported as a dependency now, but was not being installed directly, so Pulp dependencies were not installed. This caused an error. 

Log error:

> 2025-09-04 14:00:00,022 ERROR:    [optinist] (6360) _snakemake_execute_process():113 - snakemake_execute failed: Pulp: cannot execute cbc cwd: /private/tmp/studio/output/1/cd5c6983
> 2025-09-04 14:00:00,022 ERROR:    [cd5c6983] (6360) _snakemake_execute_process():117 - Pulp: cannot execute cbc cwd: /private/tmp/studio/output/1/cd5c6983
> 2025-09-04 14:00:00,023 ERROR:    [optinist] (6360) _snakemake_execute_process():122 - snakemake_execute failed..
> ### Others
