### PR TITLE
Fix/fix and improve logging middleware

### DIFF
--- a/studio/app/common/core/auth/auth_helper.py
+++ b/studio/app/common/core/auth/auth_helper.py
@@ -5,7 +5,11 @@ This module provides shared utilities for extracting user_id (uid) from
 authentication tokens, supporting both Firebase and JWT authentication methods.
 """
 
-from typing import Optional, Tuple
+import asyncio
+import hashlib
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, Optional, Tuple
 
 from fastapi import Request
 from fastapi.security import HTTPAuthorizationCredentials
@@ -13,6 +17,134 @@ from firebase_admin import auth as firebase_auth
 
 from studio.app.common.core.auth.auth_config import AUTH_CONFIG
 from studio.app.common.core.auth.security import validate_access_token
+
+# Thread pool for running synchronous Firebase calls asynchronously
+_thread_pool = ThreadPoolExecutor(max_workers=10, thread_name_prefix="firebase_auth")
+
+# Token cache with TTL (Time To Live)
+# Structure: {token_hash: {"uid": str, "expires_at": float}}
+#
+# IMPORTANT: Multi-process considerations
+# ========================================
+# This is an in-memory, process-local cache. In multi-process deployments
+# (e.g., Gunicorn/Uvicorn with multiple workers), each process maintains
+# its own independent cache.
+#
+# Implications:
+# - Security: No security issues. Each process correctly validates tokens.
+# - Performance: Cache hit rate decreases proportionally to the number of processes.
+#   For example, with 4 workers, the effective cache hit rate is ~25% of single-process.
+# - Firebase API calls: Increases by a factor of the number of processes.
+#
+# Alternative solutions for multi-process environments:
+# - Use a shared cache backend (Redis, Memcached) for cross-process cache sharing
+# - Rely on Firebase Admin SDK's built-in caching (may already provide some caching)
+# - Use sticky sessions at the load balancer to improve cache hit rates
+#
+# Current decision: Acceptable for current deployment as Firebase API has sufficient quota
+# and the performance impact is manageable.
+_token_cache: Dict[str, Dict[str, any]] = {}
+
+# Cache TTL in seconds (5 minutes)
+_CACHE_TTL_SECONDS = 300
+
+
+def _compute_token_hash(token: str) -> str:
+    """
+    Compute a hash of the token for use as a cache key
+
+    Args:
+        token: Authentication token string
+
+    Returns:
+        SHA256 hash of the token
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _get_cached_uid(token: str) -> Optional[str]:
+    """
+    Get cached uid for a token if it exists and hasn't expired
+
+    Args:
+        token: Authentication token string
+
+    Returns:
+        Cached uid if found and valid, None otherwise
+    """
+    token_hash = _compute_token_hash(token)
+    cached_data = _token_cache.get(token_hash)
+
+    if cached_data is None:
+        return None
+
+    # Check if cache has expired
+    if time.time() > cached_data["expires_at"]:
+        # Remove expired cache entry
+        del _token_cache[token_hash]
+        return None
+
+    return cached_data["uid"]
+
+
+def _cache_uid(token: str, uid: Optional[str]) -> None:
+    """
+    Cache the uid for a token with TTL
+
+    Args:
+        token: Authentication token string
+        uid: User ID to cache
+    """
+    if uid is None:
+        return
+
+    token_hash = _compute_token_hash(token)
+    _token_cache[token_hash] = {
+        "uid": uid,
+        "expires_at": time.time() + _CACHE_TTL_SECONDS,
+    }
+
+
+def _verify_firebase_token_sync(token: str) -> Optional[str]:
+    """
+    Synchronous Firebase token verification (for use in thread pool)
+
+    Args:
+        token: Firebase ID token
+
+    Returns:
+        User ID if verification succeeds, None otherwise
+    """
+    try:
+        user = firebase_auth.verify_id_token(token)
+        return user.get("uid")
+    except Exception:
+        return None
+
+
+async def _verify_firebase_token_async(token: str) -> Optional[str]:
+    """
+    Asynchronous Firebase token verification using thread pool
+
+    Args:
+        token: Firebase ID token
+
+    Returns:
+        User ID if verification succeeds, None otherwise
+    """
+    # Check cache first
+    cached_uid = _get_cached_uid(token)
+    if cached_uid is not None:
+        return cached_uid
+
+    # Run synchronous Firebase call in thread pool
+    loop = asyncio.get_event_loop()
+    uid = await loop.run_in_executor(_thread_pool, _verify_firebase_token_sync, token)
+
+    # Cache the result
+    _cache_uid(token, uid)
+
+    return uid
 
 
 def extract_uid_from_firebase_credential(
@@ -57,12 +189,42 @@ def extract_uid_from_jwt_token(ex_token: str) -> Tuple[Optional[str], Optional[s
         return None, f"JWT token validation failed: {e}"
 
 
+def _extract_token_from_request(request: Request) -> Optional[str]:
+    """
+    Extract authentication token from request headers based on configured auth method
+
+    This function checks AUTH_CONFIG.USE_FIREBASE_TOKEN to determine which
+    authentication method to use and extracts the appropriate token.
+
+    Args:
+        request: FastAPI Request object
+
+    Returns:
+        Token string if found, None otherwise
+    """
+    if AUTH_CONFIG.USE_FIREBASE_TOKEN:
+        # Firebase authentication via Bearer token
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            return auth_header.replace("Bearer ", "")
+    else:
+        # JWT authentication via ExToken header
+        ex_token = request.headers.get("ExToken")
+        if ex_token:
+            return ex_token
+
+    return None
+
+
 def extract_uid_from_request(request: Request) -> Optional[str]:
     """
     Extract user_id (uid) from HTTP request based on configured authentication method
 
-    This is a convenience function for middleware and other non-dependency contexts
-    where you need to extract uid without raising exceptions.
+    This is a SYNCHRONOUS convenience function for middleware and other non-dependency
+    contexts where you need to extract uid without raising exceptions.
+
+    Note: This function uses caching to reduce Firebase API calls.
+    For async contexts, prefer extract_uid_from_request_async() for better performance.
 
     Note: This function directly accesses request.headers because it's designed for
     middleware context where FastAPI's Dependency Injection is not available.
@@ -76,28 +238,85 @@ def extract_uid_from_request(request: Request) -> Optional[str]:
         user_id if found, None otherwise (errors are silently ignored)
     """
     try:
-        use_firebase_auth = AUTH_CONFIG.USE_FIREBASE_TOKEN
+        token = _extract_token_from_request(request)
+        if token is None:
+            return None
 
-        if use_firebase_auth:
-            # Firebase authentication via Bearer token
-            auth_header = request.headers.get("Authorization")
-            if auth_header and auth_header.startswith("Bearer "):
-                token = auth_header.replace("Bearer ", "")
-                try:
-                    user = firebase_auth.verify_id_token(token)
-                    return user.get("uid")
-                except Exception:
-                    pass
+        if AUTH_CONFIG.USE_FIREBASE_TOKEN:
+            # Firebase authentication
+            # Check cache first
+            cached_uid = _get_cached_uid(token)
+            if cached_uid is not None:
+                return cached_uid
+
+            # Verify token and cache result
+            try:
+                user = firebase_auth.verify_id_token(token)
+                uid = user.get("uid")
+                _cache_uid(token, uid)
+                return uid
+            except Exception:
+                pass
+
         else:
-            # JWT authentication via ExToken header
-            ex_token = request.headers.get("ExToken")
-            if ex_token:
-                try:
-                    payload, err = validate_access_token(ex_token)
-                    if err is None and payload:
-                        return payload.get("sub")
-                except Exception:
-                    pass
+            # JWT authentication
+            try:
+                payload, err = validate_access_token(token)
+                if err is None and payload:
+                    return payload.get("sub")
+            except Exception:
+                pass
+
+    except Exception:
+        pass
+
+    return None
+
+
+async def extract_uid_from_request_async(request: Request) -> Optional[str]:
+    """
+    ASYNC version: Extract user_id (uid) from HTTP request based on configured auth method
+
+    This is an ASYNCHRONOUS convenience function that should be used in async contexts
+    like middleware. It runs Firebase token verification in a thread pool to avoid
+    blocking the event loop.
+
+    Benefits over sync version:
+    - Non-blocking Firebase API calls (runs in thread pool)
+    - Automatic caching with TTL
+    - Better performance for high-concurrency scenarios
+
+    Recommended usage: Use this in all async contexts (middleware, async route handlers, etc.)
+
+    Args:
+        request: FastAPI Request object
+
+    Returns:
+        user_id if found, None otherwise (errors are silently ignored)
+    """
+    try:
+        token = _extract_token_from_request(request)
+        if token is None:
+            return None
+
+        if AUTH_CONFIG.USE_FIREBASE_TOKEN:
+            # Firebase authentication
+            # Use async verification with caching and thread pool
+            uid = await _verify_firebase_token_async(token)
+            return uid
+
+        else:
+            # JWT authentication
+            # JWT validation is typically fast, run in thread pool anyway to avoid blocking
+            try:
+                loop = asyncio.get_event_loop()
+                payload, err = await loop.run_in_executor(
+                    _thread_pool, validate_access_token, token
+                )
+                if err is None and payload:
+                    return payload.get("sub")
+            except Exception:
+                pass
 
     except Exception:
         pass

--- a/studio/app/common/core/auth/auth_helper.py
+++ b/studio/app/common/core/auth/auth_helper.py
@@ -41,8 +41,8 @@ _thread_pool = ThreadPoolExecutor(max_workers=10, thread_name_prefix="firebase_a
 # - Rely on Firebase Admin SDK's built-in caching (may already provide some caching)
 # - Use sticky sessions at the load balancer to improve cache hit rates
 #
-# Current decision: Acceptable for current deployment as Firebase API has sufficient quota
-# and the performance impact is manageable.
+# Current decision: Acceptable for current deployment as Firebase API has
+#  sufficient quota and the performance impact is manageable.
 _token_cache: Dict[str, Dict[str, any]] = {}
 
 # Cache TTL in seconds (5 minutes)
@@ -275,7 +275,8 @@ def extract_uid_from_request(request: Request) -> Optional[str]:
 
 async def extract_uid_from_request_async(request: Request) -> Optional[str]:
     """
-    ASYNC version: Extract user_id (uid) from HTTP request based on configured auth method
+    ASYNC version: Extract user_id (uid) from HTTP request
+      based on configured auth method
 
     This is an ASYNCHRONOUS convenience function that should be used in async contexts
     like middleware. It runs Firebase token verification in a thread pool to avoid
@@ -286,7 +287,8 @@ async def extract_uid_from_request_async(request: Request) -> Optional[str]:
     - Automatic caching with TTL
     - Better performance for high-concurrency scenarios
 
-    Recommended usage: Use this in all async contexts (middleware, async route handlers, etc.)
+    Recommended usage: Use this in all async contexts
+      (middleware, async route handlers, etc.)
 
     Args:
         request: FastAPI Request object
@@ -307,7 +309,8 @@ async def extract_uid_from_request_async(request: Request) -> Optional[str]:
 
         else:
             # JWT authentication
-            # JWT validation is typically fast, run in thread pool anyway to avoid blocking
+            # JWT validation is typically fast,
+            #   run in thread pool anyway to avoid blocking
             try:
                 loop = asyncio.get_event_loop()
                 payload, err = await loop.run_in_executor(

--- a/studio/app/common/core/middleware/logging_middleware.py
+++ b/studio/app/common/core/middleware/logging_middleware.py
@@ -7,7 +7,7 @@ from typing import Optional
 from fastapi import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from studio.app.common.core.auth.auth_helper import extract_uid_from_request
+from studio.app.common.core.auth.auth_helper import extract_uid_from_request_async
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 
@@ -43,7 +43,8 @@ class ClientIdLoggingMiddleware:
         # Skip uid extraction for standalone mode
         if not MODE.IS_STANDALONE:
             request = Request(scope, receive)
-            uid = extract_uid_from_request(request)
+            # Use async version with caching and thread pool for better performance
+            uid = await extract_uid_from_request_async(request)
             client_id = AppLogger.generate_client_id(uid)
 
         # Set client_id in logging context

--- a/studio/app/common/core/middleware/logging_middleware.py
+++ b/studio/app/common/core/middleware/logging_middleware.py
@@ -5,29 +5,44 @@ Logging middleware for capturing user context in logs
 from typing import Optional
 
 from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from studio.app.common.core.auth.auth_helper import extract_uid_from_request
 from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 
 
-class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
+class ClientIdLoggingMiddleware:
     """
-    Middleware to extract client_id from request and set it in logging context
+    Pure ASGI Middleware to extract client_id from request and set it in logging context
 
     This middleware:
     - Extracts uid from authentication tokens (Firebase or JWT (ExToken))
     - Generate client_id from uid (by hashing, etc.)
     - Sets the client_id in the logging context for all log messages during the request
     - In standalone mode, skips client_id extraction and logging (client_id is blank)
+
+    Note: This uses pure ASGI middleware instead of BaseHTTPMiddleware to avoid
+    known performance issues and connection handling problems with BaseHTTPMiddleware.
+    See: https://github.com/encode/starlette/issues/1012
     """
 
-    async def dispatch(self, request: Request, call_next):
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            # Skip non-HTTP requests (e.g., websocket, lifespan)
+            # Note: scope["type"] == "http" for both HTTP and HTTPS requests
+            await self.app(scope, receive, send)
+            return
+
+        # Extract client_id from request headers
         client_id: Optional[str] = None
 
         # Skip uid extraction for standalone mode
         if not MODE.IS_STANDALONE:
+            request = Request(scope, receive)
             uid = extract_uid_from_request(request)
             client_id = AppLogger.generate_client_id(uid)
 
@@ -35,6 +50,4 @@ class ClientIdLoggingMiddleware(BaseHTTPMiddleware):
         AppLogger.set_client_id(client_id)
 
         # Process the request
-        response = await call_next(request)
-
-        return response
+        await self.app(scope, receive, send)


### PR DESCRIPTION
### Content

The fix for #949 introduced the issue in #957.

<img width="1129" height="677" alt="Image" src="https://github.com/user-attachments/assets/1328dd7a-9952-4740-aa87-1784eedfc73e" />

#### Cause
- It appears there was a specific issue with BaseHTTPMiddleware used in #957. This caused frontend requests to wait.

#### Solution
- The implementation was changed to use pure ASGI instead of BaseHTTPMiddleware.

#### Other improvements
- Reduced excessive Firebase API requests within logging_middleware (using cache).

### Testcase

- [x] Fixed issue #957
- [x] Confirmed proper operation of the original functionality
  - Test case of #949
- [x] Just to be sure, re-ran performance testing of the run API
  - #735
    > Test utilities
    > Performance test program
