### PR TITLE
Filter log display by user

### DIFF
--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -14,6 +14,7 @@ from studio.app.common.core.auth.auth_dependencies import (
     get_current_user,
 )
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.middleware import UserIdLoggingMiddleware
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
@@ -109,6 +110,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add UserIdLoggingMiddleware to capture user_id for logging
+app.add_middleware(UserIdLoggingMiddleware)
 
 
 @app.get("/is_standalone", response_model=bool, tags=["others"])

--- a/studio/__main_unit__.py
+++ b/studio/__main_unit__.py
@@ -14,7 +14,7 @@ from studio.app.common.core.auth.auth_dependencies import (
     get_current_user,
 )
 from studio.app.common.core.logger import AppLogger
-from studio.app.common.core.middleware import UserIdLoggingMiddleware
+from studio.app.common.core.middleware import ClientIdLoggingMiddleware
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
@@ -111,8 +111,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Add UserIdLoggingMiddleware to capture user_id for logging
-app.add_middleware(UserIdLoggingMiddleware)
+# Add LoggingMiddleware to capture client_id for logging
+app.add_middleware(ClientIdLoggingMiddleware)
 
 
 @app.get("/is_standalone", response_model=bool, tags=["others"])

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -11,8 +11,12 @@ import yaml
 from studio.app.common.core.mode import MODE
 from studio.app.dir_path import DIRPATH
 
-# Context variable for storing user_id per request/context
-_user_id_context: ContextVar[Optional[str]] = ContextVar("user_id", default=None)
+LOGGING_CLIENT_ID_KEY = "client_id"
+
+# Context variable for storing client_id per request/context
+_client_id_context: ContextVar[Optional[str]] = ContextVar(
+    LOGGING_CLIENT_ID_KEY, default=None
+)
 
 
 class AppLogger:
@@ -22,15 +26,22 @@ class AppLogger:
 
     LOGGER_NAME = "optinist"
 
-    class UserIdFilter(logging.Filter):
+    class ClientIdFilter(logging.Filter):
         """
-        Logging filter to inject user_id from context into log records
+        Logging filter to inject client_id from context into log records
         """
 
+        # Alternate text to log if client_id is not obtained
+        NO_CLIENT_ID_DEFAULT_VALUE = "default"
+
         def filter(self, record):
-            # Get user_id from context, default to "none" if not set
-            user_id = _user_id_context.get()
-            record.user_id = user_id if user_id is not None else "none"
+            # Get client_id from context, default to "none" if not set
+            client_id = _client_id_context.get()
+            record.client_id = (
+                client_id
+                if client_id is not None
+                else __class__.NO_CLIENT_ID_DEFAULT_VALUE
+            )
             return True
 
     @classmethod
@@ -107,19 +118,20 @@ class AppLogger:
             log_file = f"{DIRPATH.DATA_DIR}/{log_file}"
             logging_config["handlers"]["rotating_file"]["filename"] = log_file
 
-        # Add UserIdFilter configuration to filters section
+        # Add ClientIdFilter configuration to filters section
+        CLIENT_ID_FILTER_NAME = "client_id_filter"
         if "filters" not in logging_config:
             logging_config["filters"] = {}
-        logging_config["filters"]["user_id_filter"] = {
-            "()": "studio.app.common.core.logger.AppLogger.UserIdFilter"
+        logging_config["filters"][CLIENT_ID_FILTER_NAME] = {
+            "()": "studio.app.common.core.logger.AppLogger.ClientIdFilter"
         }
 
-        # Add user_id_filter to all handlers
+        # Add client_id_filter to all handlers
         for handler_config in logging_config.get("handlers", {}).values():
             if "filters" not in handler_config:
                 handler_config["filters"] = []
-            if "user_id_filter" not in handler_config["filters"]:
-                handler_config["filters"].append("user_id_filter")
+            if CLIENT_ID_FILTER_NAME not in handler_config["filters"]:
+                handler_config["filters"].append(CLIENT_ID_FILTER_NAME)
 
         return logging_config
 
@@ -134,18 +146,18 @@ class AppLogger:
         return logger
 
     @staticmethod
-    def set_user_id(user_id: Optional[str]):
+    def set_client_id(client_id: Optional[str]):
         """
-        Set user_id in the current context for logging
+        Set client_id in the current context for logging
         """
-        _user_id_context.set(user_id)
+        _client_id_context.set(client_id)
 
     @staticmethod
-    def get_user_id() -> Optional[str]:
+    def get_client_id() -> Optional[str]:
         """
-        Get user_id from the current context
+        Get client_id from the current context
         """
-        return _user_id_context.get()
+        return _client_id_context.get()
 
     @staticmethod
     def format_exc_traceback(e: Exception):

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -3,11 +3,16 @@ import logging.config
 import os
 import platform
 import traceback
+from contextvars import ContextVar
+from typing import Optional
 
 import yaml
 
 from studio.app.common.core.mode import MODE
 from studio.app.dir_path import DIRPATH
+
+# Context variable for storing user_id per request/context
+_user_id_context: ContextVar[Optional[str]] = ContextVar("user_id", default=None)
 
 
 class AppLogger:
@@ -16,6 +21,17 @@ class AppLogger:
     """
 
     LOGGER_NAME = "optinist"
+
+    class UserIdFilter(logging.Filter):
+        """
+        Logging filter to inject user_id from context into log records
+        """
+
+        def filter(self, record):
+            # Get user_id from context, default to "none" if not set
+            user_id = _user_id_context.get()
+            record.user_id = user_id if user_id is not None else "none"
+            return True
 
     @classmethod
     def init_logger(cls):
@@ -91,6 +107,20 @@ class AppLogger:
             log_file = f"{DIRPATH.DATA_DIR}/{log_file}"
             logging_config["handlers"]["rotating_file"]["filename"] = log_file
 
+        # Add UserIdFilter configuration to filters section
+        if "filters" not in logging_config:
+            logging_config["filters"] = {}
+        logging_config["filters"]["user_id_filter"] = {
+            "()": "studio.app.common.core.logger.AppLogger.UserIdFilter"
+        }
+
+        # Add user_id_filter to all handlers
+        for handler_config in logging_config.get("handlers", {}).values():
+            if "filters" not in handler_config:
+                handler_config["filters"] = []
+            if "user_id_filter" not in handler_config["filters"]:
+                handler_config["filters"].append("user_id_filter")
+
         return logging_config
 
     @staticmethod
@@ -102,6 +132,20 @@ class AppLogger:
             __class__.init_logger()
 
         return logger
+
+    @staticmethod
+    def set_user_id(user_id: Optional[str]):
+        """
+        Set user_id in the current context for logging
+        """
+        _user_id_context.set(user_id)
+
+    @staticmethod
+    def get_user_id() -> Optional[str]:
+        """
+        Get user_id from the current context
+        """
+        return _user_id_context.get()
 
     @staticmethod
     def format_exc_traceback(e: Exception):

--- a/studio/app/common/core/logger.py
+++ b/studio/app/common/core/logger.py
@@ -1,9 +1,11 @@
+import hashlib
 import logging
 import logging.config
 import os
 import platform
 import traceback
 from contextvars import ContextVar
+from datetime import datetime
 from typing import Optional
 
 import yaml
@@ -158,6 +160,34 @@ class AppLogger:
         Get client_id from the current context
         """
         return _client_id_context.get()
+
+    @staticmethod
+    def generate_client_id(uid: str, auto_refresh: bool = False) -> str:
+        """
+        Generate a client_id for logging based on the specified uid.
+
+        Args:
+            uid: User ID to generate client_id from
+            auto_refresh: If true, refresh id at period interval (weekly)
+
+        Returns:
+            Generated client_id (16 character hash)
+        """
+        if not uid:
+            return uid
+
+        if auto_refresh:
+            datetime_str = datetime.now().strftime(
+                "%Y-%m-%d-%w"
+            )  # Refresh by period (weekly)
+            hash_source = f"{uid}-{datetime_str}"
+        else:
+            hash_source = uid
+
+        client_id = hashlib.md5(hash_source.encode()).hexdigest()
+        client_id = client_id[0:16]
+
+        return client_id
 
     @staticmethod
     def format_exc_traceback(e: Exception):

--- a/studio/app/common/core/logger_context_helpers.py
+++ b/studio/app/common/core/logger_context_helpers.py
@@ -1,0 +1,92 @@
+"""
+Helper utilities for managing logging context across process boundaries
+
+This module provides utilities to propagate client_id context across:
+- ProcessPoolExecutor subprocess boundaries
+- Snakemake script execution contexts
+"""
+
+from functools import wraps
+from typing import Any, Callable, Optional, TypeVar
+
+from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
+
+R = TypeVar("R")
+
+
+def with_client_id_context(func: Callable[..., R]) -> Callable[..., R]:
+    """
+    Decorator to automatically set client_id
+      in logging context for subprocess functions.
+
+    This decorator extracts 'client_id' from function kwargs and sets it in the
+    logging context before executing the function. Useful for ProcessPoolExecutor
+    subprocess functions.
+
+    Usage:
+        @with_client_id_context
+        def subprocess_function(arg1, arg2):
+            # client_id is automatically set in logging context
+            logger.info("This log will include client_id")
+
+        # Call from parent process
+        client_id = get_client_id_for_subprocess()
+        executor.submit(subprocess_function, arg1, arg2, client_id=client_id)
+
+    Args:
+        func: The function to wrap
+
+    Returns:
+        Wrapped function with client_id context management
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> R:
+        # Get client_id from kwargs (keep it in kwargs for function to use)
+        client_id = kwargs.get(LOGGING_CLIENT_ID_KEY, None)
+
+        # Set in logging context
+        if client_id is not None:
+            AppLogger.set_client_id(client_id)
+
+        # Execute original function (client_id remains in kwargs)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def get_client_id_for_subprocess() -> Optional[str]:
+    """
+    Get client_id from current context for passing to subprocess.
+
+    Use this function in the parent process to retrieve the current client_id
+    before spawning a subprocess via ProcessPoolExecutor.
+
+    Usage:
+        client_id = get_client_id_for_subprocess()
+        future = executor.submit(subprocess_func, args, client_id=client_id)
+
+    Returns:
+        Current client_id or None if not set
+    """
+    return AppLogger.get_client_id()
+
+
+def init_client_id_from_snakemake_config(config: dict):
+    """
+    Initialize client_id from snakemake config.
+
+    This function should be called at the beginning of the main() function
+    in snakemake script files to set up the logging context with client_id
+    passed through snakemake config.
+
+    Args:
+        config: Snakemake config dictionary (typically snakemake.config)
+
+    Usage (in snakemake script main function):
+        def main():
+            init_client_id_from_snakemake_config(snakemake.config)
+            # ... rest of processing
+    """
+    client_id = config.get(LOGGING_CLIENT_ID_KEY)
+    AppLogger.set_client_id(client_id)

--- a/studio/app/common/core/middleware/__init__.py
+++ b/studio/app/common/core/middleware/__init__.py
@@ -1,0 +1,7 @@
+"""
+Middleware modules for the Studio application
+"""
+
+from studio.app.common.core.middleware.logging_middleware import UserIdLoggingMiddleware
+
+__all__ = ["UserIdLoggingMiddleware"]

--- a/studio/app/common/core/middleware/__init__.py
+++ b/studio/app/common/core/middleware/__init__.py
@@ -2,6 +2,8 @@
 Middleware modules for the Studio application
 """
 
-from studio.app.common.core.middleware.logging_middleware import UserIdLoggingMiddleware
+from studio.app.common.core.middleware.logging_middleware import (
+    ClientIdLoggingMiddleware,
+)
 
-__all__ = ["UserIdLoggingMiddleware"]
+__all__ = ["ClientIdLoggingMiddleware"]

--- a/studio/app/common/core/middleware/logging_middleware.py
+++ b/studio/app/common/core/middleware/logging_middleware.py
@@ -2,8 +2,6 @@
 Logging middleware for capturing user context in logs
 """
 
-import hashlib
-from datetime import datetime
 from typing import Optional
 
 from fastapi import Request
@@ -16,7 +14,7 @@ from studio.app.common.core.mode import MODE
 
 class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
     """
-    Middleware to extract "client_id" from request and set it in logging context
+    Middleware to extract client_id from request and set it in logging context
 
     This middleware:
     - Extracts uid from authentication tokens (Firebase or JWT (ExToken))
@@ -31,7 +29,7 @@ class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
         # Skip uid extraction for standalone mode
         if not MODE.IS_STANDALONE:
             uid = extract_uid_from_request(request)
-            client_id = __class__.generate_client_id(uid)
+            client_id = AppLogger.generate_client_id(uid)
 
         # Set client_id in logging context
         AppLogger.set_client_id(client_id)
@@ -40,27 +38,3 @@ class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         return response
-
-    @staticmethod
-    def generate_client_id(uid: str, auto_refresh: bool = False) -> str:
-        """
-        Generate a client_id for logging based on the specified uid.
-
-        Args:
-            auto_refresh: If true, refresh id at period interval
-        """
-        if not uid:
-            return uid
-
-        if auto_refresh:
-            datetime_str = datetime.now().strftime(
-                "%Y-%m-%d-%w"
-            )  # Refresh by period (weekly)
-            hash_source = f"{uid}-{datetime_str}"
-        else:
-            hash_source = uid
-
-        client_id = hashlib.md5(hash_source.encode()).hexdigest()
-        client_id = client_id[0:16]
-
-        return client_id

--- a/studio/app/common/core/middleware/logging_middleware.py
+++ b/studio/app/common/core/middleware/logging_middleware.py
@@ -2,6 +2,8 @@
 Logging middleware for capturing user context in logs
 """
 
+import hashlib
+from datetime import datetime
 from typing import Optional
 
 from fastapi import Request
@@ -12,27 +14,53 @@ from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 
 
-class UserIdLoggingMiddleware(BaseHTTPMiddleware):
+class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
     """
-    Middleware to extract user_id from request and set it in logging context
+    Middleware to extract "client_id" from request and set it in logging context
 
     This middleware:
-    - Extracts user_id from authentication tokens (Firebase or JWT (ExToken))
-    - Sets the user_id in the logging context for all log messages during the request
-    - In standalone mode, skips user_id extraction and logging (user_id is blank)
+    - Extracts uid from authentication tokens (Firebase or JWT (ExToken))
+    - Generate client_id from uid (by hashing, etc.)
+    - Sets the client_id in the logging context for all log messages during the request
+    - In standalone mode, skips client_id extraction and logging (client_id is blank)
     """
 
     async def dispatch(self, request: Request, call_next):
-        user_id: Optional[str] = None
+        client_id: Optional[str] = None
 
-        # Skip user_id extraction for standalone mode
+        # Skip uid extraction for standalone mode
         if not MODE.IS_STANDALONE:
-            user_id = extract_uid_from_request(request)
+            uid = extract_uid_from_request(request)
+            client_id = __class__.generate_client_id(uid)
 
-        # Set user_id in logging context
-        AppLogger.set_user_id(user_id)
+        # Set client_id in logging context
+        AppLogger.set_client_id(client_id)
 
         # Process the request
         response = await call_next(request)
 
         return response
+
+    @staticmethod
+    def generate_client_id(uid: str, auto_refresh: bool = False) -> str:
+        """
+        Generate a client_id for logging based on the specified uid.
+
+        Args:
+            auto_refresh: If true, refresh id at period interval
+        """
+        if not uid:
+            return uid
+
+        if auto_refresh:
+            datetime_str = datetime.now().strftime(
+                "%Y-%m-%d-%w"
+            )  # Refresh by period (weekly)
+            hash_source = f"{uid}-{datetime_str}"
+        else:
+            hash_source = uid
+
+        client_id = hashlib.md5(hash_source.encode()).hexdigest()
+        client_id = client_id[0:16]
+
+        return client_id

--- a/studio/app/common/core/middleware/logging_middleware.py
+++ b/studio/app/common/core/middleware/logging_middleware.py
@@ -1,0 +1,38 @@
+"""
+Logging middleware for capturing user context in logs
+"""
+
+from typing import Optional
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from studio.app.common.core.auth.auth_helper import extract_uid_from_request
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.mode import MODE
+
+
+class UserIdLoggingMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to extract user_id from request and set it in logging context
+
+    This middleware:
+    - Extracts user_id from authentication tokens (Firebase or JWT (ExToken))
+    - Sets the user_id in the logging context for all log messages during the request
+    - In standalone mode, skips user_id extraction and logging (user_id is blank)
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        user_id: Optional[str] = None
+
+        # Skip user_id extraction for standalone mode
+        if not MODE.IS_STANDALONE:
+            user_id = extract_uid_from_request(request)
+
+        # Set user_id in logging context
+        AppLogger.set_user_id(user_id)
+
+        # Process the request
+        response = await call_next(request)
+
+        return response

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -9,7 +9,10 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    init_client_id_from_snakemake_config,
+)
 
 logger = AppLogger.get_logger()
 
@@ -23,9 +26,8 @@ def main():
         from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
         from studio.app.const import FILETYPE
 
-        # Set client_id in logging context from snakemake config
-        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
-        AppLogger.set_client_id(client_id)
+        # Initialize client_id from snakemake config
+        init_client_id_from_snakemake_config(snakemake.config)
 
         last_output = snakemake.config["last_output"]
 

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -23,6 +23,10 @@ def main():
         from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
         from studio.app.const import FILETYPE
 
+        # Set user_id in logging context from snakemake config
+        user_id = snakemake.config.get("user_id")
+        AppLogger.set_user_id(user_id)
+
         last_output = snakemake.config["last_output"]
 
         rule_config = RuleConfigReader.read(snakemake.params.name)

--- a/studio/app/common/core/rules/data.py
+++ b/studio/app/common/core/rules/data.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
 
 logger = AppLogger.get_logger()
 
@@ -23,9 +23,9 @@ def main():
         from studio.app.common.core.workflow.workflow import NodeType, NodeTypeUtil
         from studio.app.const import FILETYPE
 
-        # Set user_id in logging context from snakemake config
-        user_id = snakemake.config.get("user_id")
-        AppLogger.set_user_id(user_id)
+        # Set client_id in logging context from snakemake config
+        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
+        AppLogger.set_client_id(client_id)
 
         last_output = snakemake.config["last_output"]
 

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -22,6 +22,10 @@ def main():
         from studio.app.common.core.utils.filepath_creater import join_filepath
         from studio.app.dir_path import DIRPATH
 
+        # Set user_id in logging context from snakemake config
+        user_id = snakemake.config.get("user_id")
+        AppLogger.set_user_id(user_id)
+
         last_output = [
             join_filepath([DIRPATH.OUTPUT_DIR, x])
             for x in snakemake.config["last_output"]

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -9,7 +9,10 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    init_client_id_from_snakemake_config,
+)
 
 logger = AppLogger.get_logger()
 
@@ -22,9 +25,8 @@ def main():
         from studio.app.common.core.utils.filepath_creater import join_filepath
         from studio.app.dir_path import DIRPATH
 
-        # Set client_id in logging context from snakemake config
-        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
-        AppLogger.set_client_id(client_id)
+        # Initialize client_id from snakemake config
+        init_client_id_from_snakemake_config(snakemake.config)
 
         last_output = [
             join_filepath([DIRPATH.OUTPUT_DIR, x])

--- a/studio/app/common/core/rules/func.py
+++ b/studio/app/common/core/rules/func.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
 
 logger = AppLogger.get_logger()
 
@@ -22,9 +22,9 @@ def main():
         from studio.app.common.core.utils.filepath_creater import join_filepath
         from studio.app.dir_path import DIRPATH
 
-        # Set user_id in logging context from snakemake config
-        user_id = snakemake.config.get("user_id")
-        AppLogger.set_user_id(user_id)
+        # Set client_id in logging context from snakemake config
+        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
+        AppLogger.set_client_id(client_id)
 
         last_output = [
             join_filepath([DIRPATH.OUTPUT_DIR, x])

--- a/studio/app/common/core/snakemake/smk.py
+++ b/studio/app/common/core/snakemake/smk.py
@@ -22,6 +22,7 @@ class FlowConfig:
     rules: Dict[str, Rule]
     last_output: list
     nwb_template: dict
+    user_id: str = None  # User ID for logging purposes
 
 
 class ForceRun(BaseModel):

--- a/studio/app/common/core/snakemake/smk.py
+++ b/studio/app/common/core/snakemake/smk.py
@@ -22,7 +22,7 @@ class FlowConfig:
     rules: Dict[str, Rule]
     last_output: list
     nwb_template: dict
-    user_id: str = None  # User ID for logging purposes
+    client_id: str = None  # Client ID for logging purposes
 
 
 class ForceRun(BaseModel):

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,7 +1,7 @@
 import os
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
-from typing import Dict, Optional
+from typing import Dict
 
 from snakemake import snakemake
 
@@ -9,6 +9,10 @@ from studio.app.common.core.experiment.experiment_record_services import (
     ExperimentRecordService,
 )
 from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    get_client_id_for_subprocess,
+    with_client_id_context,
+)
 from studio.app.common.core.snakemake.smk import SmkParam
 from studio.app.common.core.snakemake.smk_status_logger import SmkStatusLogger
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
@@ -24,14 +28,17 @@ logger = AppLogger.get_logger()
 
 
 def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
-    # Get client_id from current context to pass to subprocess
-    client_id = AppLogger.get_client_id()
+    client_id = get_client_id_for_subprocess()
 
     with ProcessPoolExecutor(max_workers=1) as executor:
         logger.info("start snakemake running process.")
 
         future = executor.submit(
-            _snakemake_execute_process, workspace_id, unique_id, params, client_id
+            _snakemake_execute_process,
+            workspace_id,
+            unique_id,
+            params,
+            client_id=client_id,
         )
         future_result = future.result()
 
@@ -40,15 +47,13 @@ def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
         return future_result
 
 
+@with_client_id_context  # Automatically set client_id for logging
 def _snakemake_execute_process(
     workspace_id: str,
     unique_id: str,
     params: SmkParam,
-    client_id: Optional[str] = None,
+    client_id: str = None,
 ) -> bool:
-    # Set client_id in the subprocess context for logging
-    AppLogger.set_client_id(client_id)
-
     # ------------------------------------------------------------
     # Snakemake execution process
     # ------------------------------------------------------------

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -24,14 +24,14 @@ logger = AppLogger.get_logger()
 
 
 def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
-    # Get user_id from current context to pass to subprocess
-    logging_user_id = AppLogger.get_user_id()
+    # Get client_id from current context to pass to subprocess
+    client_id = AppLogger.get_client_id()
 
     with ProcessPoolExecutor(max_workers=1) as executor:
         logger.info("start snakemake running process.")
 
         future = executor.submit(
-            _snakemake_execute_process, workspace_id, unique_id, params, logging_user_id
+            _snakemake_execute_process, workspace_id, unique_id, params, client_id
         )
         future_result = future.result()
 
@@ -44,10 +44,10 @@ def _snakemake_execute_process(
     workspace_id: str,
     unique_id: str,
     params: SmkParam,
-    logging_user_id: Optional[str] = None,
+    client_id: Optional[str] = None,
 ) -> bool:
-    # Set logging_user_id in the subprocess context for logging
-    AppLogger.set_user_id(logging_user_id)
+    # Set client_id in the subprocess context for logging
+    AppLogger.set_client_id(client_id)
 
     # ------------------------------------------------------------
     # Snakemake execution process

--- a/studio/app/common/core/snakemake/snakemake_executor.py
+++ b/studio/app/common/core/snakemake/snakemake_executor.py
@@ -1,7 +1,7 @@
 import os
 from collections import deque
 from concurrent.futures import ProcessPoolExecutor
-from typing import Dict
+from typing import Dict, Optional
 
 from snakemake import snakemake
 
@@ -24,11 +24,14 @@ logger = AppLogger.get_logger()
 
 
 def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
+    # Get user_id from current context to pass to subprocess
+    logging_user_id = AppLogger.get_user_id()
+
     with ProcessPoolExecutor(max_workers=1) as executor:
         logger.info("start snakemake running process.")
 
         future = executor.submit(
-            _snakemake_execute_process, workspace_id, unique_id, params
+            _snakemake_execute_process, workspace_id, unique_id, params, logging_user_id
         )
         future_result = future.result()
 
@@ -38,8 +41,14 @@ def snakemake_execute(workspace_id: str, unique_id: str, params: SmkParam):
 
 
 def _snakemake_execute_process(
-    workspace_id: str, unique_id: str, params: SmkParam
+    workspace_id: str,
+    unique_id: str,
+    params: SmkParam,
+    logging_user_id: Optional[str] = None,
 ) -> bool:
+    # Set logging_user_id in the subprocess context for logging
+    AppLogger.set_user_id(logging_user_id)
+
     # ------------------------------------------------------------
     # Snakemake execution process
     # ------------------------------------------------------------

--- a/studio/app/common/core/utils/log_reader.py
+++ b/studio/app/common/core/utils/log_reader.py
@@ -1,6 +1,10 @@
 import re
 from enum import Enum
 
+from studio.app.common.core.middleware.logging_middleware import (
+    ClientIdLoggingMiddleware,
+)
+from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.file_reader import (
     ContentUnitReader,
     PaginatedFileReader,
@@ -31,8 +35,9 @@ class LogRecordReader(ContentUnitReader):
         else:
             self.levels: list[bytes] = [level.value.encode() for level in levels]
 
-        # User ID filter (None means no filtering)
-        self.filter_user_id: bytes = filter_user_id.encode() if filter_user_id else None
+        # client_id filter (None means no filtering)
+        client_id = ClientIdLoggingMiddleware.generate_client_id(filter_user_id)
+        self.filter_client_id: bytes = client_id.encode() if client_id else None
 
         # Timestamp pattern shared between start_pattern and full pattern
         timestamp_pattern = rb"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"
@@ -42,13 +47,13 @@ class LogRecordReader(ContentUnitReader):
             rb"(?=^" + timestamp_pattern + rb")", re.MULTILINE
         )
 
-        # Full pattern to parse complete log entries including user_id field
+        # Full pattern to parse complete log entries including client_id field
         self.pattern = re.compile(
             rb"^(?P<asctime>" + timestamp_pattern + rb") "
             rb"(?:\x1b\[\d+m)?(?P<levelprefix>\w+)(?:\x1b\[0m)?:?\s+"
             rb"\[(?P<name>[^\]]+)\] "
-            rb"\((?P<process>\w+)\) "
-            rb"\(user:(?P<user_id>[^\)]*)\) "
+            rb"\(pid:(?P<process>\w+)\) "
+            rb"\(client:(?P<client_id>[^\)]*)\) "
             rb"(?P<funcName>\w+)\(\):(?P<lineno>\d+) - "
             rb"(?P<message>.*)",
             re.DOTALL,
@@ -72,7 +77,7 @@ class LogRecordReader(ContentUnitReader):
             "timestamp": components["asctime"],
             "level": components["levelprefix"],
             "name": components["name"],
-            "user_id": components["user_id"],
+            "client_id": components["client_id"],
             "function": components["funcName"],
             "line": int(components["lineno"]),
             "message": components["message"],
@@ -93,10 +98,13 @@ class LogRecordReader(ContentUnitReader):
             if unit_dict["level"] not in self.levels:
                 return False
 
-        # Filter by user_id
-        if self.filter_user_id is not None:
-            if unit_dict["user_id"] != self.filter_user_id:
+        # Filter by client_id
+        if MODE.IS_MULTIUSER:
+            if unit_dict["client_id"] != self.filter_client_id:
                 return False
+        else:
+            # NOTE: In standalone mode, filtering by client_id is not performed.
+            pass
 
         return True
 

--- a/studio/app/common/core/utils/log_reader.py
+++ b/studio/app/common/core/utils/log_reader.py
@@ -1,9 +1,7 @@
 import re
 from enum import Enum
 
-from studio.app.common.core.middleware.logging_middleware import (
-    ClientIdLoggingMiddleware,
-)
+from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.common.core.utils.file_reader import (
     ContentUnitReader,
@@ -36,7 +34,9 @@ class LogRecordReader(ContentUnitReader):
             self.levels: list[bytes] = [level.value.encode() for level in levels]
 
         # client_id filter (None means no filtering)
-        client_id = ClientIdLoggingMiddleware.generate_client_id(filter_user_id)
+        client_id = (
+            AppLogger.generate_client_id(filter_user_id) if filter_user_id else None
+        )
         self.filter_client_id: bytes = client_id.encode() if client_id else None
 
         # Timestamp pattern shared between start_pattern and full pattern

--- a/studio/app/common/core/utils/log_reader.py
+++ b/studio/app/common/core/utils/log_reader.py
@@ -20,20 +20,35 @@ class LogLevel(str, Enum):
 class LogRecordReader(ContentUnitReader):
     """Log record reader that treats each log entry as a unit"""
 
-    def __init__(self, levels: list[LogLevel], **kwargs) -> None:
+    def __init__(
+        self,
+        levels: list[LogLevel],
+        filter_user_id: str = None,
+        **kwargs,
+    ) -> None:
         if LogLevel.ALL in levels:
             self.levels: list[bytes] = []
         else:
             self.levels: list[bytes] = [level.value.encode() for level in levels]
 
+        # User ID filter (None means no filtering)
+        self.filter_user_id: bytes = filter_user_id.encode() if filter_user_id else None
+
+        # Timestamp pattern shared between start_pattern and full pattern
+        timestamp_pattern = rb"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}"
+
+        # Pattern to detect the start of a log entry (for multiline support)
         self.start_pattern = re.compile(
-            rb"(?=^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})", re.MULTILINE
+            rb"(?=^" + timestamp_pattern + rb")", re.MULTILINE
         )
+
+        # Full pattern to parse complete log entries including user_id field
         self.pattern = re.compile(
-            rb"^(?P<asctime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) "
+            rb"^(?P<asctime>" + timestamp_pattern + rb") "
             rb"(?:\x1b\[\d+m)?(?P<levelprefix>\w+)(?:\x1b\[0m)?:?\s+"
             rb"\[(?P<name>[^\]]+)\] "
             rb"\((?P<process>\w+)\) "
+            rb"\(user:(?P<user_id>[^\)]*)\) "
             rb"(?P<funcName>\w+)\(\):(?P<lineno>\d+) - "
             rb"(?P<message>.*)",
             re.DOTALL,
@@ -57,6 +72,7 @@ class LogRecordReader(ContentUnitReader):
             "timestamp": components["asctime"],
             "level": components["levelprefix"],
             "name": components["name"],
+            "user_id": components["user_id"],
             "function": components["funcName"],
             "line": int(components["lineno"]),
             "message": components["message"],
@@ -72,8 +88,15 @@ class LogRecordReader(ContentUnitReader):
         if not unit_dict["parsed"]:
             return False
 
+        # Filter by log level
         if self.levels:
-            return unit_dict["level"] in self.levels
+            if unit_dict["level"] not in self.levels:
+                return False
+
+        # Filter by user_id
+        if self.filter_user_id is not None:
+            if unit_dict["user_id"] != self.filter_user_id:
+                return False
 
         return True
 
@@ -83,8 +106,9 @@ class LogReader(PaginatedFileReader):
         self,
         file_path=DIRPATH.LOG_FILE_PATH,
         levels: list[LogLevel] = [],
+        filter_user_id: str = None,
         **kwargs,
     ):
         super().__init__(file_path, **kwargs)
         self.file_path = file_path
-        self.unit_reader = LogRecordReader(levels=levels)
+        self.unit_reader = LogRecordReader(levels=levels, filter_user_id=filter_user_id)

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -136,16 +136,16 @@ class WorkflowRunner:
 
         nwb_template = get_typecheck_params(self.runItem.nwbParam, "nwb")
 
-        # Get user_id from current logging context to pass to snakemake workflow
+        # Get client_id from current logging context to pass to snakemake workflow
         from studio.app.common.core.logger import AppLogger
 
-        user_id = AppLogger.get_user_id()
+        client_id = AppLogger.get_client_id()
 
         flow_config = FlowConfig(
             rules=rules,
             last_output=last_output,
             nwb_template=nwb_template,
-            user_id=user_id,
+            client_id=client_id,
         )
 
         SmkConfigWriter.write_raw(

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -137,9 +137,11 @@ class WorkflowRunner:
         nwb_template = get_typecheck_params(self.runItem.nwbParam, "nwb")
 
         # Get client_id from current logging context to pass to snakemake workflow
-        from studio.app.common.core.logger import AppLogger
+        from studio.app.common.core.logger_context_helpers import (
+            get_client_id_for_subprocess,
+        )
 
-        client_id = AppLogger.get_client_id()
+        client_id = get_client_id_for_subprocess()
 
         flow_config = FlowConfig(
             rules=rules,

--- a/studio/app/common/core/workflow/workflow_runner.py
+++ b/studio/app/common/core/workflow/workflow_runner.py
@@ -136,10 +136,16 @@ class WorkflowRunner:
 
         nwb_template = get_typecheck_params(self.runItem.nwbParam, "nwb")
 
+        # Get user_id from current logging context to pass to snakemake workflow
+        from studio.app.common.core.logger import AppLogger
+
+        user_id = AppLogger.get_user_id()
+
         flow_config = FlowConfig(
             rules=rules,
             last_output=last_output,
             nwb_template=nwb_template,
+            user_id=user_id,
         )
 
         SmkConfigWriter.write_raw(

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -40,7 +40,9 @@ async def get_log_data(
 ):
     try:
         stop_offset = None
-        log_reader = LogReader(levels=levels, filter_user_id=current_user.uid)
+        log_reader = LogReader(
+            levels=levels, filter_user_id=current_user.uid if current_user else None
+        )
 
         if search:
             stop_offset, offset = log_reader.get_unit_position_from_search_text(

--- a/studio/app/common/routers/logs.py
+++ b/studio/app/common/routers/logs.py
@@ -1,11 +1,13 @@
 from typing import List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing_extensions import Optional
 
+from studio.app.common.core.auth.auth_dependencies import get_current_user
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.utils.log_reader import LogLevel, LogReader
 from studio.app.common.schemas.outputs import PaginatedLineResult
+from studio.app.common.schemas.users import User
 
 router = APIRouter(prefix="/logs", tags=["logs"])
 
@@ -17,6 +19,7 @@ logger = AppLogger.get_logger()
     summary="Fetch log data with pagination",
 )
 async def get_log_data(
+    current_user: User = Depends(get_current_user),
     offset: int = Query(
         default=-1,
         ge=-1,
@@ -37,7 +40,7 @@ async def get_log_data(
 ):
     try:
         stop_offset = None
-        log_reader = LogReader(levels=levels)
+        log_reader = LogReader(levels=levels, filter_user_id=current_user.uid)
 
         if search:
             stop_offset, offset = log_reader.get_unit_position_from_search_text(
@@ -64,9 +67,11 @@ async def get_log_data(
             return PaginatedLineResult(
                 next_offset=max(logs.next_offset, extra_logs.next_offset),
                 prev_offset=min(logs.prev_offset, extra_logs.prev_offset),
-                data=extra_logs.data + logs.data
-                if reverse
-                else logs.data + extra_logs.data,
+                data=(
+                    extra_logs.data + logs.data
+                    if reverse
+                    else logs.data + extra_logs.data
+                ),
             )
 
         return log_reader.read_from_offset(

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -55,12 +55,15 @@ class EditRoiUtils:
 
     @classmethod
     def execute(cls, filepath: set):
+        # Get logging_user_id from current context to pass to subprocess
+        logging_user_id = AppLogger.get_user_id()
+
         result = False
 
         with ProcessPoolExecutor(max_workers=1) as executor:
             logger.info("start snakemake edit_roi process.")
 
-            future = executor.submit(cls._execute_process, filepath)
+            future = executor.submit(cls._execute_process, filepath, logging_user_id)
             result = future.result()
 
             logger.info("finish snakemake edit_roi process. result: %s", result)
@@ -70,7 +73,10 @@ class EditRoiUtils:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @classmethod
-    def _execute_process(cls, filepath: str) -> bool:
+    def _execute_process(cls, filepath: str, logging_user_id: str = None) -> bool:
+        # Set logging_user_id in the subprocess context for logging
+        AppLogger.set_user_id(logging_user_id)
+
         result = snakemake(
             DIRPATH.SNAKEMAKE_FILEPATH,
             use_conda=True,
@@ -80,6 +86,7 @@ class EditRoiUtils:
                 "type": "EDIT_ROI",
                 "algo": cls.get_algo(filepath),
                 "file_path": filepath,
+                "user_id": logging_user_id,  # Pass user_id to snakemake config
             },
         )
 

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, status
 from snakemake import snakemake
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
-from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
 from studio.app.common.core.rules.runner import Runner
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -56,7 +56,7 @@ class EditRoiUtils:
     @classmethod
     def execute(cls, filepath: set):
         # Get logging_user_id from current context to pass to subprocess
-        logging_user_id = AppLogger.get_user_id()
+        logging_user_id = AppLogger.get_client_id()
 
         result = False
 
@@ -73,9 +73,9 @@ class EditRoiUtils:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @classmethod
-    def _execute_process(cls, filepath: str, logging_user_id: str = None) -> bool:
-        # Set logging_user_id in the subprocess context for logging
-        AppLogger.set_user_id(logging_user_id)
+    def _execute_process(cls, filepath: str, client_id: str = None) -> bool:
+        # Set client_id in the subprocess context for logging
+        AppLogger.set_client_id(client_id)
 
         result = snakemake(
             DIRPATH.SNAKEMAKE_FILEPATH,
@@ -86,7 +86,7 @@ class EditRoiUtils:
                 "type": "EDIT_ROI",
                 "algo": cls.get_algo(filepath),
                 "file_path": filepath,
-                "user_id": logging_user_id,  # Pass user_id to snakemake config
+                LOGGING_CLIENT_ID_KEY: client_id,
             },
         )
 

--- a/studio/app/optinist/core/edit_ROI/edit_ROI.py
+++ b/studio/app/optinist/core/edit_ROI/edit_ROI.py
@@ -10,6 +10,10 @@ from snakemake import snakemake
 
 from studio.app.common.core.experiment.experiment import ExptOutputPathIds
 from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    get_client_id_for_subprocess,
+    with_client_id_context,
+)
 from studio.app.common.core.rules.runner import Runner
 from studio.app.common.core.snakemake.snakemake_reader import SmkConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
@@ -55,15 +59,16 @@ class EditRoiUtils:
 
     @classmethod
     def execute(cls, filepath: set):
-        # Get logging_user_id from current context to pass to subprocess
-        logging_user_id = AppLogger.get_client_id()
+        client_id = get_client_id_for_subprocess()
 
         result = False
 
         with ProcessPoolExecutor(max_workers=1) as executor:
             logger.info("start snakemake edit_roi process.")
 
-            future = executor.submit(cls._execute_process, filepath, logging_user_id)
+            future = executor.submit(
+                cls._execute_process, filepath, client_id=client_id
+            )
             result = future.result()
 
             logger.info("finish snakemake edit_roi process. result: %s", result)
@@ -73,10 +78,8 @@ class EditRoiUtils:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @classmethod
+    @with_client_id_context  # Automatically set client_id for logging
     def _execute_process(cls, filepath: str, client_id: str = None) -> bool:
-        # Set client_id in the subprocess context for logging
-        AppLogger.set_client_id(client_id)
-
         result = snakemake(
             DIRPATH.SNAKEMAKE_FILEPATH,
             use_conda=True,

--- a/studio/app/optinist/core/rules/edit_ROI.py
+++ b/studio/app/optinist/core/rules/edit_ROI.py
@@ -18,6 +18,10 @@ def main():
     try:
         from studio.app.optinist.core.edit_ROI import EditROI
 
+        # Set user_id in logging context from snakemake config
+        user_id = snakemake.config.get("user_id")
+        AppLogger.set_user_id(user_id)
+
         config = snakemake.config
         EditROI(file_path=config["file_path"]).commit()
 

--- a/studio/app/optinist/core/rules/edit_ROI.py
+++ b/studio/app/optinist/core/rules/edit_ROI.py
@@ -9,7 +9,10 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
+from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger_context_helpers import (
+    init_client_id_from_snakemake_config,
+)
 
 logger = AppLogger.get_logger()
 
@@ -18,9 +21,8 @@ def main():
     try:
         from studio.app.optinist.core.edit_ROI import EditROI
 
-        # Set client_id in logging context from snakemake config
-        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
-        AppLogger.set_client_id(client_id)
+        # Initialize client_id from snakemake config
+        init_client_id_from_snakemake_config(snakemake.config)
 
         config = snakemake.config
         EditROI(file_path=config["file_path"]).commit()

--- a/studio/app/optinist/core/rules/edit_ROI.py
+++ b/studio/app/optinist/core/rules/edit_ROI.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname
 ROOT_DIRPATH = dirname(dirname(dirname(dirname(dirname(dirname(abspath(__file__)))))))
 sys.path.append(ROOT_DIRPATH)
 
-from studio.app.common.core.logger import AppLogger
+from studio.app.common.core.logger import LOGGING_CLIENT_ID_KEY, AppLogger
 
 logger = AppLogger.get_logger()
 
@@ -18,9 +18,9 @@ def main():
     try:
         from studio.app.optinist.core.edit_ROI import EditROI
 
-        # Set user_id in logging context from snakemake config
-        user_id = snakemake.config.get("user_id")
-        AppLogger.set_user_id(user_id)
+        # Set client_id in logging context from snakemake config
+        client_id = snakemake.config.get(LOGGING_CLIENT_ID_KEY)
+        AppLogger.set_client_id(client_id)
 
         config = snakemake.config
         EditROI(file_path=config["file_path"]).commit()

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler

--- a/studio/config/logging.multiuser.yaml
+++ b/studio/config/logging.multiuser.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (pid:%(process)d) (client:%(client_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler

--- a/studio/config/logging.yaml
+++ b/studio/config/logging.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: false
 formatters:
   default:
     (): "uvicorn.logging.DefaultFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
   access:
     (): "uvicorn.logging.AccessFormatter"
-    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) %(funcName)s():%(lineno)d - %(message)s"
+    fmt: "%(asctime)s %(levelprefix)s [%(name)s] (%(process)d) (user:%(user_id)s) %(funcName)s():%(lineno)d - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler


### PR DESCRIPTION
## Content

In the Log Viewer, a function has been implemented to filter the log display so that only the user's own log is displayed.

### Remarks

Initially, I considered switching the output log file for each user, but due to issues with processing complexity and stability, this PR attempts a simpler solution.
- Each user's log is recorded in the same log file, but with unique information that identifies the user.
- The Log Viewer filters and displays the log by user, using user-specific information in the log as a key.

## Specification

### Architecture

```mermaid
graph LR
    subgraph FrontEnd
        Screens[each Screens]
        LogViewer[log viewer]
    end

    subgraph BackEnd
        APIs[each APIs]
        
        subgraph SnakemakeRunModules["Snakemake run modules"]
            DataNode["data node <br> (data.py)"]
            AlgoNode["algo node <br> (func.py)"]
        end
        
        ContextVars[("contextvars <br> (python module)")]
        Logger[logger]
        LogFile[(log file)]
        LogAPI["API (GET logs)"]
    end

    %% FrontEnd to BackEnd connections
    Screens -->|request| APIs

    %% BackEnd internal connections
    APIs -->|set client_id| ContextVars
    ContextVars -->|get client_id| Logger
    ContextVars -->|get client_id| SnakemakeRunModules
    ContextVars -->|get client_id| LogAPI
    APIs -->|logging| Logger
    SnakemakeRunModules -->|logging| Logger
    
    Logger -->|"logging <br> (with client_id)"| LogFile
    LogFile -->|"get logs <br> (filter by client_id)"| LogAPI
    
    %% BackEnd to FrontEnd connections
    LogViewer -->|request logs| LogAPI
    LogAPI -->|response logs| LogViewer
```

### Specification Explanation

- The client_id uses a hash value based on the Firebase UID, etc., allowing for user identification while recording anonymous information in the log.
  - In cases where the client_id cannot be obtained (such as before signing in or in standalone mode), `client:default` is recorded.

- It has been confirmed that the client_id cannot be obtained in some log output locations.
  - Example
    - Logging of conda activate process in snakemake module
      *The logging for "Activating conda environment" is set to `client:default`
        ```
        2025-10-14 16:50:02,580 INFO     [snakemake.logging] (pid:70659) (client:4e782f44eac52685) text_handler():510 -
        2025-10-14 16:50:02,583 WARNING  [snakemake.logging] (pid:70659) (client:default) text_handler():578 - Activating conda environment: ../../../../barebone-studio/.snakemake/conda/31702a884cc2afe3a5cece2e88881218_
        ``` 
    - Reason:
      - Snakemake uses a thread pool internally, and there appear to be some paths where contextvars cannot be shared between different threads.

## References

- arayabrain/optinist-for-cloud#99

## Testcase

### multiuser mode

#### 単一ユーザーでの確認

- [ ] log file の内容確認（client_id の記録）
  - [ ] sign in 前の画面（sing in form）へのアクセス
    - [ ] log file (logs/studio.log) に、以下のようなLogが記録されていること
      > 2025-10-14 16:31:19,195 [32mINFO[0m:     [uvicorn.access] (pid:69668) (client:default) send():478 - 127.0.0.1:63986 - "GET /is_standalone HTTP/1.1" 200
        - `(client:{client_id})` の {client_id} に、固定文字列 "default" が記録されている
  - [ ] sign in 後の画面へのアクセス
    - [ ] log file (logs/studio.log) に、以下のようなLogが記録されていること
      > 2025-10-14 15:20:16,186 [32mINFO[0m:     [uvicorn.access] (pid:64405) (client:4e782f44eac5) send():478 - 127.0.0.1:62774 - "GET /experiments/1 HTTP/1.1" 200
        - `(client:{client_id})` の {client_id} に、16文字のハッシュ値が記録されている

- [ ] Log Viewer の動作確認  
  ※Worfklow画面で、Log Viewer を表示する ("Logs" icon を Click) 
  <img width="372" height="75" alt="image" src="https://github.com/user-attachments/assets/bc3908c4-a267-4eec-b6f0-4ac429e08c29" />
  - [ ] Log Viewerには、自身の操作で記録されたLogのみが表示されること
    - `(client:{client_id})` に複数の {client_id} が混在して表示されていないこと
    - 生log fileと比較確認
  - [ ] その他、Log Viewer を操作しても、自身の操作以外のLogが表示されていないこと
    - [ ] Workflowの実行 … リアルタイムで自身のWorkflowのLogのみが表示されること
    - [ ] Log Level Filter  … Filterが機能しつつ、自身の操作のLogのみが表示されること
    - [ ] Log histroy scroll back  … 自身の操作のLogのみが表示されること

#### 複数ユーザーでの確認

※別のユーザーで2名同時にログインし、Log Viewer の表示を確認する

- [ ] log file の内容確認
  - [ ] 2名のユーザー間で、log file に異なる {client_id} が記録されていること
- [ ] Log Viewer の動作確認
  - [ ] 2名のユーザー間で、Log Viewerには、自身の操作で記録されたLogのみが表示されること
    - 生log fileと比較確認

### standalone mode

- [ ] log file の内容確認
  - [ ] log file (logs/studio.log) に、以下のようなLogが記録されていること
    > 2025-10-14 16:39:27,833 [32mINFO[0m:     [uvicorn.access] (pid:69668) (client:default) send():478 - 127.0.0.1:64045 - "GET /workspaces?offset=0&limit=50 HTTP/1.1" 401
      - `(client:{client_id})` の {client_id} に、固定文字列 "default" が記録されている

- [ ] Log Viewer の動作確認  
      <img width="372" height="75" alt="image" src="https://github.com/user-attachments/assets/bc3908c4-a267-4eec-b6f0-4ac429e08c29" />
  - [ ] Log Viewerには、すべてのLogが表示されること
    - `(client:{client_id})` の {client_id} によらず、すべてのLogが表示されていること
    - 生log fileと比較確認
  - [ ] その他、Log Viewer を操作しても、すべてのLogが表示されていること
    - [ ] Workflowの実行 … リアルタイムで すべてのLogが表示されること
    - [ ] Log Level Filter  … Filterが機能しつつ、すべてのLogが表示されること
    - [ ] Log histroy scroll back  … すべてののLogが表示されること
