### PR TITLE
Added Timeseries Chunk Handler

### DIFF
--- a/studio/app/common/core/utils/file_reader.py
+++ b/studio/app/common/core/utils/file_reader.py
@@ -62,6 +62,49 @@ class JsonReader:
         )
 
     @classmethod
+    def read_as_timeseries_from_df(cls, df) -> JsonTimeSeriesData:
+        """
+        Create JsonTimeSeriesData from a pandas DataFrame.
+        Expects DataFrame with index as xrange and columns
+          containing 'data' and optionally 'std'.
+        Handles None/null values (which may come from NaN in original data).
+        """
+        import math
+
+        import pandas as pd
+
+        xrange = [str(idx) for idx in df.index.tolist()]
+
+        # Convert data, handling NaN/None values (null in JSON)
+        data = {}
+        for idx, val in zip(df.index, df["data"]):
+            # Check for NaN/None and convert to None (null in JSON)
+            if pd.isna(val):
+                data[str(idx)] = None
+            elif isinstance(val, float) and (math.isnan(val) or math.isinf(val)):
+                data[str(idx)] = None
+            else:
+                data[str(idx)] = float(val)
+
+        std = None
+        if "std" in df.columns:
+            std = {}
+            for idx, val in zip(df.index, df["std"]):
+                # Check for NaN/None and convert to None (null in JSON)
+                if pd.isna(val):
+                    std[str(idx)] = None
+                elif isinstance(val, float) and (math.isnan(val) or math.isinf(val)):
+                    std[str(idx)] = None
+                else:
+                    std[str(idx)] = float(val)
+
+        return JsonTimeSeriesData(
+            xrange=xrange,
+            data=data,
+            std=std,
+        )
+
+    @classmethod
     def read_as_plot_meta(cls, filepath) -> PlotMetaData:
         json_data = cls.read(filepath) if os.path.exists(filepath) else {}
         return PlotMetaData(**json_data)

--- a/studio/app/common/core/utils/json_writer.py
+++ b/studio/app/common/core/utils/json_writer.py
@@ -1,6 +1,7 @@
 import json
+import math
 import os
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -28,6 +29,30 @@ class JsonWriter:
         if data is not None:
             with open(filepath, "w") as f:
                 json.dump(data.value_present_dict(), f, indent=4)
+
+    @staticmethod
+    def sanitize_for_json(obj: Any) -> Any:
+        """
+        Recursively sanitize data structure for JSON serialization.
+        Converts NaN, Inf, -Inf to None (null in JSON).
+
+        Args:
+            obj: Object to sanitize (dict, list, float, etc.)
+
+        Returns:
+            Sanitized object safe for JSON serialization
+        """
+        if isinstance(obj, dict):
+            return {k: JsonWriter.sanitize_for_json(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [JsonWriter.sanitize_for_json(item) for item in obj]
+        elif isinstance(obj, float):
+            # Check for NaN, Infinity, -Infinity
+            if math.isnan(obj) or math.isinf(obj):
+                return None  # Convert to null in JSON
+            return obj
+        else:
+            return obj
 
 
 def save_tiff2json(tiff_filepath, save_dirpath, start_index=None, end_index=None):

--- a/studio/app/common/dataclass/csv.py
+++ b/studio/app/common/dataclass/csv.py
@@ -9,6 +9,7 @@ from studio.app.common.core.utils.filepath_creater import (
 )
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.timeseries_chunk_handler import TimeSeriesChunkHandler
 from studio.app.common.schemas.outputs import PlotMetaData
 
 
@@ -38,7 +39,13 @@ class CsvData(BaseData):
         create_directory(self.json_path)
         JsonWriter.write_plot_meta(json_dir, self.file_name, self.meta)
 
-        for i, data in enumerate(self.data):
-            JsonWriter.write_as_split(
-                join_filepath([self.json_path, f"{str(i)}.json"]), data
-            )
+        # Prepare record data for chunked storage
+        record_ids = [str(i) for i in range(len(self.data))]
+        record_data = [pd.DataFrame(row) for row in self.data]
+
+        # Use TimeSeriesChunkHandler to save in chunked format
+        TimeSeriesChunkHandler.save_chunked_data(
+            dirpath=self.json_path,
+            record_ids=record_ids,
+            record_data=record_data,
+        )

--- a/studio/app/common/dataclass/csv.py
+++ b/studio/app/common/dataclass/csv.py
@@ -41,7 +41,8 @@ class CsvData(BaseData):
 
         # Prepare record data for chunked storage
         record_ids = [str(i) for i in range(len(self.data))]
-        record_data = [pd.DataFrame(row) for row in self.data]
+        # Create DataFrames with explicit "data" column name (similar to TimeSeriesData)
+        record_data = [pd.DataFrame({"data": row}) for row in self.data]
 
         # Use TimeSeriesChunkHandler to save in chunked format
         TimeSeriesChunkHandler.save_chunked_data(

--- a/studio/app/common/dataclass/timeseries.py
+++ b/studio/app/common/dataclass/timeseries.py
@@ -76,13 +76,9 @@ class TimeSeriesData(BaseData):
             data = self.data[i]
             if self.std is not None:
                 std = self.std[i]
-                df = pd.DataFrame(
-                    np.concatenate([data[:, np.newaxis], std[:, np.newaxis]], axis=1),
-                    index=self.index,
-                    columns=["data", "std"],
-                )
+                df = pd.DataFrame({"data": data, "std": std}, index=self.index)
             else:
-                df = pd.DataFrame(data, index=self.index, columns=["data"])
+                df = pd.DataFrame({"data": data}, index=self.index)
 
             record_data.append(df)
 

--- a/studio/app/common/dataclass/timeseries.py
+++ b/studio/app/common/dataclass/timeseries.py
@@ -10,6 +10,7 @@ from studio.app.common.core.utils.filepath_creater import (
 from studio.app.common.core.utils.json_writer import JsonWriter
 from studio.app.common.core.workflow.workflow import OutputPath, OutputType
 from studio.app.common.dataclass.base import BaseData
+from studio.app.common.dataclass.timeseries_chunk_handler import TimeSeriesChunkHandler
 from studio.app.common.schemas.outputs import PlotMetaData
 
 
@@ -66,7 +67,12 @@ class TimeSeriesData(BaseData):
         create_directory(self.json_path, delete_dir=True)
         JsonWriter.write_plot_meta(json_dir, self.file_name, self.meta)
 
+        # Prepare record data for chunked storage
+        record_ids = [str(cell_i) for cell_i in self.cell_numbers]
+        record_data = []
+
         for i, cell_i in enumerate(self.cell_numbers):
+            # Prepare data for this cell
             data = self.data[i]
             if self.std is not None:
                 std = self.std[i]
@@ -78,7 +84,14 @@ class TimeSeriesData(BaseData):
             else:
                 df = pd.DataFrame(data, index=self.index, columns=["data"])
 
-            JsonWriter.write(join_filepath([self.json_path, f"{str(cell_i)}.json"]), df)
+            record_data.append(df)
+
+        # Use TimeSeriesChunkHandler to save in chunked format
+        TimeSeriesChunkHandler.save_chunked_data(
+            dirpath=self.json_path,
+            record_ids=record_ids,
+            record_data=record_data,
+        )
 
     @property
     def output_path(self) -> OutputPath:

--- a/studio/app/common/dataclass/timeseries_chunk_handler.py
+++ b/studio/app/common/dataclass/timeseries_chunk_handler.py
@@ -66,7 +66,8 @@ class TimeSeriesChunkHandler:
             List of rows, where each row is a list of values
 
         Example:
-            Input: columns=["data", "std"], record_info={"data": [1, 2], "std": [0.1, 0.2]}
+            Input: columns=["data", "std"],
+              record_info={"data": [1, 2], "std": [0.1, 0.2]}
             Output: [[1, 0.1], [2, 0.2]]
         """
         if not columns:
@@ -126,16 +127,18 @@ class TimeSeriesChunkHandler:
 
             # Initialize chunk structure if new
             if chunk_id not in chunk_data:
-                # Store index and columns at chunk level (shared by all records in chunk)
+                # Store index and columns at chunk level
+                #  (shared by all records in chunk)
                 chunk_data[chunk_id] = {
                     "index": df.index.tolist(),
                     "columns": df.columns.tolist(),
-                    "records": {}
+                    "records": {},
                 }
 
             # Add only the data portion for this record (not index/columns)
             # Convert DataFrame columns to compact list format
-            # Example: if df has columns ["data", "std"], save as {"data": [v1, v2, ...], "std": [v1, v2, ...]}
+            # Example: if df has columns ["data", "std"],
+            #   save as {"data": [v1, v2, ...], "std": [v1, v2, ...]}
             record_data = {}
             for col in df.columns:
                 record_data[col] = df[col].tolist()
@@ -288,11 +291,7 @@ class TimeSeriesChunkHandler:
         record_info = chunk_data["records"][record_id]
         data_rows = cls._convert_columns_to_rows(columns, record_info)
 
-        return {
-            "index": chunk_data["index"],
-            "columns": columns,
-            "data": data_rows
-        }
+        return {"index": chunk_data["index"], "columns": columns, "data": data_rows}
 
     @classmethod
     def get_all_record_ids(cls, dirpath: str) -> List[str]:
@@ -379,7 +378,7 @@ class TimeSeriesChunkHandler:
                 all_records[record_id] = {
                     "index": chunk_data["index"],
                     "columns": columns,
-                    "data": data_rows
+                    "data": data_rows,
                 }
 
         return all_records

--- a/studio/app/common/dataclass/timeseries_chunk_handler.py
+++ b/studio/app/common/dataclass/timeseries_chunk_handler.py
@@ -117,26 +117,36 @@ class TimeSeriesChunkHandler:
             raise ValueError("record_ids and record_data must have same length")
 
         index_map = {}  # Maps record_id to chunk_id
-        chunk_data = {}  # Temporary storage: chunk_id -> {record_id -> data}
+        chunk_data = {}  # Temporary storage: chunk_id -> optimized chunk structure
 
         for i, (record_id, df) in enumerate(zip(record_ids, record_data)):
             chunk_id = i // cls.CHUNK_SIZE
             index_map[str(record_id)] = chunk_id
 
-            # Add to chunk
+            # Initialize chunk structure if new
             if chunk_id not in chunk_data:
-                chunk_data[chunk_id] = {}
-            chunk_data[chunk_id][str(record_id)] = df.to_dict(orient="split")
+                # Store index and columns at chunk level (shared by all records in chunk)
+                chunk_data[chunk_id] = {
+                    "index": df.index.tolist(),
+                    "columns": df.columns.tolist(),
+                    "records": {}
+                }
+
+            # Add only the data portion for this record (not index/columns)
+            df_dict = df.to_dict(orient="split")
+            chunk_data[chunk_id]["records"][str(record_id)] = {
+                "data": df_dict["data"]
+            }
 
         # Write chunk files
-        for chunk_id, records in chunk_data.items():
+        for chunk_id, chunk_content in chunk_data.items():
             chunk_filepath = join_filepath(
                 [dirpath, f"{cls.CHUNK_FILE_PREFIX}{chunk_id}.json"]
             )
             # Sanitize data to convert NaN/Inf to null for JSON compliance
-            sanitized_records = _sanitize_for_json(records)
+            sanitized_chunk = _sanitize_for_json(chunk_content)
             with open(chunk_filepath, "w") as f:
-                json.dump(sanitized_records, f, indent=4)
+                json.dump(sanitized_chunk, f, indent=4)
 
         # Write index mapping file
         index_map_path = join_filepath([dirpath, cls.INDEX_MAP_FILENAME])
@@ -180,7 +190,8 @@ class TimeSeriesChunkHandler:
             # Load chunk and map all records to this chunk_id
             with open(chunk_file, "r") as f:
                 chunk_data = json.load(f)
-                for record_id in chunk_data.keys():
+                # Optimized format: {"index": ..., "columns": ..., "records": {...}}
+                for record_id in chunk_data["records"].keys():
                     index_map[record_id] = chunk_id
 
         return index_map
@@ -262,10 +273,17 @@ class TimeSeriesChunkHandler:
             raise ValueError(f"Record ID '{record_id}' not found in index map")
 
         chunk_data = cls.load_chunk_file(dirpath, chunk_id)
-        record_data = chunk_data.get(record_id)
 
-        if record_data is None:
+        # Optimized format: {"index": ..., "columns": ..., "records": {...}}
+        if record_id not in chunk_data["records"]:
             raise ValueError(f"Record ID '{record_id}' not found in chunk {chunk_id}")
+
+        # Reconstruct split format for compatibility with existing code
+        record_data = {
+            "index": chunk_data["index"],
+            "columns": chunk_data["columns"],
+            "data": chunk_data["records"][record_id]["data"]
+        }
 
         return record_data
 
@@ -343,7 +361,15 @@ class TimeSeriesChunkHandler:
 
         for chunk_id in cls.get_all_chunks(dirpath):
             chunk_data = cls.load_chunk_file(dirpath, chunk_id)
-            all_records.update(chunk_data)
+
+            # Optimized format: {"index": ..., "columns": ..., "records": {...}}
+            for record_id, record_info in chunk_data["records"].items():
+                # Reconstruct split format for compatibility
+                all_records[record_id] = {
+                    "index": chunk_data["index"],
+                    "columns": chunk_data["columns"],
+                    "data": record_info["data"]
+                }
 
         return all_records
 

--- a/studio/app/common/dataclass/timeseries_chunk_handler.py
+++ b/studio/app/common/dataclass/timeseries_chunk_handler.py
@@ -1,0 +1,379 @@
+"""
+TimeSeriesChunkHandler: Centralized chunk management for timeseries/csv data.
+
+This module provides a unified interface for saving and loading timeseries data
+in chunked format, reducing the number of JSON files generated while maintaining
+compatibility with legacy single-file-per-record format.
+
+Design:
+- Writer: Groups multiple records into chunk files (chunk_0.json, chunk_1.json, ...)
+- Reader: Loads data from chunks with transparent format detection
+- Index mapping: Maintains record_id -> chunk_id mapping for efficient lookup
+
+Backward Compatibility:
+- Chunk size changes do NOT break existing data
+- Each chunk file and chunk_index_map.json are self-contained
+- Reading relies on chunk_index_map.json, not on CHUNK_SIZE constant
+- Old data (e.g., 100 records/chunk) coexists with new data (e.g., 200 records/chunk)
+"""
+
+import json
+import math
+import os
+from glob import glob
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from studio.app.common.core.utils.filepath_creater import join_filepath
+
+
+def _sanitize_for_json(obj: Any) -> Any:
+    """
+    Recursively sanitize data structure for JSON serialization.
+    Converts NaN, Inf, -Inf to None (null in JSON).
+
+    Args:
+        obj: Object to sanitize (dict, list, float, etc.)
+
+    Returns:
+        Sanitized object safe for JSON serialization
+    """
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_sanitize_for_json(item) for item in obj]
+    elif isinstance(obj, float):
+        # Check for NaN, Infinity, -Infinity
+        if math.isnan(obj) or math.isinf(obj):
+            return None  # Convert to null in JSON
+        return obj
+    else:
+        return obj
+
+
+class TimeSeriesChunkHandler:
+    """
+    Handles reading and writing of timeseries data in chunked format.
+
+    File structure:
+        timeseries/
+          ├── chunk_0.json      # Records 0-99 (when CHUNK_SIZE=100)
+          ├── chunk_1.json      # Records 100-199
+          ├── ...
+          └── chunk_index_map.json    # Record ID -> Chunk ID mapping
+
+    Configuration:
+        CHUNK_SIZE: Number of records per chunk file (default: 100)
+                    Can be changed without breaking existing data.
+    """
+
+    # Chunk configuration
+    # Adjust this value to change how many records are saved per chunk file.
+    # Note: Changing this value only affects NEW data; existing data remains readable.
+    CHUNK_SIZE = 100
+
+    # File naming constants
+    INDEX_MAP_FILENAME = "chunk_index_map.json"
+    CHUNK_FILE_PREFIX = "chunk_"
+
+    @classmethod
+    def is_chunked_format(cls, dirpath: str) -> bool:
+        """
+        Check if the directory uses chunked JSON format.
+
+        Args:
+            dirpath: Directory path to check
+
+        Returns:
+            True if chunked format (chunk_index_map.json exists or chunk files exist)
+        """
+        # Check for index map file
+        index_map_path = join_filepath([dirpath, cls.INDEX_MAP_FILENAME])
+        if os.path.exists(index_map_path):
+            return True
+
+        # Check for chunk files (auto-recovery case)
+        chunk_pattern = join_filepath([dirpath, f"{cls.CHUNK_FILE_PREFIX}*.json"])
+        chunk_files = glob(chunk_pattern)
+        return len(chunk_files) > 0
+
+    @classmethod
+    def save_chunked_data(
+        cls,
+        dirpath: str,
+        record_ids: List[str],
+        record_data: List[pd.DataFrame],
+    ) -> None:
+        """
+        Save timeseries data in chunked format.
+
+        Args:
+            dirpath: Directory to save chunk files
+            record_ids: List of record identifiers (e.g., cell numbers, row indices)
+            record_data: List of DataFrames, one per record
+        """
+        if len(record_ids) != len(record_data):
+            raise ValueError("record_ids and record_data must have same length")
+
+        index_map = {}  # Maps record_id to chunk_id
+        chunk_data = {}  # Temporary storage: chunk_id -> {record_id -> data}
+
+        for i, (record_id, df) in enumerate(zip(record_ids, record_data)):
+            chunk_id = i // cls.CHUNK_SIZE
+            index_map[str(record_id)] = chunk_id
+
+            # Add to chunk
+            if chunk_id not in chunk_data:
+                chunk_data[chunk_id] = {}
+            chunk_data[chunk_id][str(record_id)] = df.to_dict(orient="split")
+
+        # Write chunk files
+        for chunk_id, records in chunk_data.items():
+            chunk_filepath = join_filepath(
+                [dirpath, f"{cls.CHUNK_FILE_PREFIX}{chunk_id}.json"]
+            )
+            # Sanitize data to convert NaN/Inf to null for JSON compliance
+            sanitized_records = _sanitize_for_json(records)
+            with open(chunk_filepath, "w") as f:
+                json.dump(sanitized_records, f, indent=4)
+
+        # Write index mapping file
+        index_map_path = join_filepath([dirpath, cls.INDEX_MAP_FILENAME])
+        with open(index_map_path, "w") as f:
+            json.dump(index_map, f, indent=4)
+
+    @classmethod
+    def rebuild_index_map(cls, dirpath: str) -> Dict[str, int]:
+        """
+        Rebuild index map by scanning all chunk files.
+
+        This is useful for:
+        - Recovery when chunk_index_map.json is accidentally deleted
+        - Validation/debugging of data integrity
+        - Migration from old formats
+
+        Args:
+            dirpath: Directory containing chunk files
+
+        Returns:
+            Dictionary mapping record_id (str) to chunk_id (int)
+        """
+        index_map = {}
+
+        # Find all chunk files
+        chunk_pattern = join_filepath([dirpath, f"{cls.CHUNK_FILE_PREFIX}*.json"])
+        chunk_files = glob(chunk_pattern)
+
+        for chunk_file in chunk_files:
+            # Extract chunk_id from filename (e.g., "chunk_0.json" -> 0)
+            filename = os.path.basename(chunk_file)
+            # Remove file extension (.json)
+            filename_without_ext = os.path.splitext(filename)[0]
+            # Remove chunk prefix (e.g., "chunk_0" -> "0")
+            chunk_id_str = filename_without_ext[len(cls.CHUNK_FILE_PREFIX) :]
+            try:
+                chunk_id = int(chunk_id_str)
+            except ValueError:
+                continue  # Skip non-numeric chunk files
+
+            # Load chunk and map all records to this chunk_id
+            with open(chunk_file, "r") as f:
+                chunk_data = json.load(f)
+                for record_id in chunk_data.keys():
+                    index_map[record_id] = chunk_id
+
+        return index_map
+
+    @classmethod
+    def load_index_map(cls, dirpath: str, auto_rebuild: bool = True) -> Dict[str, int]:
+        """
+        Load the index mapping file.
+
+        Args:
+            dirpath: Directory containing chunk_index_map.json
+            auto_rebuild: If True, automatically rebuild index map if missing
+
+        Returns:
+            Dictionary mapping record_id (str) to chunk_id (int)
+
+        Raises:
+            FileNotFoundError: If index map doesn't exist and auto_rebuild is False
+        """
+        index_map_path = join_filepath([dirpath, cls.INDEX_MAP_FILENAME])
+
+        # Try to load existing index map
+        if os.path.exists(index_map_path):
+            with open(index_map_path, "r") as f:
+                return json.load(f)
+
+        # Auto-rebuild if enabled
+        if auto_rebuild:
+            index_map = cls.rebuild_index_map(dirpath)
+
+            # Save the rebuilt index map for future use
+            if index_map:
+                with open(index_map_path, "w") as f:
+                    json.dump(index_map, f, indent=4)
+
+            return index_map
+
+        # Raise error if auto_rebuild is disabled
+        raise FileNotFoundError(
+            f"Index map file not found: {index_map_path}. "
+            f"Set auto_rebuild=True to automatically rebuild from chunk files."
+        )
+
+    @classmethod
+    def load_chunk_file(cls, dirpath: str, chunk_id: int) -> Dict[str, dict]:
+        """
+        Load a specific chunk file.
+
+        Args:
+            dirpath: Directory containing chunk files
+            chunk_id: Chunk ID to load
+
+        Returns:
+            Dictionary mapping record_id to record data (in split format)
+        """
+        chunk_path = join_filepath([dirpath, f"{cls.CHUNK_FILE_PREFIX}{chunk_id}.json"])
+        with open(chunk_path, "r") as f:
+            return json.load(f)
+
+    @classmethod
+    def get_record_data(cls, dirpath: str, record_id: str) -> dict:
+        """
+        Get data for a specific record from chunked storage.
+
+        Args:
+            dirpath: Directory containing chunk files
+            record_id: Record identifier to retrieve
+
+        Returns:
+            Record data in split format (dict with 'data', 'index', 'columns')
+
+        Raises:
+            ValueError: If record_id not found in index map
+        """
+        index_map = cls.load_index_map(dirpath)
+        chunk_id = index_map.get(record_id)
+
+        if chunk_id is None:
+            raise ValueError(f"Record ID '{record_id}' not found in index map")
+
+        chunk_data = cls.load_chunk_file(dirpath, chunk_id)
+        record_data = chunk_data.get(record_id)
+
+        if record_data is None:
+            raise ValueError(f"Record ID '{record_id}' not found in chunk {chunk_id}")
+
+        return record_data
+
+    @classmethod
+    def get_all_record_ids(cls, dirpath: str) -> List[str]:
+        """
+        Get all record IDs from the directory.
+
+        Supports both chunked and legacy formats.
+
+        Args:
+            dirpath: Directory to scan
+
+        Returns:
+            Sorted list of record IDs (as strings)
+        """
+        if cls.is_chunked_format(dirpath):
+            # Chunked format: read from index map
+            index_map = cls.load_index_map(dirpath)
+            # Sort numerically if possible, otherwise alphabetically
+            return sorted(index_map.keys(), key=lambda x: int(x) if x.isdigit() else x)
+        else:
+            # Legacy format: scan for individual JSON files
+            file_pattern = join_filepath([dirpath, "*.json"])
+            filenames = glob(file_pattern)
+
+            # Filter out metadata files
+            record_ids = []
+            metadata_files = [
+                cls.INDEX_MAP_FILENAME,  # chunk_index_map.json
+                "plot-meta.json",
+            ]
+            for filepath in filenames:
+                filename = os.path.basename(filepath)
+                # Skip metadata files
+                if filename in metadata_files:
+                    continue
+                # Extract record ID from filename
+                record_id = os.path.splitext(filename)[0]
+                record_ids.append(record_id)
+
+            # Sort numerically if possible
+            return sorted(record_ids, key=lambda x: int(x) if x.isdigit() else x)
+
+    @classmethod
+    def get_all_chunks(cls, dirpath: str) -> List[int]:
+        """
+        Get all chunk IDs in the directory.
+
+        Args:
+            dirpath: Directory containing chunk files
+
+        Returns:
+            Sorted list of chunk IDs
+        """
+        if not cls.is_chunked_format(dirpath):
+            return []
+
+        index_map = cls.load_index_map(dirpath)
+        chunk_ids = set(index_map.values())
+        return sorted(chunk_ids)
+
+    @classmethod
+    def load_all_records(cls, dirpath: str) -> Dict[str, dict]:
+        """
+        Load all records from chunked storage.
+
+        Args:
+            dirpath: Directory containing chunk files
+
+        Returns:
+            Dictionary mapping record_id to record data
+        """
+        all_records = {}
+
+        for chunk_id in cls.get_all_chunks(dirpath):
+            chunk_data = cls.load_chunk_file(dirpath, chunk_id)
+            all_records.update(chunk_data)
+
+        return all_records
+
+    @classmethod
+    def get_chunk_stats(cls, dirpath: str) -> Dict[str, int]:
+        """
+        Get statistics about chunked data.
+
+        Args:
+            dirpath: Directory containing chunk files
+
+        Returns:
+            Dictionary with 'total_records', 'num_chunks', 'chunk_size'
+        """
+        if not cls.is_chunked_format(dirpath):
+            # Legacy format
+            record_ids = cls.get_all_record_ids(dirpath)
+            return {
+                "total_records": len(record_ids),
+                "num_chunks": len(record_ids),  # Each file is a "chunk"
+                "chunk_size": 1,
+                "format": "legacy",
+            }
+
+        index_map = cls.load_index_map(dirpath)
+        chunk_ids = set(index_map.values())
+
+        return {
+            "total_records": len(index_map),
+            "num_chunks": len(chunk_ids),
+            "chunk_size": cls.CHUNK_SIZE,
+            "format": "chunked",
+        }

--- a/studio/app/common/dataclass/timeseries_chunk_handler.py
+++ b/studio/app/common/dataclass/timeseries_chunk_handler.py
@@ -18,38 +18,14 @@ Backward Compatibility:
 """
 
 import json
-import math
 import os
 from glob import glob
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import pandas as pd
 
 from studio.app.common.core.utils.filepath_creater import join_filepath
-
-
-def _sanitize_for_json(obj: Any) -> Any:
-    """
-    Recursively sanitize data structure for JSON serialization.
-    Converts NaN, Inf, -Inf to None (null in JSON).
-
-    Args:
-        obj: Object to sanitize (dict, list, float, etc.)
-
-    Returns:
-        Sanitized object safe for JSON serialization
-    """
-    if isinstance(obj, dict):
-        return {k: _sanitize_for_json(v) for k, v in obj.items()}
-    elif isinstance(obj, list):
-        return [_sanitize_for_json(item) for item in obj]
-    elif isinstance(obj, float):
-        # Check for NaN, Infinity, -Infinity
-        if math.isnan(obj) or math.isinf(obj):
-            return None  # Convert to null in JSON
-        return obj
-    else:
-        return obj
+from studio.app.common.core.utils.json_writer import JsonWriter
 
 
 class TimeSeriesChunkHandler:
@@ -76,6 +52,31 @@ class TimeSeriesChunkHandler:
     # File naming constants
     INDEX_MAP_FILENAME = "chunk_index_map.json"
     CHUNK_FILE_PREFIX = "chunk_"
+
+    @staticmethod
+    def _convert_columns_to_rows(columns: List[str], record_info: dict) -> List[List]:
+        """
+        Convert column-wise data to row-wise data for split format.
+
+        Args:
+            columns: List of column names
+            record_info: Dict mapping column names to lists of values
+
+        Returns:
+            List of rows, where each row is a list of values
+
+        Example:
+            Input: columns=["data", "std"], record_info={"data": [1, 2], "std": [0.1, 0.2]}
+            Output: [[1, 0.1], [2, 0.2]]
+        """
+        if not columns:
+            return []
+
+        num_rows = len(record_info[columns[0]])
+        return [
+            [record_info[col][row_idx] for col in columns]
+            for row_idx in range(num_rows)
+        ]
 
     @classmethod
     def is_chunked_format(cls, dirpath: str) -> bool:
@@ -133,10 +134,13 @@ class TimeSeriesChunkHandler:
                 }
 
             # Add only the data portion for this record (not index/columns)
-            df_dict = df.to_dict(orient="split")
-            chunk_data[chunk_id]["records"][str(record_id)] = {
-                "data": df_dict["data"]
-            }
+            # Convert DataFrame columns to compact list format
+            # Example: if df has columns ["data", "std"], save as {"data": [v1, v2, ...], "std": [v1, v2, ...]}
+            record_data = {}
+            for col in df.columns:
+                record_data[col] = df[col].tolist()
+
+            chunk_data[chunk_id]["records"][str(record_id)] = record_data
 
         # Write chunk files
         for chunk_id, chunk_content in chunk_data.items():
@@ -144,7 +148,7 @@ class TimeSeriesChunkHandler:
                 [dirpath, f"{cls.CHUNK_FILE_PREFIX}{chunk_id}.json"]
             )
             # Sanitize data to convert NaN/Inf to null for JSON compliance
-            sanitized_chunk = _sanitize_for_json(chunk_content)
+            sanitized_chunk = JsonWriter.sanitize_for_json(chunk_content)
             with open(chunk_filepath, "w") as f:
                 json.dump(sanitized_chunk, f, indent=4)
 
@@ -279,13 +283,16 @@ class TimeSeriesChunkHandler:
             raise ValueError(f"Record ID '{record_id}' not found in chunk {chunk_id}")
 
         # Reconstruct split format for compatibility with existing code
-        record_data = {
-            "index": chunk_data["index"],
-            "columns": chunk_data["columns"],
-            "data": chunk_data["records"][record_id]["data"]
-        }
+        # Convert from column-wise lists back to row-wise lists
+        columns = chunk_data["columns"]
+        record_info = chunk_data["records"][record_id]
+        data_rows = cls._convert_columns_to_rows(columns, record_info)
 
-        return record_data
+        return {
+            "index": chunk_data["index"],
+            "columns": columns,
+            "data": data_rows
+        }
 
     @classmethod
     def get_all_record_ids(cls, dirpath: str) -> List[str]:
@@ -363,12 +370,16 @@ class TimeSeriesChunkHandler:
             chunk_data = cls.load_chunk_file(dirpath, chunk_id)
 
             # Optimized format: {"index": ..., "columns": ..., "records": {...}}
+            columns = chunk_data["columns"]
             for record_id, record_info in chunk_data["records"].items():
                 # Reconstruct split format for compatibility
+                # Convert from column-wise lists back to row-wise lists
+                data_rows = cls._convert_columns_to_rows(columns, record_info)
+
                 all_records[record_id] = {
                     "index": chunk_data["index"],
-                    "columns": chunk_data["columns"],
-                    "data": record_info["data"]
+                    "columns": columns,
+                    "data": data_rows
                 }
 
         return all_records

--- a/studio/app/common/dataclass/timeseries_chunk_handler.py
+++ b/studio/app/common/dataclass/timeseries_chunk_handler.py
@@ -139,11 +139,11 @@ class TimeSeriesChunkHandler:
             # Convert DataFrame columns to compact list format
             # Example: if df has columns ["data", "std"],
             #   save as {"data": [v1, v2, ...], "std": [v1, v2, ...]}
-            record_data = {}
+            record_col_data = {}
             for col in df.columns:
-                record_data[col] = df[col].tolist()
+                record_col_data[col] = df[col].tolist()
 
-            chunk_data[chunk_id]["records"][str(record_id)] = record_data
+            chunk_data[chunk_id]["records"][str(record_id)] = record_col_data
 
         # Write chunk files
         for chunk_id, chunk_content in chunk_data.items():

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -1,5 +1,4 @@
 import os
-from glob import glob
 from typing import Optional
 
 import pandas as pd
@@ -11,6 +10,7 @@ from studio.app.common.core.utils.filepath_creater import (
     join_filepath,
 )
 from studio.app.common.core.utils.json_writer import JsonWriter, save_tiff2json
+from studio.app.common.dataclass.timeseries_chunk_handler import TimeSeriesChunkHandler
 from studio.app.common.schemas.outputs import JsonTimeSeriesData, OutputData
 from studio.app.const import ACCEPT_FILE_EXT, ORIGINAL_DATA_EXT
 from studio.app.dir_path import DIRPATH
@@ -39,12 +39,8 @@ async def get_inittimedata(
     if isFull and os.path.exists(full_json_dirpath):
         dirpath = full_json_dirpath
 
-    file_numbers = sorted(
-        [
-            os.path.splitext(os.path.basename(x))[0]
-            for x in glob(join_filepath([dirpath, "*.json"]))
-        ]
-    )
+    # Get all cell indices (supports both chunked and legacy formats)
+    file_numbers = TimeSeriesChunkHandler.get_all_record_ids(dirpath)
 
     # Handle empty case
     if not file_numbers:
@@ -52,13 +48,24 @@ async def get_inittimedata(
         return_data.meta = {"title": "0 ROIs found"}  # Set informative message
         return return_data
 
-    # Rest of the function remains the same
+    # Get first cell data
     index = file_numbers[0]
     str_index = str(index)
 
-    json_data = JsonReader.read_as_timeseries(
-        join_filepath([dirpath, f"{str(index)}.json"])
-    )
+    # Load data based on format
+    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
+        # Chunked format
+        cell_data = TimeSeriesChunkHandler.get_record_data(dirpath, str_index)
+        # Convert from split format to timeseries format
+        df = pd.DataFrame(
+            cell_data["data"], index=cell_data["index"], columns=cell_data["columns"]
+        )
+        json_data = JsonReader.read_as_timeseries_from_df(df)
+    else:
+        # Legacy format
+        json_data = JsonReader.read_as_timeseries(
+            join_filepath([dirpath, f"{str_index}.json"])
+        )
 
     data = {
         str(i): {json_data.xrange[0]: json_data.data[json_data.xrange[0]]}
@@ -94,13 +101,25 @@ async def get_timedata(
     if isFull and os.path.exists(full_json_dirpath):
         dirpath = full_json_dirpath
 
-    json_data = JsonReader.read_as_timeseries(
-        join_filepath([dirpath, f"{str(index)}.json"])
-    )
+    str_index = str(index)
+
+    # Load data based on format
+    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
+        # Chunked format
+        cell_data = TimeSeriesChunkHandler.get_record_data(dirpath, str_index)
+        # Convert from split format to timeseries format
+        df = pd.DataFrame(
+            cell_data["data"], index=cell_data["index"], columns=cell_data["columns"]
+        )
+        json_data = JsonReader.read_as_timeseries_from_df(df)
+    else:
+        # Legacy format
+        json_data = JsonReader.read_as_timeseries(
+            join_filepath([dirpath, f"{str_index}.json"])
+        )
 
     return_data = get_initial_timeseries_data(dirpath)
 
-    str_index = str(index)
     return_data.data[str_index] = json_data.data
     if json_data.std is not None:
         return_data.std[str_index] = json_data.std
@@ -112,15 +131,49 @@ async def get_timedata(
 async def get_alltimedata(dirpath: str):
     return_data = get_initial_timeseries_data(dirpath)
 
-    for i, path in enumerate(glob(join_filepath([dirpath, "*.json"]))):
-        str_idx = str(os.path.splitext(os.path.basename(path))[0])
-        json_data = JsonReader.read_as_timeseries(path)
-        if i == 0:
-            return_data.xrange = json_data.xrange
+    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
+        # Chunked format: load all chunks
+        all_records = TimeSeriesChunkHandler.load_all_records(dirpath)
 
-        return_data.data[str_idx] = json_data.data
-        if json_data.std is not None:
-            return_data.std[str_idx] = json_data.std
+        for cell_index, cell_data in all_records.items():
+            # Convert from split format to timeseries format
+            df = pd.DataFrame(
+                cell_data["data"],
+                index=cell_data["index"],
+                columns=cell_data["columns"],
+            )
+            json_data = JsonReader.read_as_timeseries_from_df(df)
+
+            if not return_data.xrange:
+                return_data.xrange = json_data.xrange
+
+            return_data.data[cell_index] = json_data.data
+            if json_data.std is not None:
+                if not return_data.std:
+                    return_data.std = {}
+                return_data.std[cell_index] = json_data.std
+    else:
+        # Legacy format: individual files
+        from glob import glob
+
+        metadata_files = [
+            TimeSeriesChunkHandler.INDEX_MAP_FILENAME,  # chunk_index_map.json
+            f"{os.path.basename(dirpath)}.plot-meta.json",
+        ]
+        for i, path in enumerate(glob(join_filepath([dirpath, "*.json"]))):
+            filename = os.path.basename(path)
+            # Skip metadata files
+            if filename in metadata_files:
+                continue
+
+            str_idx = str(os.path.splitext(filename)[0])
+            json_data = JsonReader.read_as_timeseries(path)
+            if i == 0:
+                return_data.xrange = json_data.xrange
+
+            return_data.data[str_idx] = json_data.data
+            if json_data.std is not None:
+                return_data.std[str_idx] = json_data.std
 
     return return_data
 

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -30,6 +30,32 @@ def get_initial_timeseries_data(dirpath) -> JsonTimeSeriesData:
     )
 
 
+def _load_timeseries_record(dirpath: str, record_id: str) -> JsonTimeSeriesData:
+    """
+    Load a single timeseries record from either chunked or legacy format.
+
+    Args:
+        dirpath: Directory containing the timeseries data
+        record_id: Record identifier (as string)
+
+    Returns:
+        JsonTimeSeriesData for the specified record
+    """
+    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
+        # Chunked format
+        cell_data = TimeSeriesChunkHandler.get_record_data(dirpath, record_id)
+        # Convert from split format to DataFrame
+        df = pd.DataFrame(
+            cell_data["data"], index=cell_data["index"], columns=cell_data["columns"]
+        )
+        return JsonReader.read_as_timeseries_from_df(df)
+    else:
+        # Legacy format
+        return JsonReader.read_as_timeseries(
+            join_filepath([dirpath, f"{record_id}.json"])
+        )
+
+
 @router.get("/inittimedata/{dirpath:path}", response_model=JsonTimeSeriesData)
 async def get_inittimedata(
     dirpath: str,
@@ -52,20 +78,8 @@ async def get_inittimedata(
     index = file_numbers[0]
     str_index = str(index)
 
-    # Load data based on format
-    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
-        # Chunked format
-        cell_data = TimeSeriesChunkHandler.get_record_data(dirpath, str_index)
-        # Convert from split format to timeseries format
-        df = pd.DataFrame(
-            cell_data["data"], index=cell_data["index"], columns=cell_data["columns"]
-        )
-        json_data = JsonReader.read_as_timeseries_from_df(df)
-    else:
-        # Legacy format
-        json_data = JsonReader.read_as_timeseries(
-            join_filepath([dirpath, f"{str_index}.json"])
-        )
+    # Load first record using common helper
+    json_data = _load_timeseries_record(dirpath, str_index)
 
     data = {
         str(i): {json_data.xrange[0]: json_data.data[json_data.xrange[0]]}
@@ -103,20 +117,8 @@ async def get_timedata(
 
     str_index = str(index)
 
-    # Load data based on format
-    if TimeSeriesChunkHandler.is_chunked_format(dirpath):
-        # Chunked format
-        cell_data = TimeSeriesChunkHandler.get_record_data(dirpath, str_index)
-        # Convert from split format to timeseries format
-        df = pd.DataFrame(
-            cell_data["data"], index=cell_data["index"], columns=cell_data["columns"]
-        )
-        json_data = JsonReader.read_as_timeseries_from_df(df)
-    else:
-        # Legacy format
-        json_data = JsonReader.read_as_timeseries(
-            join_filepath([dirpath, f"{str_index}.json"])
-        )
+    # Load record using common helper
+    json_data = _load_timeseries_record(dirpath, str_index)
 
     return_data = get_initial_timeseries_data(dirpath)
 


### PR DESCRIPTION
## Summary

現行のコードでは、Workflow実行時のCSV/TimeSeriesデータ保存時に、多数のファイル（JSON形式）が生成される仕様となっていた

このPRでは、データファイルのバックアップ（S3などへの）などを効率化する目的から、上記生成ファイル数の削減・最適化を実施している

## Contents

### 修正以前の課題

#### 1. ファイル数の急激な増加によるバックアップ性能問題
- **問題**: CSV/TimeSeriesデータの保存時に、1レコード = 1 JSONファイルの形式で出力していた
- **影響**:
  - 10,000レコードのデータで10,000個のJSONファイルが生成される
  - S3などのリモートストレージへのバックアップ時に、小さなファイルの大量アップロードにより無用な負荷が発生
  - ファイルシステムのinode枯渇リスク

### 対応内容

#### 1. Chunk形式による保存方式の導入

**新規ファイル**: `studio/app/common/dataclass/timeseries_chunk_handler.py`
- 複数レコードを1つのChunkファイルにまとめて保存（デフォルト: 100レコード/Chunk）
- Chunk内で`index`と`columns`を1回だけ保存し、冗長性を排除

**ファイル構造例**:
```json
{
  "index": [0, 1, 2, ...],
  "columns": ["data", "std"],
  "records": {
    "0": {"data": [v1, v2, ...], "std": [v1, v2, ...]},
    "1": {"data": [v1, v2, ...], "std": [v1, v2, ...]},
    ...
  }
}
```

**インデックスマッピング**: `chunk_index_map.json`
- レコードIDからChunk IDへの高速マッピング
- 欠損時の自動リビルド機能（`rebuild_index_map()`）

#### 2. 既存コードのカスタマイズ（Chunk Handler の適用）

**変更ファイル**:
- `studio/app/common/dataclass/(csv|timeseries).py`: Chunk Handler を使用するように変更
- `studio/app/common/routers/outputs.py`: Chunk形式からのデータ読み込みに対応

#### 3. 後方互換性の維持

**レガシー形式のサポート**:
- 既存の1ファイル/レコード形式のデータも引き続き読み込み可能
- `TimeSeriesChunkHandler.is_chunked_format()` による自動判定
- フロントエンドのオンデマンドローディング機能は維持

### 修正による効果

この修正適用の前後で、以下のようにファイル数削減の効果が得られている

- Tutorial 1 … 2,384 → 65 (**98%削減**)
- Tutorial 2 … ※元より入出力のファイル数が少ないため省略
- Tutorial 3 … 2,124 → 65 (**97%削減**)
- Tutorial 4 … 641 → 53 (**92%削減**)

## Test case

### 単体テスト

- [x] 1. ファイル数削減の検証
  - **条件**: 2,000レコードのTimeSeriesデータを保存
  - **期待結果**:
    - **修正前**: 2,000個のJSONファイル
    - **修正後**: 21個のファイル（100 Chunk + 1インデックスマップ）
    - **期待結果**: ファイル数が約99%削減

- [x] 2. データ読み込みの互換性検証
  - **条件**:
    1. 新フォーマット（Chunk形式）のデータをoutputs APIで取得
    2. レガシーフォーマット（1ファイル/レコード）のデータをoutputs APIで取得
  - **期待結果**:
    - 両方とも同じJSON応答形式でフロントエンドに返却される
    - グラフ表示が正常に動作する
    - NaN/Inf値が`null`として正しく処理される

- [x] 3. 自動リカバリー機能の検証
  - **条件**: `chunk_index_map.json`を削除
  - **期待結果**:
    - Chunkファイルから自動的にインデックスマップを再構築
    - データ読み込みが正常に継続できる

### 統合テスト

- [x] 1. 新フォーマット（Chunk形式）の生成検証
  - [x] Tutorial 1
    - Input data
      - behavior csv の chunked json file が 生成されている（※件数は修正前から2,000→20件へ削減）
    - Output data
      - suite2p_roi の fluorescence の chunked json file が 生成されている（※件数は修正前から295→3件へ削減）
  - [x] Tutorial 4
    - Input data
      - behavior csv の chunked json file が 生成されている（※件数は修正前から500→5件へ削減）
    - Output data
      - suite2p_roi の fluorescence の chunked json file が 生成されている（※件数は修正前から96→1件へ削減）

- [x] 2. 新フォーマットの output の表示検証
  - ※各outputのplotが、エラーなく表示されること
  - ※Visualize画面で確認
  - [x] Tutorial 1
    - suite2p_roi > fluorescence
    - eta > mean
  - [x] Tutorial 2
    - caiman_cnmf > fluorescence
  - [x] Tutorial 3
    - lccd_cell_detection > dff
    - lccd_cell_detection > fluorescence
  - [x] Tutorial 4
    - suite2p_roi > fluorescence

- [x] 3. 旧フォーマットの output との比較検証
  - ※新旧フォーマット間で、完全に同一のplotが再現されること
  - ※Visualize画面で確認
  - [x] Tutorial 1
    - suite2p_roi > fluorescence
    - eta > mean
  - [x] Tutorial 2
    - caiman_cnmf > fluorescence
  - [x] Tutorial 3
    - lccd_cell_detection > dff
    - lccd_cell_detection > fluorescence
  - [x] Tutorial 4
    - suite2p_roi > fluorescence

## 補足

### もし不具合があった場合の影響

この修正により、不具合が潜在した場合でも（新TimeSeries jsonフォーマットの read エラー、など）、影響は限定的であると想定される
- 事由:
  - TimeSeriesのjson fileは、基本的には frontend での outputs の plot の用途に用いられている
    - 問題があった場合は、plot で error が発生する（表示のみの問題）
  - Workflow の実行には影響がない（実行時には参照されない）データとなっている