### PR TITLE
Match the color for the Account Profile Icon

### DIFF
--- a/frontend/src/components/Layout/Profile.tsx
+++ b/frontend/src/components/Layout/Profile.tsx
@@ -5,7 +5,13 @@ import { useNavigate } from "react-router-dom"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import Logout from "@mui/icons-material/Logout"
 import PortraitIcon from "@mui/icons-material/Portrait"
-import { Menu, MenuItem } from "@mui/material"
+import {
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@mui/material"
 import IconButton from "@mui/material/IconButton"
 
 import { logout } from "store/slice/User/UserSlice"
@@ -35,19 +41,20 @@ const Profile: FC = () => {
 
   return (
     <>
-      <IconButton
-        color="inherit"
-        aria-label="open profile menu"
-        aria-haspopup="true"
-        onClick={handleMenu}
-      >
-        <AccountCircleIcon />
-      </IconButton>
+      <Tooltip title="Profile">
+        <IconButton
+          aria-label="open profile menu"
+          aria-haspopup="true"
+          onClick={handleMenu}
+        >
+          <AccountCircleIcon />
+        </IconButton>
+      </Tooltip>
       <Menu
         id="profile-menu"
         anchorEl={anchorEl}
         anchorOrigin={{
-          vertical: "top",
+          vertical: "bottom",
           horizontal: "right",
         }}
         keepMounted
@@ -59,11 +66,16 @@ const Profile: FC = () => {
         onClose={handleCloseMenu}
       >
         <MenuItem onClick={onClickAccount}>
-          <PortraitIcon /> Account Profile
+          <ListItemIcon>
+            <PortraitIcon />
+          </ListItemIcon>
+          <ListItemText>Account Profile</ListItemText>
         </MenuItem>
         <MenuItem onClick={onClickLogout}>
-          <Logout />
-          SIGN OUT
+          <ListItemIcon>
+            <Logout />
+          </ListItemIcon>
+          <ListItemText>Sign Out</ListItemText>
         </MenuItem>
       </Menu>
     </>


### PR DESCRIPTION
### Content

Match the color for the Account Profile Icon

### References

https://github.com/arayabrain/optinist-for-cloud/pull/181

### Evidence:

Stand-alone:
<img width="161" height="68" alt="Screenshot 2025-11-26 at 17 59 26" src="https://github.com/user-attachments/assets/cdf57d9c-d98a-4144-acce-78c34fedd98e" />

Multiuser:
<img width="227" height="95" alt="Screenshot 2025-11-26 at 17 59 50" src="https://github.com/user-attachments/assets/a123b5d4-2e6b-4f44-80ed-e9d149efaaf0" />
