### PR TITLE
Adjusted timeouts for the file upload/download API

### DIFF
--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -1,5 +1,5 @@
 import { OutputPathsDTO } from "api/run/Run"
-import { BASE_URL } from "const/API"
+import { API_TIMEOUT, BASE_URL } from "const/API"
 import { EXPERIMENTS_STATUS } from "store/slice/Experiments/ExperimentsType"
 import axios from "utils/axios"
 
@@ -93,6 +93,7 @@ export async function downloadExperimentNwbApi(
       : `${BASE_URL}/experiments/download/nwb/${workspaceId}/${uid}`
   const response = await axios.get(path, {
     responseType: "blob",
+    timeout: API_TIMEOUT.UPLOAD_DOWNLOAD,
   })
   return response.data
 }

--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -1,7 +1,7 @@
 import { AxiosProgressEvent } from "axios"
 
 import { FILE_TREE_TYPE_SET } from "config/fileTypes.config"
-import { BASE_URL } from "const/API"
+import { API_TIMEOUT, BASE_URL } from "const/API"
 import axios from "utils/axios"
 
 // Re-export for convenience - FILE_TREE_TYPE depends on FILE_TREE_TYPE_SET
@@ -57,7 +57,11 @@ export async function uploadFileApi(
   const response = await axios.post(
     `${BASE_URL}/files/${workspaceId}/upload/${fileName}`,
     formData,
-    config,
+    {
+      ...config,
+      // Use extended timeout for file uploads to support large files
+      timeout: API_TIMEOUT.UPLOAD_DOWNLOAD,
+    },
   )
   return response.data
 }
@@ -89,7 +93,10 @@ export const uploadViaUrlApi = async (
   const res = await axios.post(
     `${BASE_URL}/files/${workspaceId}/download`,
     { url },
-    // config,
+    {
+      // Use extended timeout for URL-based file downloads to support large remote files
+      timeout: API_TIMEOUT.UPLOAD_DOWNLOAD,
+    },
   )
   return res.data
 }

--- a/frontend/src/const/API.ts
+++ b/frontend/src/const/API.ts
@@ -11,3 +11,11 @@ const PORT =
 
 export const BASE_URL =
   PORT == null ? `${PROTO}://${HOST}` : `${PROTO}://${HOST}:${PORT}`
+
+/**
+ * API Request Timeout Constants (in milliseconds, set to axios)
+ */
+export const API_TIMEOUT = {
+  DEFAULT: 600000, // Default timeout for backend API
+  UPLOAD_DOWNLOAD: 0, // Upload/Download API timeout (No timeout(0), consider large file transfers)
+} as const

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -1,12 +1,12 @@
 import axiosLibrary from "axios"
 
 import { refreshTokenApi } from "api/auth/Auth"
-import { BASE_URL } from "const/API"
+import { API_TIMEOUT, BASE_URL } from "const/API"
 import { getExToken, getToken, logout, saveToken } from "utils/auth/AuthUtils"
 
 const axios = axiosLibrary.create({
   baseURL: BASE_URL,
-  timeout: 600000,
+  timeout: API_TIMEOUT.DEFAULT,
 })
 
 axios.interceptors.request.use(


### PR DESCRIPTION
### Content

Due to a lack of consideration for timeouts in the upload and download API, there was a possibility that unexpected timeouts could occur when uploading or downloading large files depending on the environment.

Here, the timeouts for the upload and download APIs were adjusted to accommodate slow environments.
(The timeouts for these APIs have been extended (set to unlimited))

### Testcase

- [x] Check the normal API timeout.
  - API requests (other than upload/download) with response times exceeding API_TIMEOUT.DEFAULT (10 minutes) should time out after API_TIMEOUT.DEFAULT has elapsed.
    - *However, since there are no APIs that require 10 minutes in reality, it is acceptable to simulate this by inserting a sleep period (10 minutes) on the API side and checking operation.

- [x] Check the Upload/Download API timeout.
  - [x] The Upload API should not time out even if it exceeds API_TIMEOUT.DEFAULT (10 minutes).
    - *However, since upload requests rarely exceed 10 minutes in a local environment, it is acceptable to simulate this by inserting a sleep period (10 minutes) on the API side and checking operation.
  - [x] For the Download (Record > NWB) API, perform the same check as for the Upload API timeout.