### PR TITLE
Standardise logging levels

### DIFF
--- a/studio/app/common/core/auth/__init__.py
+++ b/studio/app/common/core/auth/__init__.py
@@ -1,10 +1,12 @@
 import json
-import logging
 
 import pyrebase
 
+from studio.app.common.core.logger import AppLogger
 from studio.app.common.core.mode import MODE
 from studio.app.dir_path import DIRPATH
+
+logger = AppLogger.get_logger()
 
 try:
     pyrebase_app = pyrebase.initialize_app(
@@ -14,8 +16,8 @@ except FileNotFoundError as e:
     if MODE.IS_STANDALONE:
         pyrebase_app = None
     else:
-        logging.getLogger().error("Firebase config file not found.")
+        logger.error("Firebase config file not found.")
         raise e
 except Exception as e:
-    logging.getLogger().error(e)
+    logger.error(e)
     raise e

--- a/studio/app/common/core/auth/auth.py
+++ b/studio/app/common/core/auth/auth.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from typing import Tuple
 
 from fastapi import HTTPException, status
@@ -15,9 +14,12 @@ from studio.app.common.core.auth.security import (
     create_refresh_token,
     validate_refresh_token,
 )
+from studio.app.common.core.logger import AppLogger
 from studio.app.common.models.user import User as UserModel
 from studio.app.common.schemas.auth import AccessToken, Token, UserAuth
 from studio.app.common.schemas.users import User
+
+logger = AppLogger.get_logger()
 
 
 async def authenticate_user(db: Session, data: UserAuth) -> Tuple[Token, UserModel]:
@@ -42,11 +44,11 @@ async def authenticate_user(db: Session, data: UserAuth) -> Tuple[Token, UserMod
         return token, user_db
 
     except (HTTPError, AssertionError) as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.error(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
         )
@@ -61,7 +63,7 @@ async def refresh_current_user_token(refresh_token: str):
         user = pyrebase_app.auth().refresh(refresh_token=token["sub"])
         return AccessToken(access_token=user["idToken"])
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
 
 
@@ -73,14 +75,14 @@ async def send_reset_password_mail(db: Session, email: str):
         pyrebase_app.auth().send_password_reset_email(email)
         return JSONResponse(content=None, status_code=status.HTTP_200_OK)
     except HTTPError as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         err = json.loads(e.strerror)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=err.get("error").get("message"),
         )
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.error(e)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
@@ -108,11 +110,11 @@ async def login_with_uid(db: Session, uid: str, current_user: User) -> Token:
         return token
 
     except (HTTPError, AssertionError) as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.error(e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
         )

--- a/studio/app/common/core/auth/auth_dependencies.py
+++ b/studio/app/common/core/auth/auth_dependencies.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 import sqlalchemy
@@ -14,12 +13,15 @@ from studio.app.common.core.auth.auth_helper import (
     extract_uid_from_firebase_credential,
     extract_uid_from_jwt_token,
 )
+from studio.app.common.core.logger import AppLogger
 from studio.app.common.db.database import get_db
 from studio.app.common.models import User as UserModel
 from studio.app.common.models import UserRole as UserRoleModel
 from studio.app.common.models.experiment import ExperimentRecord
 from studio.app.common.models.workspace import Workspace
 from studio.app.common.schemas.users import User
+
+logger = AppLogger.get_logger()
 
 
 async def get_current_user(
@@ -54,10 +56,10 @@ async def get_current_user(
         return User.from_orm(authed_user)
 
     except ValidationError as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         raise HTTPException(status_code=422, detail=f"Validator Error: {e}")
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             headers={"WWW-Authenticate": 'Bearer realm="auth_required"'},

--- a/studio/app/common/core/auth/security.py
+++ b/studio/app/common/core/auth/security.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -6,6 +5,9 @@ from jose import ExpiredSignatureError, JWTError, jwt
 from pydantic import ValidationError
 
 from studio.app.common.core.auth.auth_config import AUTH_CONFIG
+from studio.app.common.core.logger import AppLogger
+
+logger = AppLogger.get_logger()
 
 
 def _create_token(
@@ -71,13 +73,13 @@ def _validate_token(
         if payload.get("token_type") != token_type:
             err = "Invalid token type"
     except ExpiredSignatureError as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         err = "Credentials has expired"
     except (JWTError, ValidationError) as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         err = "Could not validate credentials"
     except Exception as e:
-        logging.getLogger().error(e)
+        logger.warning(e)
         err = "Bad token"
 
     return payload, err

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -138,7 +138,7 @@ class ExptConfigReader:
                 return None
             return WorkflowRunStatus(config.success)
         except (ValueError, AssertionError, yaml.YAMLError) as e:
-            logger.debug(
+            logger.warning(
                 f"experiment config read error: [{workspace_id}/{unique_id}] {e}"
             )
             return None

--- a/studio/app/common/core/experiment/experiment_reader.py
+++ b/studio/app/common/core/experiment/experiment_reader.py
@@ -138,7 +138,7 @@ class ExptConfigReader:
                 return None
             return WorkflowRunStatus(config.success)
         except (ValueError, AssertionError, yaml.YAMLError) as e:
-            logger.warning(
+            logger.debug(
                 f"experiment config read error: [{workspace_id}/{unique_id}] {e}"
             )
             return None

--- a/studio/app/common/core/experiment/experiment_record_services.py
+++ b/studio/app/common/core/experiment/experiment_record_services.py
@@ -91,6 +91,6 @@ class ExperimentRecordService:
 
         except NoResultFound:
             # If it fails roll back the transaction
-            logger.error(
+            logger.warning(
                 f"Experiment {unique_id} not found in workspace {workspace_id}"
             )

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -202,7 +202,7 @@ class Runner:
             if function_id not in output_info["nwbfile"][NWBDATASET.CONFIG]:
                 output_info["nwbfile"][NWBDATASET.CONFIG][function_id] = {}
         except Exception as e:
-            logger.warning(f"Failed to initialize CONFIG dataset for{function_id}:{e}")
+            logger.debug(f"Failed to initialize CONFIG dataset for{function_id}:{e}")
 
         # Store conda env config in CONFIG dataset
         try:
@@ -216,7 +216,7 @@ class Runner:
                 "conda_config"
             ] = config_str
         except Exception as e:
-            logger.info(f"Failed to add conda environment config to NWB file: {e}")
+            logger.debug(f"Failed to add conda environment config to NWB file: {e}")
 
         try:
             # Store node parameters in CONFIG dataset
@@ -225,7 +225,7 @@ class Runner:
                 "node_params"
             ] = params_str
         except Exception as e:
-            logger.warning(f"Failed to add node parameters to NWB file: {e}")
+            logger.debug(f"Failed to add node parameters to NWB file: {e}")
 
         return output_info
 

--- a/studio/app/common/core/rules/runner.py
+++ b/studio/app/common/core/rules/runner.py
@@ -202,7 +202,7 @@ class Runner:
             if function_id not in output_info["nwbfile"][NWBDATASET.CONFIG]:
                 output_info["nwbfile"][NWBDATASET.CONFIG][function_id] = {}
         except Exception as e:
-            logger.debug(f"Failed to initialize CONFIG dataset for{function_id}:{e}")
+            logger.warning(f"Failed to initialize CONFIG dataset for{function_id}:{e}")
 
         # Store conda env config in CONFIG dataset
         try:
@@ -216,7 +216,7 @@ class Runner:
                 "conda_config"
             ] = config_str
         except Exception as e:
-            logger.debug(f"Failed to add conda environment config to NWB file: {e}")
+            logger.warning(f"Failed to add conda environment config to NWB file: {e}")
 
         try:
             # Store node parameters in CONFIG dataset
@@ -225,7 +225,7 @@ class Runner:
                 "node_params"
             ] = params_str
         except Exception as e:
-            logger.debug(f"Failed to add node parameters to NWB file: {e}")
+            logger.warning(f"Failed to add node parameters to NWB file: {e}")
 
         return output_info
 

--- a/studio/app/common/core/snakemake/smk_utils.py
+++ b/studio/app/common/core/snakemake/smk_utils.py
@@ -102,7 +102,7 @@ class SmkUtils:
                 return hardware_arch
 
         except Exception as e:
-            logger.info("Failed to detect Apple Silicon: %s", e)
+            logger.warning("Failed to detect Apple Silicon: %s", e)
             return False
 
     @staticmethod
@@ -122,12 +122,14 @@ class SmkUtils:
                 modified_params["advanced"]["quality_evaluation_params"][
                     "use_cnn"
                 ] = False
-                logger.info("Disabled CNN usage in CaImAn parameters for Apple Silicon")
+                logger.debug(
+                    "Disabled CNN usage in CaImAn parameters for Apple Silicon"
+                )
 
         # Also check top-level parameters
         if "quality_evaluation_params" in modified_params:
             modified_params["quality_evaluation_params"]["use_cnn"] = False
-            logger.info("Disabled CNN usage in CaImAn parameters for Apple Silicon")
+            logger.debug("Disabled CNN usage in CaImAn parameters for Apple Silicon")
 
         return modified_params
 

--- a/studio/app/common/core/workflow/workflow_params.py
+++ b/studio/app/common/core/workflow/workflow_params.py
@@ -21,7 +21,7 @@ def check_types(params, default_params):
     faq_url = "https://github.com/oist/optinist/wiki/FAQ"
     for key in params.keys():
         if key not in default_params:
-            logger.error(f"Invalid Workflow yaml param: [{key}]. See {faq_url}")
+            logger.warning(f"Invalid Workflow yaml param: [{key}]. See {faq_url}")
             raise KeyError("Workflow yaml error, see FAQ")
         if isinstance(params[key], dict):
             params[key] = check_types(params[key], default_params[key])

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -117,7 +117,7 @@ class WorkflowResult:
             # Check node processed status (inspect ExptConfig)
             expt_function = expt_config.function.get(node_id)
             if not expt_function:
-                logger.debug(f"Invalid node_id [{node_id}]")
+                logger.warning(f"Invalid node_id [{node_id}]")
                 continue
 
             # Perform observations of nodes

--- a/studio/app/common/core/workflow/workflow_result.py
+++ b/studio/app/common/core/workflow/workflow_result.py
@@ -117,7 +117,7 @@ class WorkflowResult:
             # Check node processed status (inspect ExptConfig)
             expt_function = expt_config.function.get(node_id)
             if not expt_function:
-                logger.warning(f"Invalid node_id [{node_id}]")
+                logger.debug(f"Invalid node_id [{node_id}]")
                 continue
 
             # Perform observations of nodes
@@ -418,7 +418,7 @@ class WorkflowMonitor:
 
             # get process
             process = Process(last_pid)
-            logger.info(f"Found workflow process. {process}")
+            logger.debug(f"Found workflow process. {process}")
 
             # validate process name
             process_cmdline = " ".join(process.cmdline()).replace("\\", "/")
@@ -458,7 +458,7 @@ class WorkflowMonitor:
 
                     if re.search(self.PROCESS_CONDA_CMDLINE, cmdline):
                         conda_ps_create_elapsed = int(time.time() - proc.create_time())
-                        logger.info(
+                        logger.debug(
                             f"Found conda process. [{proc}] [{cmdline}] "
                             f"[{conda_ps_create_elapsed} sec]",
                         )

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -29,7 +29,7 @@ class WorkspaceDataCapacityService:
     def update_experiment_data_usage(cls, workspace_id: str, unique_id: str):
         workflow_dir = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
         if not os.path.exists(workflow_dir):
-            logger.debug(f"'{workflow_dir}' does not exist")
+            logger.warning(f"'{workflow_dir}' does not exist")
             return
 
         data_usage = get_folder_size(workflow_dir)
@@ -44,7 +44,7 @@ class WorkspaceDataCapacityService:
         # Read experiment config
         config = ExptConfigReader.read(workspace_id, unique_id)
         if not config:
-            logger.debug(f"[{workspace_id}/{unique_id}] does not exist")
+            logger.warning(f"[{workspace_id}/{unique_id}] does not exist")
             return
 
         # Make overwrite params
@@ -82,7 +82,7 @@ class WorkspaceDataCapacityService:
     ):
         workspace_dir = join_filepath([DIRPATH.INPUT_DIR, workspace_id])
         if not os.path.exists(workspace_dir):
-            logger.debug(f"'{workspace_dir}' does not exist")
+            logger.warning(f"'{workspace_dir}' does not exist")
             return
 
         input_data_usage = get_folder_size(workspace_dir)
@@ -121,7 +121,7 @@ class WorkspaceDataCapacityService:
     ):
         folder = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
         if not os.path.exists(folder):
-            logger.debug(f"'{folder}' does not exist")
+            logger.warning(f"'{folder}' does not exist")
             return
         exp_records = []
 

--- a/studio/app/common/core/workspace/workspace_data_capacity_services.py
+++ b/studio/app/common/core/workspace/workspace_data_capacity_services.py
@@ -29,7 +29,7 @@ class WorkspaceDataCapacityService:
     def update_experiment_data_usage(cls, workspace_id: str, unique_id: str):
         workflow_dir = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id, unique_id])
         if not os.path.exists(workflow_dir):
-            logger.error(f"'{workflow_dir}' does not exist")
+            logger.debug(f"'{workflow_dir}' does not exist")
             return
 
         data_usage = get_folder_size(workflow_dir)
@@ -44,7 +44,7 @@ class WorkspaceDataCapacityService:
         # Read experiment config
         config = ExptConfigReader.read(workspace_id, unique_id)
         if not config:
-            logger.error(f"[{workspace_id}/{unique_id}] does not exist")
+            logger.debug(f"[{workspace_id}/{unique_id}] does not exist")
             return
 
         # Make overwrite params
@@ -82,7 +82,7 @@ class WorkspaceDataCapacityService:
     ):
         workspace_dir = join_filepath([DIRPATH.INPUT_DIR, workspace_id])
         if not os.path.exists(workspace_dir):
-            logger.error(f"'{workspace_dir}' does not exist")
+            logger.debug(f"'{workspace_dir}' does not exist")
             return
 
         input_data_usage = get_folder_size(workspace_dir)
@@ -121,7 +121,7 @@ class WorkspaceDataCapacityService:
     ):
         folder = join_filepath([DIRPATH.OUTPUT_DIR, workspace_id])
         if not os.path.exists(folder):
-            logger.error(f"'{folder}' does not exist")
+            logger.debug(f"'{folder}' does not exist")
             return
         exp_records = []
 
@@ -153,7 +153,7 @@ class WorkspaceDataCapacityService:
                     )
                 )
                 db.bulk_save_objects(exp_records)
-                logger.info(
+                logger.debug(
                     f"Deleted and recreated {len(exp_records)} experiment records "
                     f"for workspace [{workspace_id}]"
                 )
@@ -176,7 +176,7 @@ class WorkspaceDataCapacityService:
                         # Insert new record if it doesn't exist
                         db.add(exp_record)
 
-                logger.info(
+                logger.debug(
                     f"Updated/inserted {len(exp_records)} experiment records "
                     f"for workspace [{workspace_id}]"
                 )

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -39,7 +39,7 @@ class WorkspaceService:
 
                 deleted_statuses.append(deleted_status)
         else:
-            logger.debug(f"Workspace directory '{workspace_dir}' does not exist")
+            logger.warning(f"Workspace directory '{workspace_dir}' does not exist")
 
         if all(deleted_statuses):
             # Delete the workspace directory itself

--- a/studio/app/common/core/workspace/workspace_services.py
+++ b/studio/app/common/core/workspace/workspace_services.py
@@ -39,7 +39,7 @@ class WorkspaceService:
 
                 deleted_statuses.append(deleted_status)
         else:
-            logger.warning(f"Workspace directory '{workspace_dir}' does not exist")
+            logger.debug(f"Workspace directory '{workspace_dir}' does not exist")
 
         if all(deleted_statuses):
             # Delete the workspace directory itself
@@ -68,7 +68,7 @@ class WorkspaceService:
                 shutil.rmtree(directory)
                 logger.info(f"Deleted directory: {directory}")
             else:
-                logger.warning(f"'{directory}' already deleted or never existed")
+                logger.debug(f"'{directory}' already deleted or never existed")
         except Exception as e:
             logger.error(
                 f"Failed to delete directory '{directory}': {e}",

--- a/studio/app/optinist/wrappers/caiman/cnmf.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf.py
@@ -203,7 +203,7 @@ def caiman_cnmf(
         c, dview, n_processes = setup_cluster(
             backend="multiprocessing", n_processes=n_processes
         )
-    logger.info(f"n_processes: {n_processes}")
+    logger.debug(f"n_processes: {n_processes}")
 
     if use_online:
         ops.change_params(
@@ -384,7 +384,7 @@ def caiman_cnmf(
     try:
         util_cleanup_image_memmap(mmap_paths)
     except Exception as e:
-        logger.error("Failed to cleanup memmap files.")
-        logger.error(e)
+        logger.warning("Failed to cleanup memmap files.")
+        logger.warning(e)
 
     return info

--- a/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
+++ b/studio/app/optinist/wrappers/caiman/cnmf_multisession.py
@@ -47,7 +47,7 @@ def caiman_cnmf_multisession(
         raise Exception(f"Set n_reg_files to a integer value gte 2. Now {n_reg_files}.")
     reg_file_rate = params.pop("reg_file_rate", 1.0)
     if reg_file_rate > 1.0:
-        logger.warn(
+        logger.warning(
             f"reg_file_rate {reg_file_rate}, should be lte 1. Using 1.0 instead."
         )
         reg_file_rate = 1.0
@@ -88,7 +88,7 @@ def caiman_cnmf_multisession(
         c, dview, n_processes = setup_cluster(
             backend="multiprocessing", n_processes=n_processes
         )
-    logger.info(f"n_processes: {n_processes}")
+    logger.debug(f"n_processes: {n_processes}")
 
     cnm_list = []
     templates = []
@@ -239,7 +239,7 @@ def caiman_cnmf_multisession(
     try:
         util_cleanup_image_memmap(mmap_paths)
     except Exception as e:
-        logger.error("Failed to cleanup memmap files.")
-        logger.error(e)
+        logger.warning("Failed to cleanup memmap files.")
+        logger.warning(e)
 
     return info

--- a/studio/app/optinist/wrappers/caiman/motion_correction.py
+++ b/studio/app/optinist/wrappers/caiman/motion_correction.py
@@ -51,7 +51,7 @@ def caiman_mc(
         c, dview, n_processes = setup_cluster(
             backend="multiprocessing", n_processes=n_processes
         )
-    logger.info(f"n_processes: {n_processes}")
+    logger.debug(f"n_processes: {n_processes}")
 
     mc = MotionCorrect(image.path, dview=dview, **opts.get_group("motion"))
 
@@ -102,15 +102,15 @@ def caiman_mc(
     try:
         __handle_mmap_cleanup(mc, mmap_file_new)
     except Exception as e:
-        logger.error("caiman_mc: Failed to cleanup memmap files.")
-        logger.error(e)
+        logger.warning("caiman_mc: Failed to cleanup memmap files.")
+        logger.warning(e)
 
     # Clean up unique CAIMAN_TEMPDIR
     try:
         CaimanUtils.cleanup_caiman_byid_tempdir(mc_unique_id)
     except Exception as e:
-        logger.error("caiman_mc: Failed to cleanup tempdir.")
-        logger.error(e)
+        logger.warning("caiman_mc: Failed to cleanup tempdir.")
+        logger.warning(e)
 
     return info
 

--- a/studio/app/optinist/wrappers/data_utils/data_concat.py
+++ b/studio/app/optinist/wrappers/data_utils/data_concat.py
@@ -100,7 +100,7 @@ def data_concat(
         output_type = output_type.strip().lower()
         logger.info(f"Output type specified: {output_type}")
     else:
-        logger.info("Output type unspecified, using same type as input data 1")
+        logger.debug("Output type unspecified, using same type as input data 1")
 
     try:
         data1_array = data1.data
@@ -152,17 +152,17 @@ def data_concat(
                 if len(combined) != len(np.unique(combined)):
                     # Has duplicates - create new continuous index
                     concatenated_index = np.arange(len(combined))
-                    logger.info(
+                    logger.debug(
                         f"Created new continuous index "
                         f"(0 to {len(combined)-1}) to avoid duplicates"
                     )
                 else:
                     concatenated_index = combined
-                    logger.info("Concatenated time indices")
+                    logger.debug("Concatenated time indices")
             else:
                 # Use data1's index (should be same for non-time concatenation)
                 concatenated_index = data1.index
-                logger.info("Used data1 index")
+                logger.debug("Used data1 index")
         elif hasattr(data1, "index") and data1.index is not None:
             concatenated_index = data1.index
         elif hasattr(data2, "index") and data2.index is not None:
@@ -180,7 +180,7 @@ def data_concat(
             ):
                 try:
                     concatenated_std = np.concatenate([data1.std, data2.std], axis=axis)
-                    logger.info("Concatenated existing std arrays")
+                    logger.debug("Concatenated existing std arrays")
                 except Exception as e:
                     logger.warning(f"Could not concatenate std arrays: {e}")
 
@@ -195,12 +195,12 @@ def data_concat(
                     concatenated_std = np.broadcast_to(
                         axis_std, concatenated_array.shape
                     )
-                    logger.info(f"Computed std with shape {concatenated_std.shape}")
+                    logger.debug(f"Computed std with shape {concatenated_std.shape}")
                 else:
                     concatenated_std = np.std(
                         concatenated_array, axis=effective_std_axis
                     )
-                    logger.info(f"Computed new std along axis {std_axis}")
+                    logger.debug(f"Computed new std along axis {std_axis}")
 
             except Exception as e:
                 logger.warning(f"Could not compute std: {e}")

--- a/studio/app/optinist/wrappers/data_utils/data_slice.py
+++ b/studio/app/optinist/wrappers/data_utils/data_slice.py
@@ -57,7 +57,7 @@ def data_slice(
 
     # Handle case where no slice specs are provided
     if slice_dims is None:
-        logger.info("No slice specifications provided, returning original data")
+        logger.debug("No slice specifications provided, returning original data")
         return return_as_data_type(data, raw_data, output_dir, "sliced_data")
 
     # Convert slice_dims to list format if it's a string
@@ -140,7 +140,7 @@ def data_slice(
         logger.warning(f"Unrecognized slice spec: {spec}")
         index_specs.append(slice(None))
 
-    logger.info(f"Data slice - Applying indexing: {index_specs}")
+    logger.debug(f"Data slice - Applying indexing: {index_specs}")
 
     try:
         # Apply slices to all parts of data

--- a/studio/app/optinist/wrappers/data_utils/data_utils_utils.py
+++ b/studio/app/optinist/wrappers/data_utils/data_utils_utils.py
@@ -21,7 +21,7 @@ def return_as_data_type(data, processed_data, output_dir, file_name, **kwargs):
 
     logger.info(f"Input data type: {type(data).__name__}")
     if output_type is None:
-        logger.info("No output_type specified, using input data type for output")
+        logger.debug("No output_type specified, using input data type for output")
 
     # Determine output type and key based on input type or explicit output_type
     if output_type in ["behaviors_data", "BehaviorData", "CsvData"] or (
@@ -92,5 +92,5 @@ def return_as_data_type(data, processed_data, output_dir, file_name, **kwargs):
         )
         output_key = "data"
 
-    logger.info(f"Created {type(result).__name__} with output key: {output_key}")
+    logger.debug(f"Created {type(result).__name__} with output key: {output_key}")
     return {output_key: result}

--- a/studio/app/optinist/wrappers/data_utils/vacant_roi.py
+++ b/studio/app/optinist/wrappers/data_utils/vacant_roi.py
@@ -20,7 +20,7 @@ def vacant_roi(
     recursive_flatten_params(params, flattened_params)
     params = flattened_params
 
-    logger.info("params: %s", params)
+    logger.debug("params: %s", params)
 
     D = LoadData(mc_images)
     assert len(D.shape) == 3, "input array should have dimensions (width, height, time)"

--- a/studio/app/optinist/wrappers/lccd/lccd_detection.py
+++ b/studio/app/optinist/wrappers/lccd/lccd_detection.py
@@ -22,7 +22,7 @@ def lccd_detect(
     recursive_flatten_params(params, flattened_params)
     params = flattened_params
 
-    logger.info("params: %s", params)
+    logger.debug("params: %s", params)
     lccd = LCCD(params)
     D = LoadData(mc_images)
     assert len(D.shape) == 3, "input array should have dimensions (width, height, time)"
@@ -31,7 +31,7 @@ def lccd_detect(
         num_cell = roi.shape[1]
     except ValueError as e:
         if "No roi region found" in str(e):
-            logger.info("No ROIs found in LCCD detection")
+            logger.warning("No ROIs found in LCCD detection")
             num_cell = 0
             roi = np.zeros((D.shape[0] * D.shape[1], 0))  # Empty ROIs
         else:

--- a/studio/app/optinist/wrappers/optinist/dimension_reduction/dpca_fit.py
+++ b/studio/app/optinist/wrappers/optinist/dimension_reduction/dpca_fit.py
@@ -119,7 +119,7 @@ def createMatrix(D, triggers, stims, duration):
             ]
 
         else:
-            logger.warn(
+            logger.warning(
                 "currently the number of condition category has to be less than 4"
             )
             return

--- a/studio/app/optinist/wrappers/optinist/neural_decoding/glm.py
+++ b/studio/app/optinist/wrappers/optinist/neural_decoding/glm.py
@@ -105,16 +105,16 @@ def GLM(
         error_message = f"Error fitting GLM: {str(e)}."
         "Check for NaN or inf values. Ensure your family/link choice is appropriate"
         logger.error(error_message)
-        logger.info(f"X shape: {tX.shape}, Y shape: {tY.shape}")
-        logger.info(
+        logger.debug(f"X shape: {tX.shape}, Y shape: {tY.shape}")
+        logger.debug(
             f"X contains NaN: {np.isnan(tX.values).any()},"
             "X contains inf: {np.isinf(tX.values).any()}"
         )
-        logger.info(
+        logger.debug(
             f"Y contains NaN: {np.isnan(tY.values).any()},"
             "Y contains inf: {np.isinf(tY.values).any()}"
         )
-        logger.info(f"Y min: {np.min(tY.values)}, Y max: {np.max(tY.values)}")
+        logger.debug(f"Y min: {np.min(tY.values)}, Y max: {np.max(tY.values)}")
         raise ValueError(error_message)
 
     # NWB追加

--- a/studio/app/optinist/wrappers/optinist/neural_population_analysis/granger.py
+++ b/studio/app/optinist/wrappers/optinist/neural_population_analysis/granger.py
@@ -65,7 +65,7 @@ def Granger(
     params = params["Granger"]  # remove nested dict
 
     if params["use_adfuller_test"]:
-        logger.info("Running adfuller test ")
+        logger.info("Running adfuller test")
 
         for i in tqdm(range(num_cell)):
             tp = adfuller(tX[:, i], **params["adfuller"])
@@ -115,7 +115,7 @@ def Granger(
     }
 
     if params["use_coint_test"]:
-        logger.info("Running cointegration test ")
+        logger.info("Running cointegration test")
 
         for i in tqdm(range(num_comb)):
             tp = coint(X[:, comb[i][0]], X[:, comb[i][1]], **params["coint"])
@@ -126,7 +126,7 @@ def Granger(
             cit["cit_crit_value"][i, :] = tp[2]
 
     #  Granger causality
-    logger.info("Running granger test ")
+    logger.info("Running granger test")
 
     if hasattr(params["Granger_maxlag"], "__iter__"):
         num_lag = len(params["Granger_maxlag"])

--- a/studio/app/optinist/wrappers/suite2p/file_convert.py
+++ b/studio/app/optinist/wrappers/suite2p/file_convert.py
@@ -48,8 +48,8 @@ def suite2p_file_convert(
         data_path_list.append(os.path.dirname(file_path))
         data_name_list.append(os.path.basename(file_path))
 
-    logger.info(data_path_list)
-    logger.info(data_name_list)
+    logger.debug(data_path_list)
+    logger.debug(data_name_list)
     # data pathと保存pathを指定
     db = {
         "data_path": data_path_list,

--- a/studio/app/optinist/wrappers/suite2p/roi.py
+++ b/studio/app/optinist/wrappers/suite2p/roi.py
@@ -95,7 +95,7 @@ def suite2p_roi(
                 logger.info("No ROIs detected in the data.")
 
     except Exception as e:
-        logger.error(f"Error during ROI detection: {str(e)}")
+        logger.warning(f"Error during ROI detection: {str(e)}")
         # Continue with empty results
 
     # Create ROI list


### PR DESCRIPTION
## Summary

Audited all logging calls across the codebase against the logging level policy.
Fixed ~64 violations across 24 files. No logic changes -- only log level adjustments.

## Logging Level Policy

This section defines **when to use each log level**. All new logging calls
must follow these rules. Existing calls that violate these rules should be
corrected when the surrounding code is modified.

### Level Definitions

#### CRITICAL

System is unusable or data integrity is compromised.

- Partial operations that leave the system in an inconsistent state
  (e.g., Firebase account deleted but DB record remains)
- Unrecoverable startup failures

Expected frequency: near-zero in healthy systems.

#### ERROR

An operation **failed and cannot proceed**. The caller will receive an error
response, or a job item will be skipped/retried.

Use ERROR when:
- A database write/read fails unexpectedly
- An external API call fails (S3, Stripe, Firebase) and no fallback exists
- A workflow execution fails
- A business-logic invariant is violated

Do NOT use ERROR when:
- The system handles the failure gracefully (use WARNING)
- The failure is expected in normal operation (use WARNING or DEBUG)

#### WARNING

Something **unexpected happened but the system recovered** or degraded
gracefully. A human should review these periodically but no immediate action
is required.

Use WARNING when:
- A resource is **unexpectedly** missing but the code returns early or uses
  a fallback (e.g., a file that should have been created by a prior step is
  absent, a config file is malformed)
- A non-critical cleanup operation fails (e.g., temp file deletion after
  successful computation)
- A caught exception represents a client-side issue, not a server bug
  (e.g., validation error -> 400/401, expired auth token)
- A platform detection or optional feature probe fails
- A caught exception that was handled but may indicate a deeper issue
- In science wrappers: invalid user input that was silently corrected or
  ignored (e.g., out-of-bounds index, unrecognised parameter value)

Do NOT use WARNING when:
- The condition is the normal/happy path (use DEBUG or INFO)
- The operation succeeded (use INFO)
- The absence check is **routine** -- the code is designed to handle
  non-existence as a normal path, not an anomaly (use DEBUG). Examples:
  checking whether a workspace directory exists before it has been created,
  or reading an optional config that may not be present yet.

#### INFO

A **significant business event or operational milestone** occurred. INFO is
the default production-visible level in the frontend log viewer.

Use INFO when:
- A high-level operation starts or completes (workflow run, background job,
  experiment copy/delete)
- A business event occurs (user login, subscription created/renewed/cancelled,
  email sent)
- Infrastructure initializes (cloud services connected, S3 bucket created,
  DB connection verified)
- A job-level summary is produced ("Processed N items", "Cleanup complete")

Do NOT use INFO when:
- Logging per-item details in a batch operation (use DEBUG)
- Logging internal function parameters or return values (use DEBUG)
- Logging step-by-step traces through a multi-step process (use DEBUG)
- Logging sensitive data: auth tokens, verification links, webhook secrets
  (use DEBUG -- these should only appear when explicitly requested)

Rule of thumb: **one INFO message per high-level operation**. If a loop
body contains `logger.info()`, it almost certainly should be `logger.debug()`.

#### DEBUG

**Diagnostic detail** for developers investigating issues. Always captured
by CloudWatch but hidden from the frontend log viewer when `LOG_LEVEL=INFO`.

Use DEBUG when:
- Logging step-by-step progress through a multi-step process (webhook
  processing, checkout flow, S3 sync)
- Logging per-item details in batch operations (per-file download,
  per-experiment cleanup, per-user reconciliation)
- Logging function parameters, return values, or intermediate state
- Logging cache hits/misses, skip decisions, no-op conditions
- Logging sensitive data that aids debugging (verification links, password
  reset links, webhook signatures, Lambda response bodies)
- Logging the happy/normal path of a check ("no limit warning" = user is
  within limits = nothing to report at higher levels)
- Routine absence checks where non-existence is a normal, expected state
  (e.g., `"'{path}' does not exist"` when the code is designed to return
  early without error)

### Decision Flowchart

```
Is the system in an inconsistent/unusable state?
  YES -> CRITICAL

Did the operation fail and the caller will get an error?
  YES -> ERROR

Did something unexpected happen but the system handled it?
  YES -> WARNING

Is this a significant business event or operational milestone?
  YES -> INFO

Everything else (traces, per-item details, parameters, sensitive data)
  -> DEBUG
```

### Anti-Patterns

These are the most common mistakes found during the log-level audit. Avoid
them in new code and fix them when modifying existing code.

| Anti-Pattern | Correct Level | Example |
|---|---|---|
| Caught exception logged as INFO | WARNING | `"Failed to detect Apple Silicon: {e}"` |
| Happy-path / no-problem-found logged as WARNING | DEBUG | `"No limit warning for user {id}"` |
| Successful recovery logged as WARNING | INFO | `"Bucket recovery on login: {bucket}"` |
| Per-item batch detail logged as INFO | DEBUG | `"Deleting input directory: {dir}"` |
| Internal state dump logged as INFO | DEBUG | `"Lambda response body: {body}"` |
| Sensitive credentials logged as INFO | DEBUG | `"Verification link: {url}"` |
| Unexpected missing resource logged as ERROR | WARNING | `"Experiment {id} not found"` (should exist) |
| Routine absence check logged as WARNING | DEBUG | `"'{path}' does not exist"` (may not exist yet) |
| Non-critical cleanup failure logged as ERROR | WARNING | `"Failed to cleanup memmap files"` |

### Logger Usage

All modules must use `AppLogger.get_logger()` from
`studio.app.common.core.logger`. Do not use `logging.getLogger()` directly.

```python
# Correct
from studio.app.common.core.logger import AppLogger
logger = AppLogger.get_logger()

# Incorrect -- do not use
import logging
logging.getLogger().info(...)
```

This ensures all log output passes through the centralized configuration
(YAML-based levels, `ClientIdFilter`, concurrent file handler, `LOG_LEVEL`
frontend filtering).


---

## Rules Applied

### 1. Logger initialisation

All modules must use `AppLogger.get_logger()`. Direct `logging.getLogger()` is prohibited.

### 2. Level selection (general code)

| Situation | Level |
|---|---|
| System unusable / inconsistent state | CRITICAL |
| Operation failed, caller gets an error | ERROR |
| Unexpected condition but system recovered or degraded gracefully | WARNING |
| Significant business event or operational milestone (one per high-level operation) | INFO |
| Everything else (traces, per-item detail, parameters, sensitive data) | DEBUG |

### 3. Level selection (science wrappers)

Wrapper functions under `/wrappers/` are used directly by scientists via the
workflow UI. Their log output doubles as a run summary. The following refinements
apply:

| Situation | Level | Examples |
|---|---|---|
| Operation start/complete | INFO | `start caiman_cnmf`, `Starting data concatenation` |
| Scientist-visible config choices | INFO | `Concatenation axis specified: 0`, `Using default time_axis 1` |
| Input/output shape summaries | INFO | `Original data shape: (512, 512, 1000)`, `Sliced data shape: (512, 512, 500)` |
| Sub-operation progress in multi-step analysis | INFO | `Running adfuller test`, `Running granger test` |
| Invalid user input the scientist should know about | WARNING | `Invalid std_method`, `Index out of bounds`, `reg_file_rate should be lte 1` |
| Unexpected condition with graceful fallback | WARNING | `No input files found`, `No ROIs found in LCCD detection` |
| Internal mechanics (index handling, std computation, type routing) | DEBUG | `Concatenated time indices`, `Computed std with shape ...` |
| Hardcoded internals | DEBUG | `n_processes: 1` |
| Raw parameter dumps | DEBUG | `params: {...}` |

### 4. Anti-patterns fixed

| Anti-pattern | Correct level | Occurrences fixed |
|---|---|---|
| Client auth/validation error (400) logged as ERROR | WARNING | 7 |
| Graceful early-return (missing resource) logged as WARNING | DEBUG | 8 |
| Per-parameter config detail logged as INFO | DEBUG | ~10 |
| Internal state dump in exception handler logged as INFO | DEBUG | 4 |
| Invalid user input silently corrected logged as DEBUG | WARNING | 8 |
| Deprecated `logger.warn()` | `logger.warning()` | 2 |
| Direct `logging.getLogger()` | `AppLogger.get_logger()` | 1 file |

---

## Changes by file

### Logger initialisation fix

| File | Change |
|---|---|
| `studio/app/common/core/auth/__init__.py` | `logging.getLogger()` -> `AppLogger.get_logger()` |

### ERROR -> WARNING (client/graceful failures)

| File | Lines | Reason |
|---|---|---|
| `core/auth/auth.py` | 47, 66, 78, 113 | HTTPError/AssertionError -> 400 responses |
| `core/auth/security.py` | 76, 79, 82 | Token validation failures handled gracefully |
| `core/workflow/workflow_params.py` | 24 | Invalid YAML param (user input) |
| `core/experiment/experiment_record_services.py` | 94 | NoResultFound during copy (expected) |
| `wrappers/suite2p/roi.py` | 98 | ROI detection error, continues with empty results |

### WARNING -> DEBUG (normal conditions in non-wrapper code)

| File | Lines | Reason |
|---|---|---|
| `core/workspace/workspace_data_capacity_services.py` | 32, 47, 85, 124 | Missing resource, early return |
| `core/workspace/workspace_services.py` | 42, 71 | Missing directory checks |
| `core/workflow/workflow_result.py` | 120 | Invalid node_id skipped in loop |
| `core/experiment/experiment_reader.py` | 141 | Config read error, returns None |
| `core/rules/runner.py` | 205, 219, 228 | Non-critical NWB metadata failures |

### WARNING -> WARNING (science wrappers -- kept or restored)

| File | Lines | Reason |
|---|---|---|
| `wrappers/suite2p/roi.py` | 64 | No input files, returns empty |
| `wrappers/data_utils/data_slice.py` | 91, 105, 130, 134, 140 | Invalid user slice specs with fallback |
| `wrappers/data_utils/data_utils_utils.py` | 87 | Unknown output_type, defaulting |
| `wrappers/caiman/cnmf_multisession.py` | 50 | reg_file_rate corrected |
| `wrappers/optinist/dimension_reduction/dpca_fit.py` | 122 | Condition category limit, returns early |

### INFO -> WARNING (caught exception)

| File | Lines | Reason |
|---|---|---|
| `wrappers/lccd/lccd_detection.py` | 34 | Caught ValueError handled gracefully |

### INFO -> DEBUG (internal detail in non-wrapper code)

| File | Lines | Reason |
|---|---|---|
| `core/workspace/workspace_data_capacity_services.py` | 156, 179 | Intermediate DB operation counts |
| `core/workflow/workflow_result.py` | 421, 461 | Process discovery diagnostics |
| `core/snakemake/smk_utils.py` | 125, 130 | CNN disable (skip decision) |

### INFO -> DEBUG (internal detail in wrappers)

| File | Lines | Reason |
|---|---|---|
| `wrappers/caiman/motion_correction.py` | 54 | `n_processes` (hardcoded) |
| `wrappers/caiman/cnmf.py` | 206 | `n_processes` (hardcoded) |
| `wrappers/caiman/cnmf_multisession.py` | 91 | `n_processes` (hardcoded) |
| `wrappers/optinist/neural_decoding/glm.py` | 108-117 | Exception handler state dumps |
| `wrappers/data_utils/vacant_roi.py` | 23 | Raw params dump |
| `wrappers/data_utils/data_concat.py` | 103, 155, 161, 165, 183, 198, 203 | Index/std internal mechanics |
| `wrappers/data_utils/data_slice.py` | 60, 143 | No-op condition, indexing spec detail |

### INFO kept/restored (science-facing summaries in wrappers)

| File | Lines | Reason |
|---|---|---|
| `wrappers/data_utils/data_concat.py` | 58, 62, 69, 71, 86, 94, 101, 110, 129 | Config choices, shapes |
| `wrappers/data_utils/data_slice.py` | 51, 148 | Input/output shapes |
| `wrappers/data_utils/data_transpose.py` | 81, 91, 92 | Permutation, shapes |
| `wrappers/data_utils/data_utils_utils.py` | 22 | Input data type |
| `wrappers/optinist/neural_population_analysis/granger.py` | 68, 118, 129 | Sub-operation progress |
| `wrappers/caiman/cnmf_multisession.py` | 65 | Split count summary |

### Deprecated `logger.warn()` eliminated

| File | Original | Replacement |
|---|---|---|
| `wrappers/caiman/cnmf_multisession.py` | `logger.warn(...)` | `logger.warning(...)` |
| `wrappers/optinist/dimension_reduction/dpca_fit.py` | `logger.warn(...)` | `logger.warning(...)` |

---

## Risk Assessment

```
| Area                          | Risk | Notes                                           |
|-------------------------------|------|-------------------------------------------------|
| Log level changes             | Low  | No logic changes; only level adjustments        |
| Logger init fix (auth)        | Low  | Same output, different logger instance           |
| Science wrapper visibility    | Low  | Scientists see same or better info at INFO level |
| Production log volume         | Low  | Net reduction in INFO noise; more at DEBUG       |
```
