### PR TITLE
Porting common fixes in the fork repository (node control related)

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/Buttons/CreateWorkflow.tsx
+++ b/frontend/src/components/Workspace/FlowChart/Buttons/CreateWorkflow.tsx
@@ -5,6 +5,7 @@ import { AddToPhotos } from "@mui/icons-material"
 import { IconButton, Tooltip } from "@mui/material"
 
 import { ConfirmDialog } from "components/common/ConfirmDialog"
+import { WORKSPACE_TYPE } from "const/Workspace"
 import { clearFlowElements } from "store/slice/FlowElement/FlowElementSlice"
 import { selectPipelineIsStartedSuccess } from "store/slice/Pipeline/PipelineSelectors"
 
@@ -12,12 +13,13 @@ export const CreateWorkflowButton = memo(function CreateWorkflowButton() {
   const [open, setOpen] = useState(false)
   const dispatch = useDispatch()
   const isPending = useSelector(selectPipelineIsStartedSuccess)
+  const workspaceType = WORKSPACE_TYPE.DEFAULT // Currently a fixed value
 
   const openDialog = () => {
     setOpen(true)
   }
   const onConfirm = () => {
-    dispatch(clearFlowElements())
+    dispatch(clearFlowElements({ workspaceType }))
   }
 
   return (

--- a/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
+++ b/frontend/src/components/Workspace/FlowChart/FlowChart.tsx
@@ -102,11 +102,11 @@ const FlowChart = memo(function FlowChart(props: UseRunPipelineReturnType) {
     setNodeRefresh(true)
 
     try {
-      await dispatch(getAlgoList()) // Ensure it waits for the API call to finish
+      await dispatch(getAlgoList()).unwrap()
+      handleClickVariant("success", "Algorithm List Refreshed")
     } catch (error) {
       handleClickVariant("error", "Failed to get Algorithm List")
     } finally {
-      handleClickVariant("success", "Algorithm List Refreshed")
       setNodeRefresh(false)
     }
   }

--- a/frontend/src/const/Workspace.ts
+++ b/frontend/src/const/Workspace.ts
@@ -1,0 +1,9 @@
+export enum WORKSPACE_TYPE {
+  DEFAULT = 0,
+  NORMAL = 1,
+}
+
+export const WORKSPACE_TYPE_LABEL: Record<WORKSPACE_TYPE, string> = {
+  [WORKSPACE_TYPE.DEFAULT]: "Normal", // Same as NORMAL
+  [WORKSPACE_TYPE.NORMAL]: "Normal",
+}

--- a/frontend/src/store/slice/AlgorithmList/AlgorithmListSlice.ts
+++ b/frontend/src/store/slice/AlgorithmList/AlgorithmListSlice.ts
@@ -6,6 +6,7 @@ import {
   AlgorithmListType,
 } from "store/slice/AlgorithmList/AlgorithmListType"
 import { convertToAlgoListType } from "store/slice/AlgorithmList/AlgorithmListUtils"
+import { getWorkspace } from "store/slice/Workspace/WorkspaceActions"
 
 export const initialState: AlgorithmListType = {
   isLatest: false,
@@ -15,13 +16,23 @@ export const initialState: AlgorithmListType = {
 export const algorithmListSlice = createSlice({
   name: ALGORITHM_LIST_SLICE_NAME,
   initialState,
-  reducers: {},
+  reducers: {
+    resetAlgoListCache: (state) => {
+      state.isLatest = false
+    },
+  },
   extraReducers: (builder) => {
-    builder.addCase(getAlgoList.fulfilled, (state, action) => {
-      state.tree = convertToAlgoListType(action.payload)
-      state.isLatest = true
-    })
+    builder
+      .addCase(getAlgoList.fulfilled, (state, action) => {
+        state.tree = convertToAlgoListType(action.payload)
+        state.isLatest = true
+      })
+      .addCase(getWorkspace.fulfilled, (state) => {
+        // Reset AlgoList cache when workspace is switched
+        state.isLatest = false
+      })
   },
 })
 
+export const { resetAlgoListCache } = algorithmListSlice.actions
 export default algorithmListSlice.reducer

--- a/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementSlice.ts
@@ -19,6 +19,7 @@ import {
   INITIAL_IMAGE_ELEMENT_ID,
   INITIAL_IMAGE_ELEMENT_NAME,
 } from "const/flowchart"
+import { WORKSPACE_TYPE } from "const/Workspace"
 import { uploadFile } from "store/slice/FileUploader/FileUploaderActions"
 import {
   addAlgorithmNode,
@@ -38,11 +39,19 @@ import {
   importWorkflowConfig,
   fetchWorkflow,
 } from "store/slice/Workflow/WorkflowActions"
+import { getWorkspace } from "store/slice/Workspace/WorkspaceActions"
 
-const initialNodes: Node<NodeData>[] = [
+/**
+ * Get the appropriate React Flow node type for the initial node
+ */
+const getInitialNodeType = (_workspaceType?: number): string => {
+  return REACT_FLOW_NODE_TYPE_KEY.ImageFileNode
+}
+
+const createInitialNodes = (workspaceType?: number): Node<NodeData>[] => [
   {
     id: INITIAL_IMAGE_ELEMENT_ID,
-    type: REACT_FLOW_NODE_TYPE_KEY.ImageFileNode,
+    type: getInitialNodeType(workspaceType),
     data: {
       type: NODE_TYPE_SET.INPUT,
       label: INITIAL_IMAGE_ELEMENT_NAME,
@@ -59,34 +68,44 @@ const initialElementCoord: ElementCoord = {
   y: 150,
 }
 
-const initialState: FlowElement = {
-  flowNodes: initialNodes,
-  flowEdges: [],
-  flowPosition: initialFlowPosition,
-  elementCoord: initialElementCoord,
-  loading: false,
+/**
+ * Create initial state with workspace type
+ * @param workspaceType - Workspace type to use directly (optional)
+ * @param preserveFrom - Old state to preserve workspace type from (optional)
+ *
+ * Priority: workspaceType > preserveFrom.currentWorkspaceType > undefined
+ */
+const createInitialState = (
+  workspaceType?: number,
+  preserveFrom?: FlowElement,
+): FlowElement => {
+  // Priority: explicit workspaceType > preserved from state > undefined
+  const effectiveWorkspaceType =
+    workspaceType !== undefined
+      ? workspaceType
+      : preserveFrom?.currentWorkspaceType
+
+  return {
+    flowNodes: createInitialNodes(effectiveWorkspaceType),
+    flowEdges: [],
+    flowPosition: initialFlowPosition,
+    elementCoord: initialElementCoord,
+    loading: false,
+    currentWorkspaceType: effectiveWorkspaceType,
+  }
 }
+
+const initialState: FlowElement = createInitialState()
 
 export const flowElementSlice = createSlice({
   name: FLOW_ELEMENT_SLICE_NAME,
   initialState,
   reducers: {
-    clearFlowElements: (state) => {
-      state.flowNodes = applyNodeChanges(
-        state.flowNodes.map((node) => {
-          return { id: node.id, type: "remove" }
-        }),
-        state.flowNodes,
-      )
-      state.flowNodes = initialNodes
-      state.flowEdges = applyEdgeChanges(
-        state.flowEdges.map((edge) => {
-          return { id: edge.id, type: "remove" }
-        }),
-        state.flowEdges,
-      )
-      state.flowPosition = initialFlowPosition
-      state.elementCoord = initialElementCoord
+    clearFlowElements: (
+      state,
+      action: PayloadAction<{ workspaceType?: number }>,
+    ) => {
+      return createInitialState(action.payload?.workspaceType, state)
     },
     setFlowPosition: (state, action: PayloadAction<Transform>) => {
       state.flowPosition = action.payload
@@ -159,6 +178,20 @@ export const flowElementSlice = createSlice({
   },
   extraReducers: (builder) =>
     builder
+      .addCase(getWorkspace.fulfilled, (state) => {
+        // Save workspace type for later use
+        const workspaceType = WORKSPACE_TYPE.DEFAULT // Currently a fixed value
+        state.currentWorkspaceType = workspaceType
+
+        // Update the initial node type based on workspace type
+        const initialNodeIdx = state.flowNodes.findIndex(
+          (node) => node.id === INITIAL_IMAGE_ELEMENT_ID,
+        )
+        if (initialNodeIdx !== -1) {
+          state.flowNodes[initialNodeIdx].type =
+            getInitialNodeType(workspaceType)
+        }
+      })
       .addCase(addAlgorithmNode.fulfilled, (state, action) => {
         let { node } = action.meta.arg
         if (node.data?.type === NODE_TYPE_SET.ALGORITHM) {
@@ -226,7 +259,10 @@ export const flowElementSlice = createSlice({
       .addCase(reproduceWorkflow.pending, (state) => {
         state.loading = true
       })
-      .addCase(fetchWorkflow.rejected, () => initialState)
+      .addCase(fetchWorkflow.rejected, (state) => {
+        // Clear previous workspace nodes and reset to initial state
+        return createInitialState(undefined, state)
+      })
       .addCase(reproduceWorkflow.rejected, (state) => {
         state.loading = false
       })

--- a/frontend/src/store/slice/FlowElement/FlowElementType.ts
+++ b/frontend/src/store/slice/FlowElement/FlowElementType.ts
@@ -33,6 +33,7 @@ export interface FlowElement {
   flowPosition: Transform
   elementCoord: ElementCoord
   loading?: boolean
+  currentWorkspaceType?: number
 }
 
 export interface NodeIdProps {

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, isAnyOf, PayloadAction } from "@reduxjs/toolkit"
 
 import { isInputNodePostData } from "api/run/RunUtils"
 import { INITIAL_IMAGE_ELEMENT_ID } from "const/flowchart"
+import { WORKSPACE_TYPE } from "const/Workspace"
 import { FileNodeFactory } from "factories/FileNodeFactory"
 import { uploadFile } from "store/slice/FileUploader/FileUploaderActions"
 import { addInputNode } from "store/slice/FlowElement/FlowElementActions"
@@ -20,6 +21,7 @@ import {
   InputNodeType,
   INPUT_NODE_SLICE_NAME,
   MatlabInputNode,
+  WORKSPACE_TYPE_KEY,
 } from "store/slice/InputNode/InputNodeType"
 import {
   isCsvInputNode,
@@ -31,13 +33,50 @@ import {
   importWorkflowConfig,
   fetchWorkflow,
 } from "store/slice/Workflow/WorkflowActions"
+import { getWorkspace } from "store/slice/Workspace/WorkspaceActions"
 
-const initialState: InputNode = {
-  [INITIAL_IMAGE_ELEMENT_ID]: {
-    fileType: FILE_TYPE_SET.IMAGE,
-    param: {},
-  },
-} as InputNode
+/**
+ * Get the appropriate file type for the initial node
+ */
+const getInitialNodeFileType = (_workspaceType?: number) => {
+  return FILE_TYPE_SET.IMAGE
+}
+
+/**
+ * Create initial state with workspace type
+ * @param workspaceType - Workspace type to use directly (optional)
+ * @param preserveFrom - Old state to preserve workspace type from (optional)
+ * @param includeInitialNode - Whether to include initial node (default: true)
+ */
+const createInitialState = (
+  workspaceType?: number,
+  preserveFrom?: InputNode,
+  includeInitialNode = true,
+): InputNode => {
+  const effectiveWorkspaceType =
+    workspaceType !== undefined
+      ? workspaceType
+      : preserveFrom?.[WORKSPACE_TYPE_KEY]
+
+  const newState: InputNode = {}
+
+  // Add initial node if requested
+  if (includeInitialNode) {
+    newState[INITIAL_IMAGE_ELEMENT_ID] = {
+      fileType: getInitialNodeFileType(effectiveWorkspaceType),
+      param: {},
+    } as InputNodeType
+  }
+
+  // Preserve workspace type in new state
+  if (effectiveWorkspaceType !== undefined) {
+    newState[WORKSPACE_TYPE_KEY] = effectiveWorkspaceType
+  }
+
+  return newState
+}
+
+const initialState: InputNode = createInitialState()
 
 export const inputNodeSlice = createSlice({
   name: INPUT_NODE_SLICE_NAME,
@@ -88,6 +127,18 @@ export const inputNodeSlice = createSlice({
   },
   extraReducers: (builder) =>
     builder
+      .addCase(getWorkspace.fulfilled, (state) => {
+        // Save workspace type for later use
+        const workspaceType = WORKSPACE_TYPE.DEFAULT // Currently a fixed value
+        state[WORKSPACE_TYPE_KEY] = workspaceType
+
+        // Update the initial node based on workspace type
+        const initialNode = state[INITIAL_IMAGE_ELEMENT_ID]
+        if (initialNode) {
+          const newFileType = getInitialNodeFileType(workspaceType)
+          initialNode.fileType = newFileType as typeof initialNode.fileType
+        }
+      })
       .addCase(setInputNodeFilePath, (state, action) => {
         const { nodeId, filePath } = action.payload
         const targetNode = state[nodeId]
@@ -111,7 +162,9 @@ export const inputNodeSlice = createSlice({
           }
         }
       })
-      .addCase(clearFlowElements, () => initialState)
+      .addCase(clearFlowElements, (state, action) =>
+        createInitialState(action.payload?.workspaceType, state),
+      )
       .addCase(deleteFlowNodes, (state, action) => {
         action.payload.forEach((node) => {
           if (node.data?.type === NODE_TYPE_SET.INPUT) {
@@ -141,9 +194,13 @@ export const inputNodeSlice = createSlice({
           }
         }
       })
-      .addCase(fetchWorkflow.rejected, () => initialState)
-      .addCase(importWorkflowConfig.fulfilled, (_, action) => {
-        const newState: InputNode = {}
+      .addCase(fetchWorkflow.rejected, (state) => {
+        // Clear previous workspace nodes and reset to initial state
+        return createInitialState(undefined, state)
+      })
+      .addCase(importWorkflowConfig.fulfilled, (state, action) => {
+        const newState = createInitialState(undefined, state, false)
+
         Object.values(action.payload.nodeDict)
           .filter(isInputNodePostData)
           .forEach((node) => {
@@ -174,8 +231,9 @@ export const inputNodeSlice = createSlice({
       })
       .addMatcher(
         isAnyOf(fetchWorkflow.fulfilled, reproduceWorkflow.fulfilled),
-        (_, action) => {
-          const newState: InputNode = {}
+        (state, action) => {
+          const newState = createInitialState(undefined, state, false)
+
           Object.values(action.payload.nodeDict)
             .filter(isInputNodePostData)
             .forEach((node) => {

--- a/frontend/src/store/slice/InputNode/InputNodeType.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeType.ts
@@ -2,12 +2,16 @@ import { FILE_TYPE_SET, FILE_TYPE } from "config/fileTypes.config"
 
 export const INPUT_NODE_SLICE_NAME = "inputNode"
 
+// Symbol key for storing workspace type without interfering with Object.entries/values
+export const WORKSPACE_TYPE_KEY = Symbol("workspaceType")
+
 // Re-export for convenience
 export type { FILE_TYPE }
 export { FILE_TYPE_SET }
 
 export type InputNode = {
   [nodeId: string]: InputNodeType
+  [WORKSPACE_TYPE_KEY]?: number
 }
 
 export type InputNodeType =


### PR DESCRIPTION
### Content

Porting common fixes in the fork repository (Updated Node control related code)

#### Improved requests to the GET alogolist API

- Changed to refresh the algolist when switching workspaces.
- Originally, the algolist was cached once it was retrieved, but this did not address the new requirement of switching the algolist for each workspace, so this was updated.
- Also, API error handling was incorrect, so it was fixed. (Errors are now displayed as success.)

#### Improved the initial node switching

- Improved the initial node switching based on workspace type for more accurate behavior.
  - porting of bellow:
    - arayabrain/optinist-for-server#478
    - 2d6df3c077cdc169166e63caef25711d53b66791
  - However, in this repository modification, the workspace type is a fixed value (because there is only one type).
- The initialization process has been clarified by providing a helper function.

### Testcase

#### Improved requests to the GET alogolist API

- [x] The GET logolist API is called every time you change workspaces, and the changes are reflected in the algorithm list in the left side menu.

#### Improved the initial node switching

- Initializing a workflow
  - [x] Displaying the workflow screen for a workspace with zero records (e.g., immediately after creation)
    - The `image` node is initially displayed
  - [x] Clicking the "Create new workflow" button on the workflow screen
    - The `image` node is initially displayed
- Reproducing a workflow
  - [x] Displaying the workflow screen for a workspace with one or more records
    - The latest workflow configuration is displayed
  - [x] Reproducing any record
    - The reproduced workflow configuration is displayed