### PR TITLE
Improve FileSelectDialog - Added FilterBox etc

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
@@ -43,8 +43,6 @@ describe("TreeItemLabel Component", () => {
           label="testFile"
           isDir={false}
           checkboxProps={{ checked: false, onChange: jest.fn() }}
-          setSelectedFilePath={jest.fn()}
-          selectedFilePath={""}
           filePath="testFile"
         />
       </Provider>,
@@ -77,8 +75,6 @@ describe("TreeItemLabel Component", () => {
           label="testFile"
           isDir={false}
           checkboxProps={{ checked: false, onChange: jest.fn() }}
-          setSelectedFilePath={jest.fn()}
-          selectedFilePath={""}
           filePath="testFile"
         />
       </Provider>,
@@ -105,8 +101,6 @@ describe("TreeItemLabel Component", () => {
           label="testFile"
           isDir={false}
           checkboxProps={{ checked: true, onChange: jest.fn() }}
-          setSelectedFilePath={jest.fn()}
-          selectedFilePath={""}
           filePath="testFile"
         />
       </Provider>,
@@ -126,8 +120,6 @@ describe("TreeItemLabel Component", () => {
           label="testFile"
           isDir={false}
           checkboxProps={{ checked: false, onChange: jest.fn() }}
-          setSelectedFilePath={jest.fn()}
-          selectedFilePath={""}
           filePath="testFile"
         />
       </Provider>,

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
@@ -45,6 +45,7 @@ describe("TreeItemLabel Component", () => {
           checkboxProps={{ checked: false, onChange: jest.fn() }}
           setSelectedFilePath={jest.fn()}
           selectedFilePath={""}
+          filePath="testFile"
         />
       </Provider>,
     )
@@ -61,7 +62,7 @@ describe("TreeItemLabel Component", () => {
       deleteFile({
         workspaceId: 123,
         fileName: "testFile",
-        fileType: "image",
+        fileType: "all",
       }),
     )
   })
@@ -78,6 +79,7 @@ describe("TreeItemLabel Component", () => {
           checkboxProps={{ checked: false, onChange: jest.fn() }}
           setSelectedFilePath={jest.fn()}
           selectedFilePath={""}
+          filePath="testFile"
         />
       </Provider>,
     )
@@ -105,6 +107,7 @@ describe("TreeItemLabel Component", () => {
           checkboxProps={{ checked: true, onChange: jest.fn() }}
           setSelectedFilePath={jest.fn()}
           selectedFilePath={""}
+          filePath="testFile"
         />
       </Provider>,
     )
@@ -125,6 +128,7 @@ describe("TreeItemLabel Component", () => {
           checkboxProps={{ checked: false, onChange: jest.fn() }}
           setSelectedFilePath={jest.fn()}
           selectedFilePath={""}
+          filePath="testFile"
         />
       </Provider>,
     )

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
@@ -8,7 +8,7 @@ import "@testing-library/jest-dom"
 import { Store, AnyAction } from "@reduxjs/toolkit"
 import { render, screen } from "@testing-library/react"
 
-import { TreeItemLabel } from "components/Workspace/FlowChart/Dialog/FileSelectDialog"
+import { FileTreeItemLabel } from "components/Workspace/FlowChart/Dialog/FileSelectDialog"
 import { AppDispatch } from "store/store"
 
 // Create a mock context
@@ -40,13 +40,13 @@ describe("TreeItemLabel Component", () => {
     mockOnOpenDeleteDialog.mockClear()
   })
 
-  it("should render TreeItemLabel component", () => {
+  it("should render FileTreeItemLabel component", () => {
     render(
       <Provider store={store}>
         <MockFileTreeActionsContext.Provider
           value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
         >
-          <TreeItemLabel
+          <FileTreeItemLabel
             multiSelect={true}
             fileType="all"
             shape={[100, 100]}
@@ -70,7 +70,7 @@ describe("TreeItemLabel Component", () => {
         <MockFileTreeActionsContext.Provider
           value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
         >
-          <TreeItemLabel
+          <FileTreeItemLabel
             multiSelect={true}
             fileType="all"
             shape={[100, 100]}
@@ -93,7 +93,7 @@ describe("TreeItemLabel Component", () => {
         <MockFileTreeActionsContext.Provider
           value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
         >
-          <TreeItemLabel
+          <FileTreeItemLabel
             multiSelect={true}
             fileType="all"
             shape={[100, 100]}

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.test.tsx
@@ -1,18 +1,24 @@
+import React, { createContext } from "react"
 import { Provider } from "react-redux"
 
-import configureStore from "redux-mock-store"
+import { default as configureStore } from "redux-mock-store"
 
-import { describe, it, beforeEach } from "@jest/globals"
+import { describe, it, beforeEach, jest, expect } from "@jest/globals"
+import "@testing-library/jest-dom"
 import { Store, AnyAction } from "@reduxjs/toolkit"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 
 import { TreeItemLabel } from "components/Workspace/FlowChart/Dialog/FileSelectDialog"
-import { deleteFile } from "store/slice/FilesTree/FilesTreeAction"
 import { AppDispatch } from "store/store"
 
-jest.mock("store/slice/FilesTree/FilesTreeAction", () => ({
-  deleteFile: jest.fn(),
-}))
+// Create a mock context
+type FileTreeActionsContextType = {
+  onOpenDeleteDialog: (filePath: string, fileName: string) => void
+}
+const MockFileTreeActionsContext =
+  createContext<FileTreeActionsContextType | null>(null)
+
+const mockOnOpenDeleteDialog = jest.fn()
 
 const mockStore = configureStore<
   Partial<{ workspace: { currentWorkspace: { workspaceId?: number } } }>,
@@ -31,101 +37,76 @@ describe("TreeItemLabel Component", () => {
       },
     })
     store.dispatch = jest.fn()
+    mockOnOpenDeleteDialog.mockClear()
   })
 
-  it("should dispatch deleteFile action when delete is confirmed", () => {
+  it("should render TreeItemLabel component", () => {
     render(
       <Provider store={store}>
-        <TreeItemLabel
-          multiSelect={true}
-          fileType="all"
-          shape={[100, 100]}
-          label="testFile"
-          isDir={false}
-          checkboxProps={{ checked: false, onChange: jest.fn() }}
-          filePath="testFile"
-        />
+        <MockFileTreeActionsContext.Provider
+          value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
+        >
+          <TreeItemLabel
+            multiSelect={true}
+            fileType="all"
+            shape={[100, 100]}
+            label="testFile"
+            isDir={false}
+            checkboxProps={{ checked: false, onChange: jest.fn() }}
+            filePath="testFile"
+          />
+        </MockFileTreeActionsContext.Provider>
       </Provider>,
     )
 
-    // Simulate opening the delete confirmation dialog
-    const deleteIcon = screen.getByTestId("DeleteIcon")
-    fireEvent.click(deleteIcon)
-
-    // Confirm the delete action
-    const confirmButton = screen.getByRole("button", { name: /DELETE/i })
-    fireEvent.click(confirmButton)
-
-    expect(store.dispatch).toHaveBeenCalledWith(
-      deleteFile({
-        workspaceId: 123,
-        fileName: "testFile",
-        fileType: "all",
-      }),
-    )
-  })
-
-  it("should not dispatch deleteFile action if confirmation clicked no", () => {
-    render(
-      <Provider store={store}>
-        <TreeItemLabel
-          multiSelect={true}
-          fileType="all"
-          shape={[100, 100]}
-          label="testFile"
-          isDir={false}
-          checkboxProps={{ checked: false, onChange: jest.fn() }}
-          filePath="testFile"
-        />
-      </Provider>,
-    )
-
-    // Simulate opening the delete confirmation dialog
-    const deleteIcon = screen.getByTestId("DeleteIcon")
-    fireEvent.click(deleteIcon)
-
-    // Confirm the delete action
-    const confirmButton = screen.getByRole("button", { name: /CANCEL/i })
-    fireEvent.click(confirmButton)
-
-    expect(store.dispatch).not.toHaveBeenCalledWith(deleteFile)
+    // Check that the delete button exists
+    const deleteButton = screen.getByTestId("DeleteIconBtn")
+    expect(deleteButton).toBeTruthy()
   })
 
   it("should disable delete button if the file checkbox is checked", () => {
     render(
       <Provider store={store}>
-        <TreeItemLabel
-          multiSelect={true}
-          fileType="all"
-          shape={[100, 100]}
-          label="testFile"
-          isDir={false}
-          checkboxProps={{ checked: true, onChange: jest.fn() }}
-          filePath="testFile"
-        />
+        <MockFileTreeActionsContext.Provider
+          value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
+        >
+          <TreeItemLabel
+            multiSelect={true}
+            fileType="all"
+            shape={[100, 100]}
+            label="testFile"
+            isDir={false}
+            checkboxProps={{ checked: true, onChange: jest.fn() }}
+            filePath="testFile"
+          />
+        </MockFileTreeActionsContext.Provider>
       </Provider>,
     )
 
     const deleteButton = screen.getByTestId("DeleteIconBtn")
-    expect(deleteButton).toBeDisabled()
+    expect(deleteButton.hasAttribute("disabled")).toBe(true)
   })
 
   it("should enable delete button if the file checkbox is not checked", () => {
     render(
       <Provider store={store}>
-        <TreeItemLabel
-          multiSelect={true}
-          fileType="all"
-          shape={[100, 100]}
-          label="testFile"
-          isDir={false}
-          checkboxProps={{ checked: false, onChange: jest.fn() }}
-          filePath="testFile"
-        />
+        <MockFileTreeActionsContext.Provider
+          value={{ onOpenDeleteDialog: mockOnOpenDeleteDialog }}
+        >
+          <TreeItemLabel
+            multiSelect={true}
+            fileType="all"
+            shape={[100, 100]}
+            label="testFile"
+            isDir={false}
+            checkboxProps={{ checked: false, onChange: jest.fn() }}
+            filePath="testFile"
+          />
+        </MockFileTreeActionsContext.Provider>
       </Provider>,
     )
 
-    const deleteButton = screen.getByTestId("DeleteIcon")
-    expect(deleteButton).toBeEnabled()
+    const deleteButton = screen.getByTestId("DeleteIconBtn")
+    expect(deleteButton.hasAttribute("disabled")).toBe(false)
   })
 })

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -287,6 +287,53 @@ const FileTreeView = memo(function FileTreeView({
     }
   }
 
+  // Check all functionality
+  const getAllFiles = useCallback((): string[] => {
+    if (!tree) return []
+    const files: string[] = []
+    const collectFiles = (nodes: TreeNodeType[]) => {
+      nodes.forEach((node) => {
+        if (!node.isDir) {
+          files.push(node.path)
+        } else if (node.nodes) {
+          collectFiles(node.nodes)
+        }
+      })
+    }
+    collectFiles(tree)
+    return files
+  }, [tree])
+
+  const isAllChecked = useCallback(() => {
+    if (!Array.isArray(selectedFilePath) || !tree) return false
+    const allFiles = getAllFiles()
+    return (
+      allFiles.length > 0 &&
+      allFiles.every((file) => selectedFilePath.includes(file))
+    )
+  }, [selectedFilePath, tree, getAllFiles])
+
+  const isSomeChecked = useCallback(() => {
+    if (!Array.isArray(selectedFilePath) || !tree) return false
+    const allFiles = getAllFiles()
+    return (
+      allFiles.some((file) => selectedFilePath.includes(file)) &&
+      !isAllChecked()
+    )
+  }, [selectedFilePath, tree, getAllFiles, isAllChecked])
+
+  const handleCheckAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        const allFiles = getAllFiles()
+        setSelectedFilePath(allFiles)
+      } else {
+        setSelectedFilePath([])
+      }
+    },
+    [getAllFiles, setSelectedFilePath],
+  )
+
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
     setIsDragging(true)
@@ -345,9 +392,24 @@ const FileTreeView = memo(function FileTreeView({
             paddingBottom: "6px",
           }}
         >
-          <Typography sx={{ width: `${columnWidth}%`, ...ellipsisStyle }}>
-            Files
-          </Typography>
+          <Box
+            sx={{
+              width: `${columnWidth}%`,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            {multiSelect && (
+              <StyledCheckbox
+                checked={isAllChecked()}
+                indeterminate={isSomeChecked()}
+                onChange={(e) => handleCheckAll(e.target.checked)}
+                size="small"
+                disableRipple
+              />
+            )}
+            <Typography sx={{ ...ellipsisStyle }}>Files</Typography>
+          </Box>
           <StyledColumnResizer
             sx={{ left: `calc(${columnWidth}% - 5px)` }}
             onMouseDown={handleMouseDown}

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -587,7 +587,7 @@ const FileTreeView = memo(function FileTreeView({
         <Box sx={{ flex: 1, overflow: "auto", px: 1 }}>
           <TreeView disableSelection={multiSelect} multiSelect={multiSelect}>
             {filteredTree?.map((node) => (
-              <TreeNode
+              <FileTreeNode
                 fileType={fileType}
                 key={node.name}
                 node={node}
@@ -615,7 +615,7 @@ const FileTreeView = memo(function FileTreeView({
   )
 })
 
-interface TreeNodeProps {
+interface FileTreeNodeProps {
   fileType: FILE_TREE_TYPE
   node: TreeNodeType
   selectedFilePath: string[] | string
@@ -626,7 +626,7 @@ interface TreeNodeProps {
   columnWidth?: number
 }
 
-const TreeNode = memo(function TreeNode({
+const FileTreeNode = memo(function FileTreeNode({
   fileType,
   node,
   selectedFilePath,
@@ -635,7 +635,7 @@ const TreeNode = memo(function TreeNode({
   onCheckFile,
   setSelectedFilePath,
   columnWidth = COLUMN_DEFAULT_WIDTH,
-}: TreeNodeProps) {
+}: FileTreeNodeProps) {
   if (node.isDir) {
     const allChecked =
       Array.isArray(selectedFilePath) &&
@@ -660,7 +660,7 @@ const TreeNode = memo(function TreeNode({
           },
         }}
         label={
-          <TreeItemLabel
+          <FileTreeItemLabel
             multiSelect={multiSelect}
             isDir={node.isDir}
             fileType={fileType}
@@ -685,7 +685,7 @@ const TreeNode = memo(function TreeNode({
         }
       >
         {node.nodes.map((childNode, i) => (
-          <TreeNode
+          <FileTreeNode
             fileType={fileType}
             node={childNode}
             selectedFilePath={selectedFilePath}
@@ -710,7 +710,7 @@ const TreeNode = memo(function TreeNode({
           },
         }}
         label={
-          <TreeItemLabel
+          <FileTreeItemLabel
             multiSelect={multiSelect}
             isDir={node.isDir}
             fileType={fileType}
@@ -752,7 +752,7 @@ const TreeNode = memo(function TreeNode({
   }
 })
 
-interface TreeItemLabelProps {
+interface FileTreeItemLabelProps {
   fileType: FILE_TREE_TYPE
   shape: number[]
   label: string
@@ -764,7 +764,7 @@ interface TreeItemLabelProps {
   filePath: string
 }
 
-export const TreeItemLabel = memo(function TreeItemLabel({
+export const FileTreeItemLabel = memo(function FileTreeItemLabel({
   fileType,
   shape,
   label,
@@ -774,7 +774,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
   multiSelect,
   columnWidth = COLUMN_DEFAULT_WIDTH,
   filePath,
-}: TreeItemLabelProps) {
+}: FileTreeItemLabelProps) {
   const dispatch = useDispatch<AppDispatch>()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const fileTreeActions = useContext(FileTreeActionsContext)

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -6,6 +6,7 @@ import React, {
   MouseEvent,
   useCallback,
   useRef,
+  useMemo,
 } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
@@ -27,12 +28,21 @@ import {
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import AutorenewIcon from "@mui/icons-material/Autorenew"
+import ClearIcon from "@mui/icons-material/Clear"
 import CloseIcon from "@mui/icons-material/Close"
 import DeleteIcon from "@mui/icons-material/Delete"
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator"
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline"
 import FolderIcon from "@mui/icons-material/Folder"
-import { Divider, IconButton, Tooltip, Chip } from "@mui/material"
+import SearchIcon from "@mui/icons-material/Search"
+import {
+  Divider,
+  IconButton,
+  Tooltip,
+  Chip,
+  InputAdornment,
+  TextField,
+} from "@mui/material"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import Checkbox, { CheckboxProps } from "@mui/material/Checkbox"
@@ -220,6 +230,7 @@ const FileTreeView = memo(function FileTreeView({
   const [initialized, setInitialized] = useState(false)
   const [columnWidth, setColumnWidth] = useState(COLUMN_DEFAULT_WIDTH) // Column width in percentage
   const [isDragging, setIsDragging] = useState(false)
+  const [filterText, setFilterText] = useState("") // Filter text state
 
   // Helper function to check if a file exists in the tree
   const isFileInTree = (path: string, tree: TreeNodeType[] | null): boolean => {
@@ -286,9 +297,60 @@ const FileTreeView = memo(function FileTreeView({
     }
   }
 
-  // Check all functionality
+  // Filter functionality
+  const matchesFilter = useCallback((path: string, filter: string): boolean => {
+    if (!filter) return true
+
+    // Convert wildcard pattern to regex
+    const pattern = filter
+      .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars
+      .replace(/\*/g, ".*") // Convert * to .*
+
+    const regex = new RegExp(pattern, "i") // Case insensitive
+    return regex.test(path)
+  }, [])
+
+  // Get filtered tree and counts
+  const { filteredTree, totalFileCount, filteredFileCount } = useMemo(() => {
+    if (!tree)
+      return { filteredTree: null, totalFileCount: 0, filteredFileCount: 0 }
+
+    let totalCount = 0
+    let filteredCount = 0
+
+    const filterNodes = (nodes: TreeNodeType[]): TreeNodeType[] => {
+      return nodes
+        .map((node) => {
+          if (node.isDir) {
+            const filteredChildren = filterNodes(node.nodes)
+            // Include directory if it has any visible children
+            if (filteredChildren.length > 0) {
+              return { ...node, nodes: filteredChildren }
+            }
+            return null
+          } else {
+            totalCount++
+            if (matchesFilter(node.path, filterText)) {
+              filteredCount++
+              return node
+            }
+            return null
+          }
+        })
+        .filter((node): node is TreeNodeType => node !== null)
+    }
+
+    const filtered = filterNodes(tree)
+    return {
+      filteredTree: filtered,
+      totalFileCount: totalCount,
+      filteredFileCount: filteredCount,
+    }
+  }, [tree, filterText, matchesFilter])
+
+  // Check all functionality (use filtered files)
   const getAllFiles = useCallback((): string[] => {
-    if (!tree) return []
+    if (!filteredTree) return []
     const files: string[] = []
     const collectFiles = (nodes: TreeNodeType[]) => {
       nodes.forEach((node) => {
@@ -299,27 +361,27 @@ const FileTreeView = memo(function FileTreeView({
         }
       })
     }
-    collectFiles(tree)
+    collectFiles(filteredTree)
     return files
-  }, [tree])
+  }, [filteredTree])
 
   const isAllChecked = useCallback(() => {
-    if (!Array.isArray(selectedFilePath) || !tree) return false
+    if (!Array.isArray(selectedFilePath) || !filteredTree) return false
     const allFiles = getAllFiles()
     return (
       allFiles.length > 0 &&
       allFiles.every((file) => selectedFilePath.includes(file))
     )
-  }, [selectedFilePath, tree, getAllFiles])
+  }, [selectedFilePath, filteredTree, getAllFiles])
 
   const isSomeChecked = useCallback(() => {
-    if (!Array.isArray(selectedFilePath) || !tree) return false
+    if (!Array.isArray(selectedFilePath) || !filteredTree) return false
     const allFiles = getAllFiles()
     return (
       allFiles.some((file) => selectedFilePath.includes(file)) &&
       !isAllChecked()
     )
-  }, [selectedFilePath, tree, getAllFiles, isAllChecked])
+  }, [selectedFilePath, filteredTree, getAllFiles, isAllChecked])
 
   const handleCheckAll = useCallback(
     (checked: boolean) => {
@@ -379,6 +441,54 @@ const FileTreeView = memo(function FileTreeView({
       style={{ display: "flex", flexDirection: "column", height: "100%" }}
     >
       {isLoading && <LinearProgress />}
+      {/* Filter input */}
+      <Box sx={{ px: 1, pt: 0.75, pb: 2 }}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="Filter... (* as wildcard)"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+            endAdornment: filterText && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => setFilterText("")}
+                  edge="end"
+                >
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        {/* File count info */}
+        {filterText && (
+          <Box
+            sx={{ mt: 0.5, display: "flex", alignItems: "center", gap: 0.5 }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              Showing
+            </Typography>
+            <Chip
+              label={filteredFileCount}
+              size="small"
+              sx={{ height: "18px", fontSize: "0.7rem" }}
+              color={filteredFileCount === 0 ? "default" : "primary"}
+              variant="outlined"
+            />
+            <Typography variant="caption" color="text.secondary">
+              of {totalFileCount} files
+            </Typography>
+          </Box>
+        )}
+      </Box>
       <>
         <Box
           sx={{
@@ -389,6 +499,10 @@ const FileTreeView = memo(function FileTreeView({
             zIndex: 5,
             userSelect: "none",
             paddingBottom: "6px",
+            borderTop: "1px solid",
+            borderTopColor: "divider",
+            px: 1,
+            pt: "6px",
           }}
         >
           <Box
@@ -421,9 +535,9 @@ const FileTreeView = memo(function FileTreeView({
         </Box>
         <Divider />
       </>
-      <Box sx={{ flex: 1, overflow: "auto" }}>
+      <Box sx={{ flex: 1, overflow: "auto", px: 1 }}>
         <TreeView disableSelection={multiSelect} multiSelect={multiSelect}>
-          {tree?.map((node) => (
+          {filteredTree?.map((node) => (
             <TreeNode
               fileType={fileType}
               key={node.name}

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   useRef,
   useMemo,
+  createContext,
 } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
@@ -76,6 +77,14 @@ import { AppDispatch } from "store/store"
 const COLUMN_MIN_WIDTH = 20
 const COLUMN_MAX_WIDTH = 80
 const COLUMN_DEFAULT_WIDTH = 50
+
+// Context for file tree actions
+type FileTreeActionsContextType = {
+  onOpenDeleteDialog: (filePath: string, fileName: string) => void
+}
+const FileTreeActionsContext = createContext<FileTreeActionsContextType | null>(
+  null,
+)
 
 // Styled components (5+ attributes or commonly used)
 const StyledColumnResizer = styled(Box)({
@@ -231,6 +240,11 @@ const FileTreeView = memo(function FileTreeView({
   const [columnWidth, setColumnWidth] = useState(COLUMN_DEFAULT_WIDTH) // Column width in percentage
   const [isDragging, setIsDragging] = useState(false)
   const [filterText, setFilterText] = useState("") // Filter text state
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [deleteTargetFile, setDeleteTargetFile] = useState<{
+    path: string
+    name: string
+  } | null>(null)
 
   // Helper function to check if a file exists in the tree
   const isFileInTree = (path: string, tree: TreeNodeType[] | null): boolean => {
@@ -405,6 +419,40 @@ const FileTreeView = memo(function FileTreeView({
   }, [])
 
   const containerRef = useRef<HTMLDivElement>(null)
+  const dispatch = useDispatch<AppDispatch>()
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
+
+  const onOpenDeleteDialog = useCallback(
+    (filePath: string, fileName: string) => {
+      setDeleteTargetFile({ path: filePath, name: fileName })
+      setDeleteDialogOpen(true)
+    },
+    [],
+  )
+
+  const onDeleteFile = useCallback(() => {
+    if (!workspaceId || !deleteTargetFile) return
+
+    // Remove the file from selectedFile state
+    if (Array.isArray(selectedFilePath)) {
+      setSelectedFilePath(
+        selectedFilePath.filter((file) => file !== deleteTargetFile.path),
+      )
+    }
+
+    dispatch(
+      deleteFile({ workspaceId, fileName: deleteTargetFile.path, fileType }),
+    )
+    setDeleteDialogOpen(false)
+    setDeleteTargetFile(null)
+  }, [
+    dispatch,
+    fileType,
+    selectedFilePath,
+    setSelectedFilePath,
+    workspaceId,
+    deleteTargetFile,
+  ])
 
   const handleMouseMove = useCallback(
     (e: Event) => {
@@ -535,23 +583,34 @@ const FileTreeView = memo(function FileTreeView({
         </Box>
         <Divider />
       </>
-      <Box sx={{ flex: 1, overflow: "auto", px: 1 }}>
-        <TreeView disableSelection={multiSelect} multiSelect={multiSelect}>
-          {filteredTree?.map((node) => (
-            <TreeNode
-              fileType={fileType}
-              key={node.name}
-              node={node}
-              selectedFilePath={selectedFilePath}
-              multiSelect={multiSelect}
-              onCheckDir={onCheckDir}
-              onCheckFile={onCheckFile}
-              setSelectedFilePath={setSelectedFilePath}
-              columnWidth={columnWidth}
-            />
-          ))}
-        </TreeView>
-      </Box>
+      <FileTreeActionsContext.Provider value={{ onOpenDeleteDialog }}>
+        <Box sx={{ flex: 1, overflow: "auto", px: 1 }}>
+          <TreeView disableSelection={multiSelect} multiSelect={multiSelect}>
+            {filteredTree?.map((node) => (
+              <TreeNode
+                fileType={fileType}
+                key={node.name}
+                node={node}
+                selectedFilePath={selectedFilePath}
+                multiSelect={multiSelect}
+                onCheckDir={onCheckDir}
+                onCheckFile={onCheckFile}
+                setSelectedFilePath={setSelectedFilePath}
+                columnWidth={columnWidth}
+              />
+            ))}
+          </TreeView>
+        </Box>
+      </FileTreeActionsContext.Provider>
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        setOpen={setDeleteDialogOpen}
+        onConfirm={onDeleteFile}
+        title="Are you sure you want to delete this item?"
+        content={deleteTargetFile?.name || ""}
+        confirmLabel="delete"
+        iconType="warning"
+      />
     </div>
   )
 })
@@ -620,8 +679,6 @@ const TreeNode = memo(function TreeNode({
                   }
                 : undefined
             }
-            setSelectedFilePath={setSelectedFilePath}
-            selectedFilePath={selectedFilePath}
             columnWidth={columnWidth}
             filePath={node.path}
           />
@@ -686,8 +743,6 @@ const TreeNode = memo(function TreeNode({
                 }
               },
             }}
-            setSelectedFilePath={setSelectedFilePath}
-            selectedFilePath={selectedFilePath}
             columnWidth={columnWidth}
             filePath={node.path}
           />
@@ -704,8 +759,6 @@ interface TreeItemLabelProps {
   checkboxProps?: CheckboxProps
   isDir?: boolean
   icon?: React.ReactNode
-  setSelectedFilePath: (path: string[] | string) => void
-  selectedFilePath: string[] | string
   multiSelect: boolean
   columnWidth?: number
   filePath: string
@@ -718,15 +771,14 @@ export const TreeItemLabel = memo(function TreeItemLabel({
   isDir,
   checkboxProps,
   icon,
-  setSelectedFilePath,
-  selectedFilePath,
   multiSelect,
   columnWidth = COLUMN_DEFAULT_WIDTH,
   filePath,
 }: TreeItemLabelProps) {
   const dispatch = useDispatch<AppDispatch>()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
-  const [deleteConfirmDialogOpen, setDeleteConfirmDialogOpen] = useState(false)
+  const fileTreeActions = useContext(FileTreeActionsContext)
+
   const onUpdate = useCallback(
     (event: MouseEvent, fileName: string) => {
       if (!workspaceId) return
@@ -735,29 +787,13 @@ export const TreeItemLabel = memo(function TreeItemLabel({
     },
     [dispatch, workspaceId],
   )
-  const onOpenDeleteConfirmDialog = useCallback(
+  const onOpenDeleteDialogClick = useCallback(
     (event: MouseEvent) => {
-      if (!workspaceId) return
+      if (!workspaceId || !fileTreeActions) return
       event.stopPropagation()
-      setDeleteConfirmDialogOpen(true)
+      fileTreeActions.onOpenDeleteDialog(filePath, label)
     },
-    [workspaceId],
-  )
-  const onDelete = useCallback(
-    (event: MouseEvent, fileName: string) => {
-      if (!workspaceId) return
-      event.stopPropagation()
-
-      // Remove the file from selectedFile state
-      if (Array.isArray(selectedFilePath)) {
-        setSelectedFilePath(
-          selectedFilePath.filter((file) => file !== fileName),
-        )
-      }
-
-      dispatch(deleteFile({ workspaceId, fileName, fileType }))
-    },
-    [dispatch, fileType, selectedFilePath, setSelectedFilePath, workspaceId],
+    [workspaceId, fileTreeActions, filePath, label],
   )
 
   return (
@@ -833,10 +869,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
           <IconButton
             sx={{ minWidth: 24 }}
             color="error"
-            onClick={(event) => {
-              event.stopPropagation()
-              onOpenDeleteConfirmDialog(event)
-            }}
+            onClick={onOpenDeleteDialogClick}
             disabled={checkboxProps?.checked}
             data-testid="DeleteIconBtn"
           >
@@ -844,18 +877,6 @@ export const TreeItemLabel = memo(function TreeItemLabel({
           </IconButton>
         </Box>
       </Box>
-      <ConfirmDialog
-        open={deleteConfirmDialogOpen}
-        setOpen={setDeleteConfirmDialogOpen}
-        onConfirm={() => {
-          onDelete({ stopPropagation: () => {} } as MouseEvent, filePath)
-          setDeleteConfirmDialogOpen(false)
-        }}
-        title="Are you sure you want to delete this item?"
-        content={`${label}`}
-        confirmLabel="delete"
-        iconType="warning"
-      />
     </Box>
   )
 })

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -86,6 +86,23 @@ const FileTreeActionsContext = createContext<FileTreeActionsContextType | null>(
   null,
 )
 
+// Common style objects for reuse
+const commonStyles = {
+  ellipsis: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  flexCenter: {
+    display: "flex",
+    alignItems: "center",
+  },
+  iconButton: {
+    minWidth: 24,
+    padding: "2px",
+  },
+} as const
+
 // Styled components (5+ attributes or commonly used)
 const StyledColumnResizer = styled(Box)({
   width: "10px",
@@ -116,12 +133,155 @@ const StyledCheckbox = styled(Checkbox)({
   minWidth: 24,
 })
 
-// Common style objects for reuse
-const ellipsisStyle = {
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-} as const
+// Custom Hooks
+const useFilteredTree = (
+  tree: TreeNodeType[] | null | undefined,
+  filterText: string,
+) => {
+  const matchesFilter = useCallback((path: string, filter: string): boolean => {
+    if (!filter) return true
+    const pattern = filter
+      .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*/g, ".*")
+    const regex = new RegExp(pattern, "i")
+    return regex.test(path)
+  }, [])
+
+  return useMemo(() => {
+    if (!tree)
+      return { filteredTree: null, totalFileCount: 0, filteredFileCount: 0 }
+
+    let totalCount = 0
+    let filteredCount = 0
+
+    const filterNodes = (nodes: TreeNodeType[]): TreeNodeType[] => {
+      return nodes
+        .map((node) => {
+          if (node.isDir) {
+            const filteredChildren = filterNodes(node.nodes)
+            if (filteredChildren.length > 0) {
+              return { ...node, nodes: filteredChildren }
+            }
+            return null
+          } else {
+            totalCount++
+            if (matchesFilter(node.path, filterText)) {
+              filteredCount++
+              return node
+            }
+            return null
+          }
+        })
+        .filter((node): node is TreeNodeType => node !== null)
+    }
+
+    const filtered = filterNodes(tree)
+    return {
+      filteredTree: filtered,
+      totalFileCount: totalCount,
+      filteredFileCount: filteredCount,
+    }
+  }, [tree, filterText, matchesFilter])
+}
+
+const useColumnResize = (initialWidth = COLUMN_DEFAULT_WIDTH) => {
+  const [columnWidth, setColumnWidth] = useState(initialWidth)
+  const [isDragging, setIsDragging] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }, [])
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  const handleMouseMove = useCallback(
+    (e: Event) => {
+      if (!isDragging || !containerRef.current) return
+      const mouseEvent = e as unknown as MouseEvent
+      const rect = containerRef.current.getBoundingClientRect()
+      const newWidth = ((mouseEvent.clientX - rect.left) / rect.width) * 100
+      setColumnWidth(
+        Math.max(COLUMN_MIN_WIDTH, Math.min(COLUMN_MAX_WIDTH, newWidth)),
+      )
+    },
+    [isDragging],
+  )
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener("mousemove", handleMouseMove)
+      document.addEventListener("mouseup", handleMouseUp)
+      document.body.style.cursor = "col-resize"
+      document.body.style.userSelect = "none"
+      return () => {
+        document.removeEventListener("mousemove", handleMouseMove)
+        document.removeEventListener("mouseup", handleMouseUp)
+        document.body.style.cursor = ""
+        document.body.style.userSelect = ""
+      }
+    }
+    return undefined
+  }, [isDragging, handleMouseMove, handleMouseUp])
+
+  return { columnWidth, handleMouseDown, containerRef }
+}
+
+const useFileSelection = (
+  selectedFilePath: string[] | string,
+  setSelectedFilePath: (path: string[] | string) => void,
+  filteredTree: TreeNodeType[] | null | undefined,
+) => {
+  const getAllFiles = useCallback((): string[] => {
+    if (!filteredTree) return []
+    const files: string[] = []
+    const collectFiles = (nodes: TreeNodeType[]) => {
+      nodes.forEach((node) => {
+        if (!node.isDir) {
+          files.push(node.path)
+        } else if (node.nodes) {
+          collectFiles(node.nodes)
+        }
+      })
+    }
+    collectFiles(filteredTree)
+    return files
+  }, [filteredTree])
+
+  const checkStatus = useMemo(() => {
+    if (!Array.isArray(selectedFilePath) || !filteredTree)
+      return { allChecked: false, someChecked: false }
+
+    const allFiles = getAllFiles()
+    if (allFiles.length === 0) return { allChecked: false, someChecked: false }
+
+    const checkedCount = allFiles.filter((file) =>
+      selectedFilePath.includes(file),
+    ).length
+
+    return {
+      allChecked: checkedCount === allFiles.length,
+      someChecked: checkedCount > 0 && checkedCount < allFiles.length,
+    }
+  }, [selectedFilePath, filteredTree, getAllFiles])
+
+  const handleCheckAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        const allFiles = getAllFiles()
+        setSelectedFilePath(allFiles)
+      } else {
+        setSelectedFilePath([])
+      }
+    },
+    [getAllFiles, setSelectedFilePath],
+  )
+
+  return { checkStatus, handleCheckAll, getAllFiles }
+}
 
 type FileSelectDialogProps = {
   initialFilePath: string[] | string
@@ -236,9 +396,6 @@ const FileTreeView = memo(function FileTreeView({
   multiSelect,
 }: FileTreeViewProps) {
   const [tree, isLoading] = useFileTree(fileType)
-  const [initialized, setInitialized] = useState(false)
-  const [columnWidth, setColumnWidth] = useState(COLUMN_DEFAULT_WIDTH) // Column width in percentage
-  const [isDragging, setIsDragging] = useState(false)
   const [filterText, setFilterText] = useState("") // Filter text state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deleteTargetFile, setDeleteTargetFile] = useState<{
@@ -246,179 +403,98 @@ const FileTreeView = memo(function FileTreeView({
     name: string
   } | null>(null)
 
+  // Use custom hooks
+  const { columnWidth, handleMouseDown, containerRef } = useColumnResize()
+  const { filteredTree, totalFileCount, filteredFileCount } = useFilteredTree(
+    tree,
+    filterText,
+  )
+  const { checkStatus, handleCheckAll } = useFileSelection(
+    selectedFilePath,
+    setSelectedFilePath,
+    filteredTree,
+  )
+
   // Helper function to check if a file exists in the tree
-  const isFileInTree = (path: string, tree: TreeNodeType[] | null): boolean => {
-    if (!tree) return false
-    const checkNode = (node: TreeNodeType): boolean => {
-      if (node.path === path) return true
-      if (node.isDir && node.nodes) {
-        return node.nodes.some(checkNode)
+  const isFileInTree = useCallback(
+    (path: string, tree: TreeNodeType[] | null): boolean => {
+      if (!tree) return false
+      const checkNode = (node: TreeNodeType): boolean => {
+        if (node.path === path) return true
+        if (node.isDir && node.nodes) {
+          return node.nodes.some(checkNode)
+        }
+        return false
       }
-      return false
-    }
-    return tree.some(checkNode)
-  }
+      return tree.some(checkNode)
+    },
+    [],
+  )
 
   // Effect to remove selected file if it's not in the tree
   useEffect(() => {
-    if (!initialized && tree) {
+    if (!tree) return
+
+    const filterValidPaths = (paths: string | string[]) => {
+      if (Array.isArray(paths)) {
+        return paths.filter((p) => isFileInTree(p, tree))
+      }
+      return isFileInTree(paths, tree) ? paths : ""
+    }
+
+    const filtered = filterValidPaths(selectedFilePath)
+    if (JSON.stringify(filtered) !== JSON.stringify(selectedFilePath)) {
+      setSelectedFilePath(filtered)
+    }
+  }, [tree, isFileInTree, selectedFilePath, setSelectedFilePath])
+
+  // File selection handlers
+  const handleFileToggle = useCallback(
+    (path: string) => {
+      if (!Array.isArray(selectedFilePath)) {
+        setSelectedFilePath(path === selectedFilePath ? "" : path)
+        return
+      }
       if (Array.isArray(selectedFilePath)) {
-        const validPaths = selectedFilePath.filter((path) =>
-          isFileInTree(path, tree),
-        )
-        if (validPaths.length !== selectedFilePath.length) {
-          setSelectedFilePath(validPaths)
-        }
-      } else if (selectedFilePath && !isFileInTree(selectedFilePath, tree)) {
-        setSelectedFilePath([])
-      }
-      setInitialized(true) // Prevents re-running on every render
-    }
-  }, [tree, initialized, selectedFilePath, setSelectedFilePath])
-
-  // multiSelectでチェックボックスを使用する時用のハンドラ
-  const onCheckFile = (path: string) => {
-    if (Array.isArray(selectedFilePath)) {
-      if (selectedFilePath.includes(path)) {
         setSelectedFilePath(
-          selectedFilePath.filter((selectedPath) => path !== selectedPath),
+          selectedFilePath.includes(path)
+            ? selectedFilePath.filter((p: string) => p !== path)
+            : [...selectedFilePath, path],
         )
-      } else {
-        setSelectedFilePath(selectedFilePath.concat(path))
-      }
-    }
-  }
-  const onCheckDir = (path: string, checked: boolean) => {
-    if (tree != null && Array.isArray(selectedFilePath)) {
-      const node = getNodeByPath(path, tree)
-      if (node != null && node.isDir) {
-        const childrenFilePathList = node.nodes
-          .filter((node) => !node.isDir)
-          .map((node) => node.path)
-        if (checked) {
-          setSelectedFilePath(
-            // concat時の重複を削除
-            Array.from(new Set(selectedFilePath.concat(childrenFilePathList))),
-          )
-        } else {
-          setSelectedFilePath(
-            selectedFilePath.filter(
-              (selectedPath) => !childrenFilePathList.includes(selectedPath),
-            ),
-          )
-        }
-      }
-    }
-  }
-
-  // Filter functionality
-  const matchesFilter = useCallback((path: string, filter: string): boolean => {
-    if (!filter) return true
-
-    // Convert wildcard pattern to regex
-    const pattern = filter
-      .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars
-      .replace(/\*/g, ".*") // Convert * to .*
-
-    const regex = new RegExp(pattern, "i") // Case insensitive
-    return regex.test(path)
-  }, [])
-
-  // Get filtered tree and counts
-  const { filteredTree, totalFileCount, filteredFileCount } = useMemo(() => {
-    if (!tree)
-      return { filteredTree: null, totalFileCount: 0, filteredFileCount: 0 }
-
-    let totalCount = 0
-    let filteredCount = 0
-
-    const filterNodes = (nodes: TreeNodeType[]): TreeNodeType[] => {
-      return nodes
-        .map((node) => {
-          if (node.isDir) {
-            const filteredChildren = filterNodes(node.nodes)
-            // Include directory if it has any visible children
-            if (filteredChildren.length > 0) {
-              return { ...node, nodes: filteredChildren }
-            }
-            return null
-          } else {
-            totalCount++
-            if (matchesFilter(node.path, filterText)) {
-              filteredCount++
-              return node
-            }
-            return null
-          }
-        })
-        .filter((node): node is TreeNodeType => node !== null)
-    }
-
-    const filtered = filterNodes(tree)
-    return {
-      filteredTree: filtered,
-      totalFileCount: totalCount,
-      filteredFileCount: filteredCount,
-    }
-  }, [tree, filterText, matchesFilter])
-
-  // Check all functionality (use filtered files)
-  const getAllFiles = useCallback((): string[] => {
-    if (!filteredTree) return []
-    const files: string[] = []
-    const collectFiles = (nodes: TreeNodeType[]) => {
-      nodes.forEach((node) => {
-        if (!node.isDir) {
-          files.push(node.path)
-        } else if (node.nodes) {
-          collectFiles(node.nodes)
-        }
-      })
-    }
-    collectFiles(filteredTree)
-    return files
-  }, [filteredTree])
-
-  const isAllChecked = useCallback(() => {
-    if (!Array.isArray(selectedFilePath) || !filteredTree) return false
-    const allFiles = getAllFiles()
-    return (
-      allFiles.length > 0 &&
-      allFiles.every((file) => selectedFilePath.includes(file))
-    )
-  }, [selectedFilePath, filteredTree, getAllFiles])
-
-  const isSomeChecked = useCallback(() => {
-    if (!Array.isArray(selectedFilePath) || !filteredTree) return false
-    const allFiles = getAllFiles()
-    return (
-      allFiles.some((file) => selectedFilePath.includes(file)) &&
-      !isAllChecked()
-    )
-  }, [selectedFilePath, filteredTree, getAllFiles, isAllChecked])
-
-  const handleCheckAll = useCallback(
-    (checked: boolean) => {
-      if (checked) {
-        const allFiles = getAllFiles()
-        setSelectedFilePath(allFiles)
-      } else {
-        setSelectedFilePath([])
       }
     },
-    [getAllFiles, setSelectedFilePath],
+    [selectedFilePath, setSelectedFilePath],
   )
 
-  const handleMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault()
-    setIsDragging(true)
-  }
+  const onCheckDir = useCallback(
+    (path: string, checked: boolean) => {
+      if (tree != null && Array.isArray(selectedFilePath)) {
+        const node = getNodeByPath(path, tree)
+        if (node != null && node.isDir) {
+          const childrenFilePathList = node.nodes
+            .filter((node) => !node.isDir)
+            .map((node) => node.path)
+          if (checked) {
+            setSelectedFilePath(
+              // concat時の重複を削除
+              Array.from(
+                new Set(selectedFilePath.concat(childrenFilePathList)),
+              ),
+            )
+          } else {
+            setSelectedFilePath(
+              selectedFilePath.filter(
+                (selectedPath) => !childrenFilePathList.includes(selectedPath),
+              ),
+            )
+          }
+        }
+      }
+    },
+    [tree, selectedFilePath, setSelectedFilePath],
+  )
 
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false)
-  }, [])
-
-  const containerRef = useRef<HTMLDivElement>(null)
+  // Delete functionality
   const dispatch = useDispatch<AppDispatch>()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
 
@@ -454,34 +530,7 @@ const FileTreeView = memo(function FileTreeView({
     deleteTargetFile,
   ])
 
-  const handleMouseMove = useCallback(
-    (e: Event) => {
-      if (!isDragging || !containerRef.current) return
-      const mouseEvent = e as unknown as MouseEvent
-      const rect = containerRef.current.getBoundingClientRect()
-      const newWidth = ((mouseEvent.clientX - rect.left) / rect.width) * 100
-      setColumnWidth(
-        Math.max(COLUMN_MIN_WIDTH, Math.min(COLUMN_MAX_WIDTH, newWidth)),
-      )
-    },
-    [isDragging],
-  )
-
-  useEffect(() => {
-    if (isDragging) {
-      document.addEventListener("mousemove", handleMouseMove)
-      document.addEventListener("mouseup", handleMouseUp)
-      document.body.style.cursor = "col-resize"
-      document.body.style.userSelect = "none"
-      return () => {
-        document.removeEventListener("mousemove", handleMouseMove)
-        document.removeEventListener("mouseup", handleMouseUp)
-        document.body.style.cursor = ""
-        document.body.style.userSelect = ""
-      }
-    }
-    return undefined
-  }, [isDragging, handleMouseMove, handleMouseUp])
+  // All column resize and filter logic is now handled by custom hooks
 
   return (
     <div
@@ -562,21 +611,24 @@ const FileTreeView = memo(function FileTreeView({
           >
             {multiSelect && (
               <StyledCheckbox
-                checked={isAllChecked()}
-                indeterminate={isSomeChecked()}
+                checked={checkStatus.allChecked}
+                indeterminate={checkStatus.someChecked}
                 onChange={(e) => handleCheckAll(e.target.checked)}
                 size="small"
                 disableRipple
               />
             )}
-            <Typography sx={{ ...ellipsisStyle }}>Files</Typography>
+            <Typography sx={{ ...commonStyles.ellipsis }}>Files</Typography>
           </Box>
           <StyledColumnResizer
             sx={{ left: `calc(${columnWidth}% - 5px)` }}
             onMouseDown={handleMouseDown}
           />
           {fileType === FILE_TREE_TYPE_SET.IMAGE && (
-            <Typography sx={{ flex: 1, ...ellipsisStyle }} marginLeft={2}>
+            <Typography
+              sx={{ flex: 1, ...commonStyles.ellipsis }}
+              marginLeft={2}
+            >
               Shapes
             </Typography>
           )}
@@ -594,7 +646,7 @@ const FileTreeView = memo(function FileTreeView({
                 selectedFilePath={selectedFilePath}
                 multiSelect={multiSelect}
                 onCheckDir={onCheckDir}
-                onCheckFile={onCheckFile}
+                onCheckFile={handleFileToggle}
                 setSelectedFilePath={setSelectedFilePath}
                 columnWidth={columnWidth}
               />
@@ -636,60 +688,78 @@ const FileTreeNode = memo(function FileTreeNode({
   setSelectedFilePath,
   columnWidth = COLUMN_DEFAULT_WIDTH,
 }: FileTreeNodeProps) {
-  if (node.isDir) {
+  // Common tree item props
+  const treeItemProps = {
+    nodeId: node.path,
+    sx: {
+      "& .MuiTreeItem-iconContainer": {
+        width: 0,
+        minWidth: 0,
+      },
+    },
+  }
+
+  // Calculate checkbox props for directories
+  const getDirCheckboxProps = useCallback(() => {
+    if (!node.isDir || !multiSelect) return undefined
+
+    const fileNodes = node.nodes.filter((n) => !n.isDir)
+    if (fileNodes.length === 0) return undefined
+
+    const filePaths = fileNodes.map((n) => n.path)
     const allChecked =
       Array.isArray(selectedFilePath) &&
-      node.nodes
-        .filter((node) => !node.isDir)
-        .map((node) => node.path)
-        .every((filePath) => selectedFilePath.includes(filePath))
-    const allNotChecked =
+      filePaths.every((path) => selectedFilePath.includes(path))
+    const someChecked =
       Array.isArray(selectedFilePath) &&
-      node.nodes
-        .filter((node) => !node.isDir)
-        .map((node) => node.path)
-        .every((filePath) => !selectedFilePath.includes(filePath))
-    const indeterminate = !(allChecked || allNotChecked)
-    return (
-      <TreeItem
-        nodeId={node.path}
-        sx={{
-          "& .MuiTreeItem-iconContainer": {
-            width: 0,
-            minWidth: 0,
-          },
-        }}
-        label={
-          <FileTreeItemLabel
-            multiSelect={multiSelect}
-            isDir={node.isDir}
-            fileType={fileType}
-            shape={node.shape}
-            label={node.name}
-            icon={<FolderIcon htmlColor="skyblue" />}
-            checkboxProps={
-              multiSelect && node.nodes.filter((node) => !node.isDir).length > 0
-                ? {
-                    indeterminate,
-                    checked: allChecked,
-                    onClick: (e) => {
-                      e.stopPropagation() // on/offのクリックにつられてTreeを開閉させないようにする
-                    },
-                    onChange: (e) => onCheckDir(node.path, e.target.checked),
-                  }
-                : undefined
-            }
-            columnWidth={columnWidth}
-            filePath={node.path}
-          />
-        }
-      >
-        {node.nodes.map((childNode, i) => (
+      filePaths.some((path) => selectedFilePath.includes(path))
+
+    return {
+      indeterminate: someChecked && !allChecked,
+      checked: allChecked,
+      onClick: (e: React.MouseEvent) => e.stopPropagation(),
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+        onCheckDir(node.path, e.target.checked),
+    }
+  }, [node, multiSelect, selectedFilePath, onCheckDir])
+
+  // Calculate checkbox props for files
+  const getFileCheckboxProps = useCallback(() => {
+    const isChecked = multiSelect
+      ? Array.isArray(selectedFilePath) && selectedFilePath.includes(node.path)
+      : selectedFilePath === node.path
+
+    return {
+      checked: isChecked,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+        e.stopPropagation()
+        onCheckFile(node.path)
+      },
+    }
+  }, [multiSelect, selectedFilePath, node.path, onCheckFile])
+
+  // Common label props
+  const labelProps = {
+    multiSelect,
+    isDir: node.isDir,
+    fileType,
+    shape: node.shape,
+    label: node.name,
+    columnWidth,
+    filePath: node.path,
+    icon: node.isDir ? <FolderIcon htmlColor="skyblue" /> : undefined,
+    checkboxProps: node.isDir ? getDirCheckboxProps() : getFileCheckboxProps(),
+  }
+
+  return (
+    <TreeItem {...treeItemProps} label={<FileTreeItemLabel {...labelProps} />}>
+      {node.isDir &&
+        node.nodes.map((childNode, i) => (
           <FileTreeNode
+            key={i}
             fileType={fileType}
             node={childNode}
             selectedFilePath={selectedFilePath}
-            key={i}
             multiSelect={multiSelect}
             onCheckDir={onCheckDir}
             onCheckFile={onCheckFile}
@@ -697,59 +767,8 @@ const FileTreeNode = memo(function FileTreeNode({
             columnWidth={columnWidth}
           />
         ))}
-      </TreeItem>
-    )
-  } else {
-    return (
-      <TreeItem
-        nodeId={node.path}
-        sx={{
-          "& .MuiTreeItem-iconContainer": {
-            width: 0,
-            minWidth: 0,
-          },
-        }}
-        label={
-          <FileTreeItemLabel
-            multiSelect={multiSelect}
-            isDir={node.isDir}
-            fileType={fileType}
-            shape={node.shape}
-            label={node.name}
-            checkboxProps={{
-              checked: multiSelect
-                ? Array.isArray(selectedFilePath) &&
-                  selectedFilePath.includes(node.path)
-                : selectedFilePath === node.path,
-              onChange: (e) => {
-                e.stopPropagation()
-
-                if (multiSelect) {
-                  if (Array.isArray(selectedFilePath)) {
-                    if (selectedFilePath.includes(node.path)) {
-                      setSelectedFilePath(
-                        selectedFilePath.filter((f) => f !== node.path),
-                      )
-                    } else {
-                      setSelectedFilePath([...selectedFilePath, node.path])
-                    }
-                  }
-                } else {
-                  if (selectedFilePath === node.path) {
-                    setSelectedFilePath("")
-                  } else {
-                    setSelectedFilePath(node.path)
-                  }
-                }
-              },
-            }}
-            columnWidth={columnWidth}
-            filePath={node.path}
-          />
-        }
-      />
-    )
-  }
+    </TreeItem>
+  )
 })
 
 interface FileTreeItemLabelProps {
@@ -779,21 +798,21 @@ export const FileTreeItemLabel = memo(function FileTreeItemLabel({
   const workspaceId = useSelector(selectCurrentWorkspaceId)
   const fileTreeActions = useContext(FileTreeActionsContext)
 
-  const onUpdate = useCallback(
-    (event: MouseEvent, fileName: string) => {
-      if (!workspaceId) return
-      event.stopPropagation()
-      dispatch(updateShape({ workspaceId, fileName }))
-    },
-    [dispatch, workspaceId],
-  )
-  const onOpenDeleteDialogClick = useCallback(
-    (event: MouseEvent) => {
-      if (!workspaceId || !fileTreeActions) return
-      event.stopPropagation()
-      fileTreeActions.onOpenDeleteDialog(filePath, label)
-    },
-    [workspaceId, fileTreeActions, filePath, label],
+  // Consolidated file actions
+  const fileActions = useMemo(
+    () => ({
+      updateShape: (event: MouseEvent) => {
+        if (!workspaceId) return
+        event.stopPropagation()
+        dispatch(updateShape({ workspaceId, fileName: filePath }))
+      },
+      deleteFile: (event: MouseEvent) => {
+        if (!workspaceId || !fileTreeActions) return
+        event.stopPropagation()
+        fileTreeActions.onOpenDeleteDialog(filePath, label)
+      },
+    }),
+    [dispatch, workspaceId, fileTreeActions, filePath, label],
   )
 
   return (
@@ -830,14 +849,19 @@ export const FileTreeItemLabel = memo(function FileTreeItemLabel({
                 {icon}
               </Box>
             )}
-            <Box sx={{ ...ellipsisStyle, whiteSpace: "pre", flex: 1 }}>
+            <Box sx={{ ...commonStyles.ellipsis, whiteSpace: "pre", flex: 1 }}>
               {label}
             </Box>
           </Box>
         </Tooltip>
         {fileType === FILE_TREE_TYPE_SET.IMAGE ? (
           <>
-            <Box flex={1} marginLeft={2} alignItems="center" sx={ellipsisStyle}>
+            <Box
+              flex={1}
+              marginLeft={2}
+              alignItems="center"
+              sx={commonStyles.ellipsis}
+            >
               {!isDir ? (
                 !shape ? (
                   <Tooltip
@@ -858,18 +882,18 @@ export const FileTreeItemLabel = memo(function FileTreeItemLabel({
           </>
         ) : null}
         <Box display="flex" alignItems="center">
-          {!isDir && multiSelect ? (
+          {!isDir && multiSelect && (
             <IconButton
-              sx={{ minWidth: 24 }}
-              onClick={(event) => onUpdate(event, filePath)}
+              sx={commonStyles.iconButton}
+              onClick={fileActions.updateShape}
             >
               <AutorenewIcon />
             </IconButton>
-          ) : null}
+          )}
           <IconButton
-            sx={{ minWidth: 24 }}
+            sx={commonStyles.iconButton}
             color="error"
-            onClick={onOpenDeleteDialogClick}
+            onClick={fileActions.deleteFile}
             disabled={checkboxProps?.checked}
             data-testid="DeleteIconBtn"
           >

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -623,6 +623,7 @@ const TreeNode = memo(function TreeNode({
             setSelectedFilePath={setSelectedFilePath}
             selectedFilePath={selectedFilePath}
             columnWidth={columnWidth}
+            filePath={node.path}
           />
         }
       >
@@ -688,6 +689,7 @@ const TreeNode = memo(function TreeNode({
             setSelectedFilePath={setSelectedFilePath}
             selectedFilePath={selectedFilePath}
             columnWidth={columnWidth}
+            filePath={node.path}
           />
         }
       />
@@ -706,6 +708,7 @@ interface TreeItemLabelProps {
   selectedFilePath: string[] | string
   multiSelect: boolean
   columnWidth?: number
+  filePath: string
 }
 
 export const TreeItemLabel = memo(function TreeItemLabel({
@@ -719,6 +722,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
   selectedFilePath,
   multiSelect,
   columnWidth = COLUMN_DEFAULT_WIDTH,
+  filePath,
 }: TreeItemLabelProps) {
   const dispatch = useDispatch<AppDispatch>()
   const workspaceId = useSelector(selectCurrentWorkspaceId)
@@ -821,7 +825,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
           {!isDir && multiSelect ? (
             <IconButton
               sx={{ minWidth: 24 }}
-              onClick={(event) => onUpdate(event, label)}
+              onClick={(event) => onUpdate(event, filePath)}
             >
               <AutorenewIcon />
             </IconButton>
@@ -844,7 +848,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
         open={deleteConfirmDialogOpen}
         setOpen={setDeleteConfirmDialogOpen}
         onConfirm={() => {
-          onDelete({ stopPropagation: () => {} } as MouseEvent, label)
+          onDelete({ stopPropagation: () => {} } as MouseEvent, filePath)
           setDeleteConfirmDialogOpen(false)
         }}
         title="Are you sure you want to delete this item?"

--- a/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/FileSelectDialog.tsx
@@ -32,7 +32,6 @@ import DeleteIcon from "@mui/icons-material/Delete"
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator"
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline"
 import FolderIcon from "@mui/icons-material/Folder"
-import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined"
 import { Divider, IconButton, Tooltip, Chip } from "@mui/material"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
@@ -480,31 +479,37 @@ const TreeNode = memo(function TreeNode({
     const indeterminate = !(allChecked || allNotChecked)
     return (
       <TreeItem
-        icon={<FolderIcon htmlColor="skyblue" />}
         nodeId={node.path}
+        sx={{
+          "& .MuiTreeItem-iconContainer": {
+            width: 0,
+            minWidth: 0,
+          },
+        }}
         label={
-          multiSelect && node.nodes.filter((node) => !node.isDir).length > 0 ? (
-            <TreeItemLabel
-              multiSelect={multiSelect}
-              isDir={node.isDir}
-              fileType={fileType}
-              shape={node.shape}
-              label={node.name}
-              checkboxProps={{
-                indeterminate,
-                checked: allChecked,
-                onClick: (e) => {
-                  e.stopPropagation() // on/offのクリックにつられてTreeを開閉させないようにする
-                },
-                onChange: (e) => onCheckDir(node.path, e.target.checked),
-              }}
-              setSelectedFilePath={setSelectedFilePath}
-              selectedFilePath={selectedFilePath}
-              columnWidth={columnWidth}
-            />
-          ) : (
-            node.name
-          )
+          <TreeItemLabel
+            multiSelect={multiSelect}
+            isDir={node.isDir}
+            fileType={fileType}
+            shape={node.shape}
+            label={node.name}
+            icon={<FolderIcon htmlColor="skyblue" />}
+            checkboxProps={
+              multiSelect && node.nodes.filter((node) => !node.isDir).length > 0
+                ? {
+                    indeterminate,
+                    checked: allChecked,
+                    onClick: (e) => {
+                      e.stopPropagation() // on/offのクリックにつられてTreeを開閉させないようにする
+                    },
+                    onChange: (e) => onCheckDir(node.path, e.target.checked),
+                  }
+                : undefined
+            }
+            setSelectedFilePath={setSelectedFilePath}
+            selectedFilePath={selectedFilePath}
+            columnWidth={columnWidth}
+          />
         }
       >
         {node.nodes.map((childNode, i) => (
@@ -525,8 +530,13 @@ const TreeNode = memo(function TreeNode({
   } else {
     return (
       <TreeItem
-        icon={<InsertDriveFileOutlinedIcon fontSize="small" />}
         nodeId={node.path}
+        sx={{
+          "& .MuiTreeItem-iconContainer": {
+            width: 0,
+            minWidth: 0,
+          },
+        }}
         label={
           <TreeItemLabel
             multiSelect={multiSelect}
@@ -575,8 +585,9 @@ interface TreeItemLabelProps {
   fileType: FILE_TREE_TYPE
   shape: number[]
   label: string
-  checkboxProps: CheckboxProps
+  checkboxProps?: CheckboxProps
   isDir?: boolean
+  icon?: React.ReactNode
   setSelectedFilePath: (path: string[] | string) => void
   selectedFilePath: string[] | string
   multiSelect: boolean
@@ -589,6 +600,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
   label,
   isDir,
   checkboxProps,
+  icon,
   setSelectedFilePath,
   selectedFilePath,
   multiSelect,
@@ -652,11 +664,21 @@ export const TreeItemLabel = memo(function TreeItemLabel({
           <Box
             sx={{
               width: `${columnWidth}%`,
-              ...ellipsisStyle,
-              whiteSpace: "pre",
+              display: "flex",
+              alignItems: "center",
             }}
           >
-            {label}
+            {checkboxProps && (
+              <StyledCheckbox {...checkboxProps} size="small" disableRipple />
+            )}
+            {icon && (
+              <Box sx={{ display: "flex", alignItems: "center", mr: 0.5 }}>
+                {icon}
+              </Box>
+            )}
+            <Box sx={{ ...ellipsisStyle, whiteSpace: "pre", flex: 1 }}>
+              {label}
+            </Box>
           </Box>
         </Tooltip>
         {fileType === FILE_TREE_TYPE_SET.IMAGE ? (
@@ -682,10 +704,6 @@ export const TreeItemLabel = memo(function TreeItemLabel({
           </>
         ) : null}
         <Box display="flex" alignItems="center">
-          <Box>
-            <StyledCheckbox {...checkboxProps} size="small" disableRipple />
-          </Box>
-
           {!isDir && multiSelect ? (
             <IconButton
               sx={{ minWidth: 24 }}
@@ -701,7 +719,7 @@ export const TreeItemLabel = memo(function TreeItemLabel({
               event.stopPropagation()
               onOpenDeleteConfirmDialog(event)
             }}
-            disabled={checkboxProps.checked}
+            disabled={checkboxProps?.checked}
             data-testid="DeleteIconBtn"
           >
             <DeleteIcon />

--- a/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from "react"
+import React, { memo, useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 
 import FolderIcon from "@mui/icons-material/Folder"
@@ -129,6 +129,50 @@ const FileTreeView = memo(function FileTreeView({
   setFileSelect: (value: string) => void
 }) {
   const [tree, isLoading] = useStructuredTree(nodeId, config)
+  const [expanded, setExpanded] = useState<string[]>([])
+
+  // Calculate paths to expand when fileSelect changes
+  useEffect(() => {
+    if (!fileSelect || !tree) return
+
+    const pathsToExpand: string[] = []
+    const findPathsToExpand = (
+      nodes: TreeNodeType[],
+      currentPath: string[] = [],
+    ) => {
+      for (const node of nodes) {
+        if (node.isDir) {
+          const dirNode = node as TreeDirType
+          // Check if any child contains the selected file
+          const containsSelectedFile = (n: TreeNodeType): boolean => {
+            if (!n.isDir && n.path === fileSelect) return true
+            if (n.isDir) {
+              return (n as TreeDirType).nodes.some(containsSelectedFile)
+            }
+            return false
+          }
+
+          if (containsSelectedFile(node)) {
+            pathsToExpand.push(node.path)
+            findPathsToExpand(dirNode.nodes, [...currentPath, node.path])
+          }
+        }
+      }
+    }
+
+    findPathsToExpand(tree)
+    if (pathsToExpand.length > 0) {
+      setExpanded(pathsToExpand)
+    }
+  }, [fileSelect, tree])
+
+  const handleNodeToggle = (
+    _event: React.SyntheticEvent,
+    nodeIds: string[],
+  ) => {
+    setExpanded(nodeIds)
+  }
+
   return (
     <div>
       {isLoading && <LinearProgress />}
@@ -140,7 +184,7 @@ const FileTreeView = memo(function FileTreeView({
         <Box flexGrow={1}></Box>
       </Box>
       <Divider />
-      <TreeView>
+      <TreeView expanded={expanded} onNodeToggle={handleNodeToggle}>
         {tree?.map((node, i) => (
           <TreeNode
             fileSelect={fileSelect}

--- a/frontend/src/store/slice/FilesTree/FilesTreeSlice.ts
+++ b/frontend/src/store/slice/FilesTree/FilesTreeSlice.ts
@@ -8,6 +8,7 @@ import { getFilesTree, deleteFile } from "store/slice/FilesTree/FilesTreeAction"
 import {
   FilesTree,
   FILES_TREE_SLICE_NAME,
+  TreeNodeType,
 } from "store/slice/FilesTree/FilesTreeType"
 import { convertToTreeNodeType } from "store/slice/FilesTree/FilesTreeUtils"
 import { uploadFile } from "store/slice/FileUploader/FileUploaderActions"
@@ -53,8 +54,14 @@ export const filesTreeSlice = createSlice({
       })
       .addCase(deleteFile.fulfilled, (state, action) => {
         const { fileType, fileName } = action.meta.arg
-        const fileTree = state[fileType].tree
-        state[fileType].tree = fileTree.filter((node) => node.name !== fileName)
+        const filterTree = (nodes: TreeNodeType[]): TreeNodeType[] =>
+          nodes
+            .map((node) =>
+              node.isDir ? { ...node, nodes: filterTree(node.nodes) } : node,
+            )
+            .filter((node) => node.path !== fileName)
+
+        state[fileType].tree = filterTree(state[fileType].tree)
         state[fileType].isLoading = false
         state[fileType].isLatest = true
       })

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -95,6 +95,9 @@ export const inputNodeSlice = createSlice({
         if (isHDF5InputNode(targetNode)) {
           targetNode.hdf5Path = undefined
         }
+        if (isMatlabInputNode(targetNode)) {
+          targetNode.matPath = undefined
+        }
       })
       .addCase(addInputNode, (state, action) => {
         const { node, fileType } = action.payload

--- a/studio/app/common/routers/files.py
+++ b/studio/app/common/routers/files.py
@@ -216,7 +216,7 @@ DOWNLOAD_STATUS: Dict[str, DownloadStatus] = {}
 
 
 @router.delete(
-    "/{workspace_id}/delete/{filename}",
+    "/{workspace_id}/delete/{filename:path}",
     response_model=bool,
     dependencies=[Depends(is_workspace_owner)],
 )


### PR DESCRIPTION
## Content

Added the following features to the FileSelectDialog:

<img width="1228" height="1330" alt="image" src="https://github.com/user-attachments/assets/f78dc935-c969-4a2f-8de0-52d292152b12" />

### File list filter box

- Filtering a file list by matching keywords
- Filtering works in the frontend

### Checkbox to select all files

- Select all in file list
- When filtered, selects only the filtered list.

### Others

- Improved the File Delete Dialog.
  - Files in subdirectories could not be deleted.
  - Refactored the component (to a simpler format).

## Testcase

### File list filter box

- [ ] Enter any filter text and make sure that only matching files are displayed.

### Checkbox to select all files

- [ ] Only displayed in type of file multiselect (for Image Node)
- [ ] Cases With filtering
  - [ ] Case without filtering
    - "all check" works
    - "all uncheck" works
  - [ ] Case with filtering
    - "all check" (applies only to filtered files) works
    - "all uncheck" works

### File Delete Dialog

- [ ] Files directly under the root directory can be deleted (any file type).
- [ ] The following files in subdirectories can be deleted (any file type).

