### PR TITLE
Refactor filetype config ts

### DIFF
--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -1,12 +1,11 @@
 import { AxiosProgressEvent } from "axios"
 
-import { FILE_TREE_TYPE_SET as CONFIG_FILE_TREE_TYPE_SET } from "config/fileTypes.config"
+import { FILE_TREE_TYPE_SET } from "config/fileTypes.config"
 import { BASE_URL } from "const/API"
 import axios from "utils/axios"
 
-// Import from config to maintain single source of truth
-
-export const FILE_TREE_TYPE_SET = CONFIG_FILE_TREE_TYPE_SET
+// Re-export for convenience - FILE_TREE_TYPE depends on FILE_TREE_TYPE_SET
+export { FILE_TREE_TYPE_SET }
 
 export type FILE_TREE_TYPE =
   (typeof FILE_TREE_TYPE_SET)[keyof typeof FILE_TREE_TYPE_SET]

--- a/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChartNode/FileSelect.tsx
@@ -19,6 +19,7 @@ import { FILE_TREE_TYPE, FILE_TREE_TYPE_SET } from "api/files/Files"
 import { CsvParamSettingDialog } from "components/Workspace/FlowChart/Dialog/CsvParamSettingDialog"
 import { DialogContext } from "components/Workspace/FlowChart/Dialog/DialogContext"
 import { LinearProgressWithLabel } from "components/Workspace/FlowChart/FlowChartNode/LinerProgressWithLabel"
+import { getFileTypeConfig } from "config/fileTypes.config"
 import { FileNodeFactory } from "factories/FileNodeFactory"
 import { getFilesTree } from "store/slice/FilesTree/FilesTreeAction"
 import { useFileUploader } from "store/slice/FileUploader/FileUploaderHook"
@@ -62,6 +63,11 @@ export const FileSelect = memo(function FileSelect({
   const onUploadFileHandle = (formData: FormData, fileName: string) => {
     onUploadFile(formData, fileName)
   }
+
+  // Get displayName from config (priority: nameNode > config.displayName > fileType)
+  const config = getFileTypeConfig(fileType)
+  const displayLabel = nameNode || config?.displayName || fileType
+
   return (
     <>
       {!uninitialized && pending && progress != null && (
@@ -69,7 +75,7 @@ export const FileSelect = memo(function FileSelect({
           <LinearProgressWithLabel value={progress} />
         </div>
       )}
-      <Typography>{nameNode || fileType}</Typography>
+      <Typography>{displayLabel}</Typography>
       <FileSelectImple
         multiSelect={multiSelect}
         filePath={filePath}

--- a/frontend/src/components/Workspace/FlowChart/TreeView.tsx
+++ b/frontend/src/components/Workspace/FlowChart/TreeView.tsx
@@ -105,8 +105,6 @@ export const AlgorithmTreeView = memo(function AlgorithmTreeView() {
           {configs.map((config) => (
             <InputNodeComponent
               key={config.key}
-              fileName={config.key}
-              nodeName={config.displayName}
               fileType={config.key as FILE_TYPE}
               config={config}
             />
@@ -130,15 +128,11 @@ export const AlgorithmTreeView = memo(function AlgorithmTreeView() {
 })
 
 interface InputNodeComponentProps {
-  fileName: string
-  nodeName: string
   fileType: FILE_TYPE
-  config: import("config/fileTypes.config").FileTypeConfig
+  config: import("config/fileTypes.config").EnhancedFileTypeConfig
 }
 
 const InputNodeComponent = memo(function InputNodeComponent({
-  fileName,
-  nodeName,
   fileType,
   config,
 }: InputNodeComponentProps) {
@@ -146,12 +140,12 @@ const InputNodeComponent = memo(function InputNodeComponent({
 
   const onAddDataNode = useCallback(
     (
-      nodeName: string,
+      displayName: string,
       fileType: FILE_TYPE,
       position?: { x: number; y: number },
     ) => {
       const newNode = FileNodeFactory.createReactFlowNode(
-        nodeName,
+        displayName,
         config,
         position,
       )
@@ -163,9 +157,9 @@ const InputNodeComponent = memo(function InputNodeComponent({
   const { isDragging, dragRef } = useLeafItemDrag(
     useCallback(
       (position) => {
-        onAddDataNode(nodeName, fileType, position)
+        onAddDataNode(config.displayName, fileType, position)
       },
-      [onAddDataNode, nodeName, fileType],
+      [onAddDataNode, config.displayName, fileType],
     ),
   )
 
@@ -176,11 +170,11 @@ const InputNodeComponent = memo(function InputNodeComponent({
         opacity: isDragging ? 0.6 : 1,
       }}
       onFocusCapture={(e) => e.stopPropagation()}
-      nodeId={fileName}
+      nodeId={config.key}
       label={
         <AddButton
-          name={fileName}
-          onClick={() => onAddDataNode(nodeName, fileType)}
+          name={config.displayName}
+          onClick={() => onAddDataNode(config.displayName, fileType)}
         />
       }
     />

--- a/frontend/src/config/fileTypes.config.ts
+++ b/frontend/src/config/fileTypes.config.ts
@@ -8,7 +8,7 @@ export type TreeHierarchyType =
 
 export interface FileTypeConfig {
   key: string
-  displayName: string
+  displayName?: string // Optional: If not provided, key will be used for display
   hasFilePath: boolean
   filePathType: "single" | "array"
   hasSpecialPath?: {
@@ -29,8 +29,12 @@ export interface FileTypeConfig {
 // Enhanced config with computed properties
 export interface EnhancedFileTypeConfig
   extends Required<
-    Omit<FileTypeConfig, "hasSpecialPath" | "stateFileType" | "treeHierarchy">
+    Omit<
+      FileTypeConfig,
+      "hasSpecialPath" | "stateFileType" | "treeHierarchy" | "displayName"
+    >
   > {
+  displayName: string // Required in enhanced config (defaults to key if not provided)
   hasSpecialPath?: FileTypeConfig["hasSpecialPath"]
   stateFileType?: string
   treeHierarchy: TreeHierarchyType // Required in enhanced config with default value
@@ -67,7 +71,7 @@ export const REACT_FLOW_NODE_TYPE_KEY = {
 export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   IMAGE: {
     key: "image",
-    displayName: "imageData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "array",
     defaultParam: {},
@@ -75,7 +79,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   CSV: {
     key: "csv",
-    displayName: "csvData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -87,7 +91,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   HDF5: {
     key: "hdf5",
-    displayName: "hdf5Data",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     hasSpecialPath: {
@@ -99,7 +103,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   FLUO: {
     key: "fluo",
-    displayName: "fluoData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -112,7 +116,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   BEHAVIOR: {
     key: "behavior",
-    displayName: "behaviorData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -125,7 +129,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   MATLAB: {
     key: "matlab",
-    displayName: "matlabData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     hasSpecialPath: {
@@ -137,7 +141,7 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   MICROSCOPE: {
     key: "microscope",
-    displayName: "microscopeData",
+    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {},
@@ -160,6 +164,7 @@ const ENHANCED_FILE_TYPE_CONFIGS: Record<string, EnhancedFileTypeConfig> =
         {
           ...config,
           // Auto-generate missing properties
+          displayName: config.displayName || config.key, // Use key as fallback if displayName is not provided
           treeType: config.treeType || config.key,
           dataType: config.dataType || config.key,
           nodeType,

--- a/frontend/src/config/fileTypes.config.ts
+++ b/frontend/src/config/fileTypes.config.ts
@@ -71,7 +71,6 @@ export const REACT_FLOW_NODE_TYPE_KEY = {
 export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   IMAGE: {
     key: "image",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "array",
     defaultParam: {},
@@ -79,7 +78,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   CSV: {
     key: "csv",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -91,7 +89,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   HDF5: {
     key: "hdf5",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     hasSpecialPath: {
@@ -103,7 +100,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   FLUO: {
     key: "fluo",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -116,7 +112,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   BEHAVIOR: {
     key: "behavior",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {
@@ -129,7 +124,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   MATLAB: {
     key: "matlab",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     hasSpecialPath: {
@@ -141,7 +135,6 @@ export const FILE_TYPE_CONFIGS: Record<string, FileTypeConfig> = {
   },
   MICROSCOPE: {
     key: "microscope",
-    displayName: undefined,
     hasFilePath: true,
     filePathType: "single",
     defaultParam: {},
@@ -218,19 +211,3 @@ export function getFileTypeConfigsByHierarchy(): Record<
 
   return hierarchyGroups
 }
-
-// Auto-generated component mapping from ENHANCED_FILE_TYPE_CONFIGS
-export const COMPONENT_MAPPING = Object.fromEntries(
-  Object.values(ENHANCED_FILE_TYPE_CONFIGS).map((config) => [
-    config.nodeType,
-    config.nodeType,
-  ]),
-) as Record<string, string>
-
-// Auto-generated data type mapping from ENHANCED_FILE_TYPE_CONFIGS
-export const DATA_TYPE_MAPPING = Object.fromEntries(
-  Object.values(ENHANCED_FILE_TYPE_CONFIGS).map((config) => [
-    config.dataType,
-    config.dataType,
-  ]),
-) as Record<string, string>

--- a/frontend/src/config/fileTypes.config.ts
+++ b/frontend/src/config/fileTypes.config.ts
@@ -1,3 +1,11 @@
+// Define tree hierarchy constants for better maintainability
+export const TREE_HIERARCHY = {
+  DATA: "Data",
+} as const
+
+export type TreeHierarchyType =
+  (typeof TREE_HIERARCHY)[keyof typeof TREE_HIERARCHY]
+
 export interface FileTypeConfig {
   key: string
   displayName: string
@@ -15,7 +23,7 @@ export interface FileTypeConfig {
   nodeType?: string // Unified: replaces nodeComponent and reactFlowNodeType
   componentPath?: string
   // Tree hierarchy configuration
-  treeHierarchy?: string // Parent node in tree hierarchy (e.g., "Data", "Sample Data")
+  treeHierarchy?: TreeHierarchyType // Parent node in tree hierarchy (e.g., "Data", "Sample Data")
 }
 
 // Enhanced config with computed properties
@@ -25,7 +33,7 @@ export interface EnhancedFileTypeConfig
   > {
   hasSpecialPath?: FileTypeConfig["hasSpecialPath"]
   stateFileType?: string
-  treeHierarchy: string // Required in enhanced config with default value
+  treeHierarchy: TreeHierarchyType // Required in enhanced config with default value
   // Backward compatibility properties
   nodeComponent: string // Same as nodeType for compatibility
   reactFlowNodeType: string // Same as nodeType for compatibility
@@ -155,7 +163,7 @@ const ENHANCED_FILE_TYPE_CONFIGS: Record<string, EnhancedFileTypeConfig> =
           treeType: config.treeType || config.key,
           dataType: config.dataType || config.key,
           nodeType,
-          treeHierarchy: config.treeHierarchy || "Data", // Default to "Data" hierarchy
+          treeHierarchy: config.treeHierarchy || TREE_HIERARCHY.DATA, // Default to "Data" hierarchy
           // Backward compatibility - both point to the same nodeType
           nodeComponent: nodeType,
           reactFlowNodeType: nodeType,

--- a/frontend/src/const/flowchart.ts
+++ b/frontend/src/const/flowchart.ts
@@ -28,8 +28,5 @@ export const HANDLE_STYLE: CSSProperties = {
   top: 15,
 }
 
-// Re-export for backward compatibility
-export { REACT_FLOW_NODE_TYPE_KEY }
-
 export type REACT_FLOW_NODE_TYPE =
   (typeof REACT_FLOW_NODE_TYPE_KEY)[keyof typeof REACT_FLOW_NODE_TYPE_KEY]

--- a/frontend/src/factories/FileNodeFactory.ts
+++ b/frontend/src/factories/FileNodeFactory.ts
@@ -1,7 +1,6 @@
 import { Node } from "reactflow"
 
 import {
-  DATA_TYPE_MAPPING,
   EnhancedFileTypeConfig,
   FileTypeConfig,
   getFileTypeConfig,
@@ -148,18 +147,16 @@ export class FileNodeFactory {
   /**
    * Converts FILE_TYPE to DATA_TYPE
    * Used for converting InputNode file types to DisplayData types
-   * Uses config-driven approach via DATA_TYPE_MAPPING
+   * Uses config-driven approach
    */
   static toDataTypeFromFileType(fileType: FILE_TYPE): DATA_TYPE {
     const dataTypeString = FileNodeFactory.getDataType(fileType)
 
-    // Use mapping from config instead of hardcoded strings
-    const mappedType =
-      DATA_TYPE_MAPPING[dataTypeString as keyof typeof DATA_TYPE_MAPPING]
-    if (mappedType) {
-      return DATA_TYPE_SET[
-        mappedType.toUpperCase() as keyof typeof DATA_TYPE_SET
-      ]
+    // Map data type string to DATA_TYPE_SET
+    const upperDataType =
+      dataTypeString.toUpperCase() as keyof typeof DATA_TYPE_SET
+    if (upperDataType in DATA_TYPE_SET) {
+      return DATA_TYPE_SET[upperDataType]
     }
 
     // Fallback to CSV for unknown types

--- a/frontend/src/store/slice/InputNode/InputNodeType.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeType.ts
@@ -2,9 +2,9 @@ import { FILE_TYPE_SET, FILE_TYPE } from "config/fileTypes.config"
 
 export const INPUT_NODE_SLICE_NAME = "inputNode"
 
-// Re-export for backward compatibility
-export { FILE_TYPE_SET }
+// Re-export for convenience
 export type { FILE_TYPE }
+export { FILE_TYPE_SET }
 
 export type InputNode = {
   [nodeId: string]: InputNodeType

--- a/frontend/src/store/test/workflow/AlgorithmNode/AlgorithmNode.test.ts
+++ b/frontend/src/store/test/workflow/AlgorithmNode/AlgorithmNode.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test } from "@jest/globals"
 
-import { REACT_FLOW_NODE_TYPE_KEY } from "const/flowchart"
+import { REACT_FLOW_NODE_TYPE_KEY } from "config/fileTypes.config"
 import {
   selectAlgorithmNodeById,
   selectAlgorithmParamsValue,

--- a/frontend/src/store/test/workflow/InputNode/InputNode.test.ts
+++ b/frontend/src/store/test/workflow/InputNode/InputNode.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test } from "@jest/globals"
 
-import { REACT_FLOW_NODE_TYPE_KEY } from "const/flowchart"
+import { REACT_FLOW_NODE_TYPE_KEY } from "config/fileTypes.config"
 import { addInputNode } from "store/slice/FlowElement/FlowElementActions"
 import { selectNodeById } from "store/slice/FlowElement/FlowElementSelectors"
 import { deleteFlowNodeById } from "store/slice/FlowElement/FlowElementSlice"


### PR DESCRIPTION
### Content

Improved the Input Node definition module (fileTypes.config.ts).

#### Feature

- You can now specify any text for the node display label.
  (This feature became necessary in the fork repo (optinist-for-server)).

<img width="1554" height="1332" alt="image" src="https://github.com/user-attachments/assets/ac697d46-da6b-48b1-b7b3-f0f70a601dc6" />

#### Refactorings

- Organized redundant imports/exports and constant definitions

### Testcase

- [x] Check the node label change
  1. Specify a displayName for each element of FILE_TYPE_CONFIGS (FileTypeConfig: IMAGE,CSV,...).
  2. Verify that the contents are reflected in the UI.
- Check that the Workflow screen is working properly
  - [x] Create a new workflow (clear it), manually configure Tutorial 1 (place nodes one by one), and verify that the workflow runs successfully.