### PR TITLE
Enhance LeftSlideBar Added Toggle and Untoggle Sidebar

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
@@ -96,6 +96,7 @@ const FlowChart = memo(function FlowChart(props: UseRunPipelineReturnType) {
   const [errorUrl, setErrorUrl] = useState("")
   const [dialogFilterNodeId, setFilterDialogNodeId] = useState("")
   const [nodeRefresh, setNodeRefresh] = useState(false)
+  const [leftSidebarOpen, setLeftSidebarOpen] = useState(true)
 
   const handleRefreshAlgoList = async () => {
     setNodeRefresh(true)
@@ -196,7 +197,10 @@ const FlowChart = memo(function FlowChart(props: UseRunPipelineReturnType) {
         }}
       >
         <DndProvider backend={HTML5Backend}>
-          <LeftSidebarContainer>
+          <LeftSidebarContainer
+            isOpen={leftSidebarOpen}
+            onToggle={() => setLeftSidebarOpen(!leftSidebarOpen)}
+          >
             <Box overflow="auto" marginRight={2}>
               <CurrentPipelineInfo />
             </Box>

--- a/frontend/src/components/Workspace/Visualize/Visualize.tsx
+++ b/frontend/src/components/Workspace/Visualize/Visualize.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react"
+import { FC, useState } from "react"
 
 import { Box } from "@mui/material"
 import { styled } from "@mui/material/styles"
@@ -11,9 +11,14 @@ import { VisualizeItemEditor } from "components/Workspace/Visualize/VisualizeIte
 import { CONTENT_HEIGHT } from "const/Layout"
 
 const Visualize: FC = () => {
+  const [leftSidebarOpen, setLeftSidebarOpen] = useState(true)
+
   return (
     <Box display="flex">
-      <LeftSidebarContainer>
+      <LeftSidebarContainer
+        isOpen={leftSidebarOpen}
+        onToggle={() => setLeftSidebarOpen(!leftSidebarOpen)}
+      >
         <Box overflow="auto" marginRight={2}>
           <CurrentPipelineInfo />
           <VisualizeItemEditor />

--- a/frontend/src/components/common/LeftSidebarContainer.tsx
+++ b/frontend/src/components/common/LeftSidebarContainer.tsx
@@ -1,32 +1,119 @@
 import { FC, ReactNode } from "react"
 
-import { Box } from "@mui/material"
+import MenuIcon from "@mui/icons-material/Menu"
+import MenuOpenIcon from "@mui/icons-material/MenuOpen"
+import { Box, IconButton, Tooltip } from "@mui/material"
 import { grey } from "@mui/material/colors"
 
-import { ResizableSidebar } from "components/common/ResizebleSidebar"
 import { DRAWER_WIDTH, CONTENT_HEIGHT } from "const/Layout"
 
 interface LeftSidebarContainerProps {
   children: ReactNode
+  isOpen: boolean
+  onToggle: () => void
 }
 
 export const LeftSidebarContainer: FC<LeftSidebarContainerProps> = ({
   children,
+  isOpen,
+  onToggle,
 }) => {
   return (
     <Box
-      minWidth={DRAWER_WIDTH}
-      overflow="auto"
-      marginRight={3}
-      borderRight={1}
-      borderColor={grey[300]}
       sx={{
+        width: isOpen ? DRAWER_WIDTH : 56,
         height: CONTENT_HEIGHT,
         display: "flex",
         flexDirection: "column",
+        marginRight: isOpen ? 3 : 0,
+        borderRight: isOpen ? 1 : 0,
+        borderColor: grey[300],
+        overflow: "hidden",
+        paddingTop: 0,
+        paddingLeft: 1,
+        transition: "width 0.3s ease-in-out, margin-right 0.3s ease-in-out",
+        position: "relative",
       }}
     >
-      <ResizableSidebar>{children}</ResizableSidebar>
+      <Box
+        sx={{
+          position: "absolute",
+          top: 8,
+          left: 8,
+          opacity: isOpen ? 0 : 1,
+          visibility: isOpen ? "hidden" : "visible",
+          transition: "opacity 0.2s ease-in-out, visibility 0.2s ease-in-out",
+          pointerEvents: isOpen ? "none" : "auto",
+        }}
+      >
+        <Tooltip title="Open sidebar" placement="right">
+          <IconButton
+            onClick={onToggle}
+            sx={{
+              backgroundColor: "transparent",
+              borderRadius: "6px",
+              width: 36,
+              height: 36,
+              color: grey[700],
+              "&:hover": {
+                backgroundColor: grey[100],
+                color: grey[900],
+              },
+            }}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          transform: isOpen ? "translateX(0)" : "translateX(-100%)",
+          opacity: isOpen ? 1 : 0,
+          transition: "transform 0.3s ease-in-out, opacity 0.3s ease-in-out",
+          pointerEvents: isOpen ? "auto" : "none",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-start",
+            alignItems: "center",
+            paddingY: 0,
+            borderBottom: `1px solid ${grey[200]}`,
+            minHeight: 26,
+          }}
+        >
+          <Tooltip title="Close sidebar">
+            <IconButton
+              onClick={onToggle}
+              sx={{
+                backgroundColor: "transparent",
+                borderRadius: "6px",
+                width: 36,
+                height: 36,
+                color: grey[700],
+                "&:hover": {
+                  backgroundColor: grey[100],
+                  color: grey[900],
+                },
+              }}
+            >
+              <MenuOpenIcon />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Box
+          sx={{
+            flex: 1,
+            overflow: "auto",
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
### Content

Enhance Left Sidebar for Workflow and Visualize
Left Sidebar was adjustable before but with limited range.
Now rather than adjusting it. I changed it to be toggleable.
Therefore, Users that don't want to show it can hide it and if they need it they can just show it.

### References

https://github.com/arayabrain/optinist-for-cloud/pull/182
(Added the changes on barebone since this feature can be share with barebone)

### Others

<img width="388" height="855" alt="Screenshot 2025-11-26 at 17 56 49" src="https://github.com/user-attachments/assets/d0eae3a3-7003-4d5d-9176-39db48683762" />

<img width="363" height="708" alt="Screenshot 2025-11-26 at 17 57 02" src="https://github.com/user-attachments/assets/00d3e818-b6a2-4ca8-b634-239c6099082e" />

