### PR TITLE
Porting common fixes in the fork repository (config reader related)

### DIFF
--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -89,9 +89,11 @@ class ExptConfigReader:
         """
         config_dict = asdict(config)
         for field in ExptConfig.required_fields():
-            assert (
-                config_dict.get(field) is not None
-            ), f"ExptConfig.{field} is required."
+            if config_dict.get(field) is None:
+                logger.warning(
+                    f"ExptConfig.{field} is missing or None in experiment config"
+                )
+                return False
 
         return True
 

--- a/studio/app/common/core/workflow/workflow_params.py
+++ b/studio/app/common/core/workflow/workflow_params.py
@@ -5,8 +5,13 @@ from studio.app.common.core.utils.filepath_finder import find_param_filepath
 logger = AppLogger.get_logger()
 
 
+def read_default_params(name: str):
+    filepath = find_param_filepath(name)
+    return ConfigReader.read(filepath)
+
+
 def get_typecheck_params(message_params, name):
-    default_params = ConfigReader.read(find_param_filepath(name))
+    default_params = read_default_params(name)
     if message_params != {} and message_params is not None:
         return check_types(nest2dict(message_params), default_params)
     return default_params

--- a/studio/app/common/core/workflow/workflow_reader.py
+++ b/studio/app/common/core/workflow/workflow_reader.py
@@ -44,6 +44,15 @@ class WorkflowConfigReader:
         return cls.read(ids.workspace_id, ids.unique_id)
 
     @classmethod
+    def _read_from_any_path(cls, filepath: str) -> WorkflowConfig:
+        assert os.path.exists(filepath), f"Config yaml file not found: [{filepath}]"
+
+        config = ConfigReader.read(filepath)
+        assert config, f"Invalid config yaml file: [{filepath}] [{config}]"
+
+        return cls._create_workflow_config(config)
+
+    @classmethod
     def read_from_bytes(cls, content: bytes) -> WorkflowConfig:
         config = ConfigReader.read_from_bytes(content)
         assert config, f"Invalid config yaml: [{config}]"

--- a/studio/app/common/routers/params.py
+++ b/studio/app/common/routers/params.py
@@ -2,8 +2,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter
 
-from studio.app.common.core.utils.config_handler import ConfigReader
-from studio.app.common.core.utils.filepath_finder import find_param_filepath
+from studio.app.common.core.workflow.workflow_params import read_default_params
 from studio.app.common.schemas.params import SnakemakeParams
 
 router = APIRouter(tags=["params"])
@@ -11,12 +10,9 @@ router = APIRouter(tags=["params"])
 
 @router.get("/params/{name}", response_model=Dict[str, Any])
 async def get_params(name: str):
-    filepath = find_param_filepath(name)
-    config = ConfigReader.read(filepath)
-    return config
+    return read_default_params(name)
 
 
 @router.get("/snakemake", response_model=SnakemakeParams)
 async def get_snakemake_params():
-    filepath = find_param_filepath("snakemake")
-    return ConfigReader.read(filepath)
+    return read_default_params("snakemake")

--- a/studio/app/optinist/routers/nwb.py
+++ b/studio/app/optinist/routers/nwb.py
@@ -3,9 +3,8 @@ from glob import glob
 from fastapi import APIRouter, Depends
 from fastapi.responses import FileResponse
 
-from studio.app.common.core.utils.config_handler import ConfigReader
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.utils.filepath_finder import find_param_filepath
+from studio.app.common.core.workflow.workflow_params import read_default_params
 from studio.app.common.core.workspace.workspace_dependencies import (
     is_workspace_available,
 )
@@ -17,8 +16,7 @@ router = APIRouter()
 
 @router.get("/nwb", response_model=NWBParams, tags=["params"])
 async def get_nwb_params():
-    filepath = find_param_filepath("nwb")
-    return ConfigReader.read(filepath)
+    return read_default_params("nwb")
 
 
 @router.get(

--- a/studio/tests/app/common/core/utils/test_config_handler.py
+++ b/studio/tests/app/common/core/utils/test_config_handler.py
@@ -1,8 +1,8 @@
 import os
 
-from studio.app.common.core.utils.config_handler import ConfigReader, ConfigWriter
+from studio.app.common.core.utils.config_handler import ConfigWriter
 from studio.app.common.core.utils.filepath_creater import join_filepath
-from studio.app.common.core.utils.filepath_finder import find_param_filepath
+from studio.app.common.core.workflow.workflow_params import read_default_params
 from studio.app.dir_path import DIRPATH
 
 dirpath = DIRPATH.OUTPUT_DIR
@@ -10,16 +10,14 @@ filename = "test.yaml"
 
 
 def test_config_reader():
-    filename = "eta"
-    filepath = find_param_filepath(filename)
-    config = ConfigReader.read(filepath)
+    node_name = "eta"
+    config = read_default_params(node_name)
 
     assert isinstance(config, dict)
     assert len(config) > 0
 
-    filename = "not_exist_config"
-    filepath = find_param_filepath(filename)
-    config = ConfigReader.read(filepath)
+    node_name = "not_exist_config"
+    config = read_default_params(node_name)
 
     assert isinstance(config, dict)
     assert len(config) == 0


### PR DESCRIPTION
### Content

Porting common fixes in the fork repository (Updated ConfigReader related code)

- **Added read_default_params function to workflow_params** (02a69cf36)
  - Considering that it will be used by additional functions, redundant code has been reduced.
- **Minor updates for WorkflowConfigReader and ExptConfigReader**

### Testcase

- **Added read_default_params function to workflow_params**
  - [x] On the Workflow screen, the "Snakemake settings" and "NWB settings" params are displayed without errors.

- **Minor updates for WorkflowConfigReader and ExptConfigReader**
  - [x] Only data that is successfully validated is displayed on the Record screen. (Data with validation errors will be skipped.)
