### PR TITLE
Improve StructureItemSelectDialog - Adjust nbyte display unit

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
@@ -105,7 +105,7 @@ const StructureView = memo(function StructureView({
           borderColor: theme.palette.divider,
         }}
       >
-        <FileTreeView
+        <StructureTreeView
           nodeId={nodeId}
           fileSelect={fileSelect}
           setFileSelect={setFileSelect}
@@ -118,7 +118,7 @@ const StructureView = memo(function StructureView({
   )
 })
 
-const FileTreeView = memo(function FileTreeView({
+const StructureTreeView = memo(function StructureTreeView({
   nodeId,
   fileSelect,
   setFileSelect,
@@ -186,7 +186,7 @@ const FileTreeView = memo(function FileTreeView({
       <Divider />
       <TreeView expanded={expanded} onNodeToggle={handleNodeToggle}>
         {tree?.map((node, i) => (
-          <TreeNode
+          <StructureTreeNode
             fileSelect={fileSelect}
             setFileSelect={setFileSelect}
             key={`${config.treeKeyPrefix}-${nodeId}-${i}`}
@@ -200,7 +200,7 @@ const FileTreeView = memo(function FileTreeView({
   )
 })
 
-interface TreeItemLabelProps {
+interface StructureTreeItemLabelProps {
   isFile: boolean
   shape: number[]
   type: string | null
@@ -209,14 +209,14 @@ interface TreeItemLabelProps {
   checkboxProps: CheckboxProps
 }
 
-export const TreeItemLabel = memo(function TreeItemLabel({
+export const StructureTreeItemLabel = memo(function StructureTreeItemLabel({
   isFile = false,
   label,
   shape,
   type,
   nbytes,
   checkboxProps,
-}: TreeItemLabelProps) {
+}: StructureTreeItemLabelProps) {
   return (
     <Box display="flex" alignItems="center" gap={2}>
       <Tooltip
@@ -249,20 +249,20 @@ export const TreeItemLabel = memo(function TreeItemLabel({
   )
 })
 
-interface TreeNodeProps extends NodeIdProps {
+interface StructureTreeNodeProps extends NodeIdProps {
   setFileSelect?: (value: string) => void
   fileSelect?: string
   node: TreeNodeType
   config: FileNodeConfig
 }
 
-const TreeNode = memo(function TreeNode({
+const StructureTreeNode = memo(function TreeNode({
   node,
   nodeId,
   setFileSelect,
   fileSelect,
   config,
-}: TreeNodeProps) {
+}: StructureTreeNodeProps) {
   const dispatch = useDispatch()
   const structureFileName = useSelector(config.selectStructurePath(nodeId))
   useEffect(() => {
@@ -301,7 +301,7 @@ const TreeNode = memo(function TreeNode({
         icon={<InsertDriveFileOutlinedIcon fontSize="small" />}
         nodeId={node.path}
         label={
-          <TreeItemLabel
+          <StructureTreeItemLabel
             isFile={true}
             label={node.name}
             type={node.dataType || null}

--- a/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
@@ -215,8 +215,8 @@ const formatBytes = (nbytesStr?: string): string => {
   const nbytes = parseInt(nbytesStr, 10)
   if (isNaN(nbytes)) return nbytesStr
 
-  const BYTES_PER_KB = 1024
-  const BYTES_PER_MB = 1024 * 1024
+  const BYTES_PER_KB = 1000
+  const BYTES_PER_MB = BYTES_PER_KB * 1000
 
   if (nbytes < BYTES_PER_KB) {
     return `${nbytes} B`

--- a/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Dialog/StructureItemSelectDialog.tsx
@@ -209,6 +209,26 @@ interface StructureTreeItemLabelProps {
   checkboxProps: CheckboxProps
 }
 
+const formatBytes = (nbytesStr?: string): string => {
+  if (!nbytesStr) return ""
+
+  const nbytes = parseInt(nbytesStr, 10)
+  if (isNaN(nbytes)) return nbytesStr
+
+  const BYTES_PER_KB = 1024
+  const BYTES_PER_MB = 1024 * 1024
+
+  if (nbytes < BYTES_PER_KB) {
+    return `${nbytes} B`
+  } else if (nbytes < BYTES_PER_MB) {
+    const kb = nbytes / BYTES_PER_KB
+    return `${kb.toFixed(1)} KB`
+  } else {
+    const mb = nbytes / BYTES_PER_MB
+    return `${mb.toFixed(1)} MB`
+  }
+}
+
 export const StructureTreeItemLabel = memo(function StructureTreeItemLabel({
   isFile = false,
   label,
@@ -233,7 +253,7 @@ export const StructureTreeItemLabel = memo(function StructureTreeItemLabel({
       </Tooltip>
       <Box width={"15%"}>{type}</Box>
       <Box width={"25%"}>{shape ? `(${shape.join(", ")})` : ""}</Box>
-      <Box width={"15%"}>{nbytes}</Box>
+      <Box width={"15%"}>{formatBytes(nbytes)}</Box>
       <Box>
         <Checkbox
           {...checkboxProps}

--- a/studio/app/optinist/routers/hdf5.py
+++ b/studio/app/optinist/routers/hdf5.py
@@ -68,7 +68,7 @@ class HDF5Getter:
                         name=name,
                         path=path,
                         shape=node.shape,
-                        nbytes=cls.format_nbytes(node.nbytes),
+                        nbytes=node.nbytes,
                         dataType=(
                             "array"
                             if isinstance(node[:], np.ndarray)
@@ -76,10 +76,6 @@ class HDF5Getter:
                         ),
                     )
                 )
-
-    @classmethod
-    def format_nbytes(cls, nbytes: int) -> str:
-        return f"{float(nbytes / (1000**2)):.1f} MB"
 
 
 @router.get("/hdf5/{file_path:path}", response_model=List[HDF5Node], tags=["outputs"])

--- a/studio/app/optinist/routers/mat.py
+++ b/studio/app/optinist/routers/mat.py
@@ -50,7 +50,7 @@ class MatGetter:
                 name=name,
                 path=current_path,
                 shape=data.shape,
-                nbytes=cls.format_nbytes(data.nbytes),
+                nbytes=data.nbytes,
                 dataType="array",
             )
         else:
@@ -60,10 +60,6 @@ class MatGetter:
                 path=current_path,
                 dataType=type(data).__name__,
             )
-
-    @classmethod
-    def format_nbytes(cls, nbytes: int) -> str:
-        return f"{float(nbytes / (1000**2)):.1f} MB"
 
 
 @router.get(


### PR DESCRIPTION
### Content

Formatting the nbytes display in the StructureItemSelectDialog

<img width="609" height="532" alt="image" src="https://github.com/user-attachments/assets/c921ec2d-285a-4c18-94cb-7fe5701504f3" />

- Conditions
  - If the size is less than 1KB ... `f"{{nbytes(Bytes)}} B"`
  - If the size is less than 1MB ... `f"{{nbytes(K Bytes)}:.1f} KB"`
  - If the size is 1MB or more ... `f"{{nbytes(M Bytes)}:.1f} MB"`

### Testcase

- [ ] Check nbytes display in hdf5 file
- [ ] Check nbytes display in mat file
