### PR TITLE
Frontend-related fixes

### DIFF
--- a/frontend/src/components/Workspace/FlowChart/TreeView.tsx
+++ b/frontend/src/components/Workspace/FlowChart/TreeView.tsx
@@ -114,14 +114,16 @@ export const AlgorithmTreeView = memo(function AlgorithmTreeView() {
 
       {/* Algorithm hierarchy remains static */}
       <TreeItem nodeId="Algorithm" label="Algorithm">
-        {Object.entries(algoList).map(([name, node], i) => (
-          <AlgoNodeComponentRecursive
-            name={name}
-            node={node}
-            onAddAlgoNode={onAddAlgoNode}
-            key={i.toFixed()}
-          />
-        ))}
+        {Object.entries(algoList)
+          .filter(([, node]) => node !== undefined)
+          .map(([name, node], i) => (
+            <AlgoNodeComponentRecursive
+              name={name}
+              node={node}
+              onAddAlgoNode={onAddAlgoNode}
+              key={i.toFixed()}
+            />
+          ))}
       </TreeItem>
     </TreeView>
   )
@@ -199,6 +201,11 @@ const AlgoNodeComponentRecursive = memo(function AlgoNodeComponentRecursive({
   node,
   onAddAlgoNode,
 }: AlgoNodeComponentRecursiveProps) {
+  // Guard against undefined nodes
+  if (!node) {
+    return null
+  }
+
   if (isAlgoChild(node)) {
     return (
       <AlgoNodeComponent
@@ -210,14 +217,16 @@ const AlgoNodeComponentRecursive = memo(function AlgoNodeComponentRecursive({
   } else {
     return (
       <TreeItem nodeId={name} label={name}>
-        {Object.entries(node.children).map(([name, node], i) => (
-          <AlgoNodeComponentRecursive
-            name={name}
-            node={node}
-            onAddAlgoNode={onAddAlgoNode}
-            key={i.toFixed()}
-          />
-        ))}
+        {Object.entries(node.children)
+          .filter(([, childNode]) => childNode !== undefined)
+          .map(([childName, childNode], i) => (
+            <AlgoNodeComponentRecursive
+              name={childName}
+              node={childNode}
+              onAddAlgoNode={onAddAlgoNode}
+              key={i.toFixed()}
+            />
+          ))}
       </TreeItem>
     )
   }


### PR DESCRIPTION
### Content

- Implemented validation enhancements in the frontend where a `Cannot read properties of undefined` error could occur.
  - When this error occurs, the screen will be blank.

### References

- arayabrain/optinist-for-server#485

### Testcase

- [x] If there is no problem with the node list display on the left side menu on the workflow screen, it is OK
  (the error reproduction check is omitted)