### PR TITLE
H5 and mat files visualisable, read path from workflow.yaml

### DIFF
--- a/frontend/src/api/outputs/Outputs.ts
+++ b/frontend/src/api/outputs/Outputs.ts
@@ -254,6 +254,33 @@ export async function getHistogramDataApi(
   return response.data
 }
 
+export type StructuredData = {
+  data: number[] | number[][] | number[][][]
+  data_type: "timeseries" | "images" | "bar"
+  columns?: string[]
+  index?: (string | number)[]
+  total_frames?: number
+}
+
+export async function getStructuredDataApi(
+  workspaceId: string,
+  uniqueId: string,
+  nodeId: string,
+  startIndex?: number,
+  endIndex?: number,
+): Promise<StructuredData> {
+  const response = await axios.get(
+    `${BASE_URL}/outputs/structured/${workspaceId}/${uniqueId}/${nodeId}`,
+    {
+      params: {
+        start_index: startIndex,
+        end_index: endIndex,
+      },
+    },
+  )
+  return response.data
+}
+
 export type PieData = number[][]
 
 export async function getPieDataApi(

--- a/frontend/src/api/outputs/Outputs.ts
+++ b/frontend/src/api/outputs/Outputs.ts
@@ -260,6 +260,7 @@ export type StructuredData = {
   columns?: string[]
   index?: (string | number)[]
   total_frames?: number
+  dataset_path?: string
 }
 
 export async function getStructuredDataApi(

--- a/frontend/src/components/Workspace/Visualize/DisplayDataItem.tsx
+++ b/frontend/src/components/Workspace/Visualize/DisplayDataItem.tsx
@@ -13,6 +13,7 @@ import { PiePlot } from "components/Workspace/Visualize/Plot/PiePlot"
 import { PolarPlot } from "components/Workspace/Visualize/Plot/PolarPlot"
 import { RoiPlot } from "components/Workspace/Visualize/Plot/RoiPlot"
 import { ScatterPlot } from "components/Workspace/Visualize/Plot/ScatterPlot"
+import { StructuredFilePlot } from "components/Workspace/Visualize/Plot/StructuredFilePlot"
 import { TimeSeriesPlot } from "components/Workspace/Visualize/Plot/TimeSeriesPlot"
 import {
   DATA_TYPE,
@@ -77,6 +78,9 @@ const DisplayPlot = memo(function DisplayPlot({ dataType }: DataTypeProps) {
       return <PiePlot />
     case DATA_TYPE_SET.POLAR:
       return <PolarPlot />
+    case DATA_TYPE_SET.HDF5:
+    case DATA_TYPE_SET.MATLAB:
+      return <StructuredFilePlot />
     default:
       return null
   }

--- a/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
@@ -1,8 +1,23 @@
-import { memo, useContext, useEffect, useState } from "react"
+import {
+  ChangeEvent,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import PlotlyChart from "react-plotlyjs-ts"
 import { useDispatch, useSelector } from "react-redux"
 
-import { Box, LinearProgress, Slider, Typography } from "@mui/material"
+import {
+  Box,
+  Button,
+  LinearProgress,
+  Slider,
+  TextField,
+  Typography,
+} from "@mui/material"
 
 import { DisplayDataContext } from "components/Workspace/Visualize/DataContext"
 import { getStructuredData } from "store/slice/DisplayData/DisplayDataActions"
@@ -66,6 +81,33 @@ export const StructuredFilePlot = memo(function StructuredFilePlot() {
   const result = structuredState.data
   if (!result) return null
 
+  return (
+    <Box>
+      {result.dataset_path && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          title={result.dataset_path}
+          noWrap
+          sx={{ px: 1, display: "block", maxWidth: "100%" }}
+        >
+          {result.dataset_path}
+        </Typography>
+      )}
+      <DataView result={result} />
+    </Box>
+  )
+})
+
+const DataView = memo(function DataView({
+  result,
+}: {
+  result: {
+    data_type: string
+    data: number[] | number[][] | number[][][]
+    total_frames?: number
+  }
+}) {
   switch (result.data_type) {
     case "timeseries":
       return <TimeSeriesView data={result.data as number[][]} />
@@ -120,8 +162,54 @@ const ImageView = memo(function ImageView({
   data: number[][][]
   totalFrames: number
 }) {
-  const [frameIndex, setFrameIndex] = useState(0)
-  const frame = data[frameIndex] || []
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [duration, setDuration] = useState(500)
+  const intervalRef = useRef<null | NodeJS.Timeout>(null)
+  const maxIndex = data.length - 1
+
+  const frame = data[activeIndex] || []
+
+  useEffect(() => {
+    if (intervalRef.current !== null && activeIndex >= maxIndex) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [activeIndex, maxIndex])
+
+  const onPlayClick = useCallback(() => {
+    if (activeIndex >= maxIndex) {
+      setActiveIndex(0)
+    }
+    if (maxIndex > 0 && intervalRef.current === null) {
+      intervalRef.current = setInterval(() => {
+        setActiveIndex((prev) => Math.min(prev + 1, maxIndex))
+      }, duration)
+    }
+  }, [activeIndex, maxIndex, duration])
+
+  const onPauseClick = () => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }
+
+  const onDurationChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const newValue =
+        event.target?.value === "" ? "" : Number(event.target?.value)
+      if (typeof newValue === "number") {
+        setDuration(newValue)
+      }
+    },
+    [],
+  )
+
+  const onSliderChange = (_: Event, value: number | number[]) => {
+    if (typeof value === "number") {
+      setActiveIndex(value)
+    }
+  }
 
   const plotData = [
     {
@@ -133,7 +221,7 @@ const ImageView = memo(function ImageView({
   ]
 
   const layout = {
-    title: `Frame ${frameIndex + 1} / ${data.length} (of ${totalFrames} total)`,
+    title: `Frame ${activeIndex + 1} / ${data.length} (of ${totalFrames} total)`,
     yaxis: { autorange: "reversed" as const },
     autosize: true,
   }
@@ -142,16 +230,43 @@ const ImageView = memo(function ImageView({
     <Box>
       <PlotlyChart data={plotData} layout={layout} />
       {data.length > 1 && (
-        <Box px={2}>
-          <Slider
-            value={frameIndex}
-            min={0}
-            max={data.length - 1}
-            onChange={(_, value) => setFrameIndex(value as number)}
-            valueLabelDisplay="auto"
-            valueLabelFormat={(v) => `Frame ${v + 1}`}
+        <>
+          <Button sx={{ mt: 1.5 }} variant="outlined" onClick={onPlayClick}>
+            Play
+          </Button>
+          <Button
+            sx={{ mt: 1.5, ml: 1 }}
+            variant="outlined"
+            onClick={onPauseClick}
+          >
+            Pause
+          </Button>
+          <TextField
+            sx={{ width: 100, ml: 2 }}
+            label="msec/frame"
+            type="number"
+            inputProps={{
+              step: 100,
+              min: 0,
+              max: 1000,
+            }}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            onChange={onDurationChange}
+            value={duration}
           />
-        </Box>
+          <Slider
+            aria-label="Custom marks"
+            value={activeIndex}
+            valueLabelDisplay="auto"
+            step={1}
+            marks
+            min={0}
+            max={maxIndex}
+            onChange={onSliderChange}
+          />
+        </>
       )}
     </Box>
   )

--- a/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
+++ b/frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx
@@ -1,0 +1,177 @@
+import { memo, useContext, useEffect, useState } from "react"
+import PlotlyChart from "react-plotlyjs-ts"
+import { useDispatch, useSelector } from "react-redux"
+
+import { Box, LinearProgress, Slider, Typography } from "@mui/material"
+
+import { DisplayDataContext } from "components/Workspace/Visualize/DataContext"
+import { getStructuredData } from "store/slice/DisplayData/DisplayDataActions"
+import { selectPipelineLatestUid } from "store/slice/Pipeline/PipelineSelectors"
+import { selectCurrentWorkspaceId } from "store/slice/Workspace/WorkspaceSelector"
+import { AppDispatch, RootState } from "store/store"
+
+const DEFAULT_START_INDEX = 0
+const DEFAULT_END_INDEX = 10
+
+export const StructuredFilePlot = memo(function StructuredFilePlot() {
+  const { nodeId, itemId } = useContext(DisplayDataContext)
+  const dispatch = useDispatch<AppDispatch>()
+
+  const workspaceId = useSelector(selectCurrentWorkspaceId)
+  const uid = useSelector(selectPipelineLatestUid)
+
+  const structuredState = useSelector(
+    (state: RootState) => state.displayData.structured[itemId],
+  )
+
+  useEffect(() => {
+    if (workspaceId && uid && nodeId) {
+      dispatch(
+        getStructuredData({
+          workspaceId: String(workspaceId),
+          uniqueId: uid,
+          nodeId,
+          itemId,
+          startIndex: DEFAULT_START_INDEX,
+          endIndex: DEFAULT_END_INDEX,
+        }),
+      )
+    }
+  }, [dispatch, workspaceId, uid, nodeId, itemId])
+
+  if (!uid || !nodeId) {
+    return (
+      <Box p={2}>
+        <Typography color="text.secondary">
+          No workflow run available. Please run the workflow first.
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (!structuredState || structuredState.pending) {
+    return <LinearProgress />
+  }
+
+  if (structuredState.error) {
+    return (
+      <Box p={2}>
+        <Typography color="error">
+          Error loading data: {structuredState.error}
+        </Typography>
+      </Box>
+    )
+  }
+
+  const result = structuredState.data
+  if (!result) return null
+
+  switch (result.data_type) {
+    case "timeseries":
+      return <TimeSeriesView data={result.data as number[][]} />
+    case "images":
+      return (
+        <ImageView
+          data={result.data as number[][][]}
+          totalFrames={
+            result.total_frames ?? (result.data as number[][][]).length
+          }
+        />
+      )
+    case "bar":
+      return <BarView data={result.data as number[]} />
+    default:
+      return <Typography>Unsupported data type: {result.data_type}</Typography>
+  }
+})
+
+const TimeSeriesView = memo(function TimeSeriesView({
+  data,
+}: {
+  data: number[][]
+}) {
+  const traces = []
+  if (data.length > 0) {
+    const numCols = data[0].length
+    for (let col = 0; col < numCols; col++) {
+      traces.push({
+        y: data.map((row) => row[col]),
+        type: "scatter",
+        mode: "lines",
+        name: `col ${col}`,
+      })
+    }
+  }
+
+  const layout = {
+    title: "Time Series",
+    xaxis: { title: "Frame" },
+    yaxis: { title: "Value" },
+    autosize: true,
+  }
+
+  return <PlotlyChart data={traces} layout={layout} />
+})
+
+const ImageView = memo(function ImageView({
+  data,
+  totalFrames,
+}: {
+  data: number[][][]
+  totalFrames: number
+}) {
+  const [frameIndex, setFrameIndex] = useState(0)
+  const frame = data[frameIndex] || []
+
+  const plotData = [
+    {
+      z: frame,
+      type: "heatmap",
+      colorscale: "Greys",
+      reversescale: true,
+    },
+  ]
+
+  const layout = {
+    title: `Frame ${frameIndex + 1} / ${data.length} (of ${totalFrames} total)`,
+    yaxis: { autorange: "reversed" as const },
+    autosize: true,
+  }
+
+  return (
+    <Box>
+      <PlotlyChart data={plotData} layout={layout} />
+      {data.length > 1 && (
+        <Box px={2}>
+          <Slider
+            value={frameIndex}
+            min={0}
+            max={data.length - 1}
+            onChange={(_, value) => setFrameIndex(value as number)}
+            valueLabelDisplay="auto"
+            valueLabelFormat={(v) => `Frame ${v + 1}`}
+          />
+        </Box>
+      )}
+    </Box>
+  )
+})
+
+const BarView = memo(function BarView({ data }: { data: number[] }) {
+  const plotData = [
+    {
+      x: data.map((_, i) => i),
+      y: data,
+      type: "bar",
+    },
+  ]
+
+  const layout = {
+    title: "Values",
+    xaxis: { title: "Index" },
+    yaxis: { title: "Value" },
+    autosize: true,
+  }
+
+  return <PlotlyChart data={plotData} layout={layout} />
+})

--- a/frontend/src/components/Workspace/Visualize/VisualizeItemEditor.tsx
+++ b/frontend/src/components/Workspace/Visualize/VisualizeItemEditor.tsx
@@ -60,6 +60,8 @@ const DisplayEditor: FC<{
     case DATA_TYPE_SET.LINE:
     case DATA_TYPE_SET.PIE:
     case DATA_TYPE_SET.POLAR:
+    case DATA_TYPE_SET.HDF5:
+    case DATA_TYPE_SET.MATLAB:
       return <SaveFig />
     case DATA_TYPE_SET.HTML:
       return <div>html editor</div>

--- a/frontend/src/components/Workspace/__tests__/Experiment/ExperimentTable.test.tsx
+++ b/frontend/src/components/Workspace/__tests__/Experiment/ExperimentTable.test.tsx
@@ -132,6 +132,7 @@ describe("ExperimentTable", () => {
         line: {},
         pie: {},
         polar: {},
+        structured: {},
         loading: false,
         statusRoi: {
           temp_add_roi: [],

--- a/frontend/src/store/slice/DisplayData/DisplayDataActions.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataActions.ts
@@ -13,6 +13,7 @@ import {
   LineData,
   PieData,
   PolarData,
+  StructuredData,
   getTimeSeriesInitDataApi,
   getTimeSeriesDataByIdApi,
   getTimeSeriesAllDataApi,
@@ -29,6 +30,7 @@ import {
   getPolarDataApi,
   getMatlabDataApi,
   MatlabData,
+  getStructuredDataApi,
   cancelRoiApi,
   addRoiApi,
   mergeRoiApi,
@@ -369,3 +371,31 @@ export const getPolarData = createAsyncThunk<
     return thunkAPI.rejectWithValue(e)
   }
 })
+
+export const getStructuredData = createAsyncThunk<
+  StructuredData,
+  {
+    workspaceId: string
+    uniqueId: string
+    nodeId: string
+    itemId: number
+    startIndex?: number
+    endIndex?: number
+  }
+>(
+  `${DISPLAY_DATA_SLICE_NAME}/getStructuredData`,
+  async ({ workspaceId, uniqueId, nodeId, startIndex, endIndex }, thunkAPI) => {
+    try {
+      const response = await getStructuredDataApi(
+        workspaceId,
+        uniqueId,
+        nodeId,
+        startIndex,
+        endIndex,
+      )
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)

--- a/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataSlice.ts
@@ -15,6 +15,7 @@ import {
   getLineData,
   getPieData,
   getPolarData,
+  getStructuredData,
   cancelRoi,
   mergeRoi,
   addRoi,
@@ -48,6 +49,7 @@ const initialState: DisplayData = {
   line: {},
   pie: {},
   polar: {},
+  structured: {},
   loading: false,
   loadingStack: [],
   statusRoi: {
@@ -634,6 +636,33 @@ export const displayDataSlice = createSlice({
           error: action.error.message ?? "rejected",
         }
       })
+      .addCase(getStructuredData.pending, (state, action) => {
+        const { itemId } = action.meta.arg
+        state.structured[itemId] = {
+          data: null,
+          pending: true,
+          fulfilled: false,
+          error: null,
+        }
+      })
+      .addCase(getStructuredData.fulfilled, (state, action) => {
+        const { itemId } = action.meta.arg
+        state.structured[itemId] = {
+          data: action.payload,
+          pending: false,
+          fulfilled: true,
+          error: null,
+        }
+      })
+      .addCase(getStructuredData.rejected, (state, action) => {
+        const { itemId } = action.meta.arg
+        state.structured[itemId] = {
+          data: null,
+          pending: false,
+          fulfilled: false,
+          error: action.error.message ?? "rejected",
+        }
+      })
       .addCase(getStatus.fulfilled, (state, action) => {
         state.statusRoi = action.payload
 
@@ -725,6 +754,11 @@ function deleteDisplayDataFn(
     delete state.pie[filePath]
   } else if (dataType === DATA_TYPE_SET.POLAR) {
     delete state.polar[filePath]
+  } else if (
+    dataType === DATA_TYPE_SET.HDF5 ||
+    dataType === DATA_TYPE_SET.MATLAB
+  ) {
+    // structured data is keyed by itemId, not filePath - cleaned up on item delete
   }
 }
 

--- a/frontend/src/store/slice/DisplayData/DisplayDataType.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataType.ts
@@ -12,6 +12,7 @@ import {
   PieData,
   PolarData,
   MatlabData,
+  StructuredData,
 } from "api/outputs/Outputs"
 import { StatusROI } from "components/Workspace/Visualize/Plot/ImagePlot"
 
@@ -56,6 +57,9 @@ export type DisplayData = {
   }
   polar: {
     [filePath: string]: PolarDisplayData
+  }
+  structured: {
+    [itemId: string]: StructuredDisplayData
   }
   loading: boolean
   loadingStack: boolean[]
@@ -151,4 +155,11 @@ export interface PieDisplayData extends BaseDisplay<"pie", PieData> {
 export interface PolarDisplayData extends BaseDisplay<"polar", PolarData> {
   columns: number[]
   index: number[]
+}
+
+export interface StructuredDisplayData {
+  data: StructuredData | null
+  pending: boolean
+  fulfilled: boolean
+  error: string | null
 }

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -303,29 +303,34 @@ async def get_structured_data(
         raise HTTPException(status_code=404, detail=f"Dataset not found: {e}")
 
     data = np.asarray(data)
+    dataset_path = hdf5_path or mat_path
 
-    if ndim == 3:
-        return {
-            "data": data.tolist(),
-            "data_type": "images",
-            "total_frames": int(shape[0]),
-        }
-    elif ndim == 2:
-        df = pd.DataFrame(data)
-        return {
-            "data": df.to_dict(orient="split")["data"],
-            "columns": [str(c) for c in df.columns.tolist()],
-            "index": [str(i) for i in df.index.tolist()],
-            "data_type": "timeseries",
-        }
-    elif ndim == 1:
-        return {
-            "data": data.tolist(),
-            "index": list(range(len(data))),
-            "data_type": "bar",
-        }
-    else:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported data dimensionality: {ndim}",
-        )
+    match ndim:
+        case 3:
+            return {
+                "data": data.tolist(),
+                "data_type": "images",
+                "total_frames": int(shape[0]),
+                "dataset_path": dataset_path,
+            }
+        case 2:
+            df = pd.DataFrame(data)
+            return {
+                "data": df.to_dict(orient="split")["data"],
+                "columns": [str(c) for c in df.columns.tolist()],
+                "index": [str(i) for i in df.index.tolist()],
+                "data_type": "timeseries",
+                "dataset_path": dataset_path,
+            }
+        case 1:
+            return {
+                "data": data.tolist(),
+                "index": list(range(len(data))),
+                "data_type": "bar",
+                "dataset_path": dataset_path,
+            }
+        case _:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported data dimensionality: {ndim}",
+            )

--- a/studio/app/common/routers/outputs.py
+++ b/studio/app/common/routers/outputs.py
@@ -1,8 +1,10 @@
 import os
 from typing import Optional
 
+import h5py
+import numpy as np
 import pandas as pd
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from studio.app.common.core.utils.file_reader import JsonReader, Reader
 from studio.app.common.core.utils.filepath_creater import (
@@ -10,10 +12,12 @@ from studio.app.common.core.utils.filepath_creater import (
     join_filepath,
 )
 from studio.app.common.core.utils.json_writer import JsonWriter, save_tiff2json
+from studio.app.common.core.workflow.workflow_reader import WorkflowConfigReader
 from studio.app.common.dataclass.timeseries_chunk_handler import TimeSeriesChunkHandler
 from studio.app.common.schemas.outputs import JsonTimeSeriesData, OutputData
 from studio.app.const import ACCEPT_FILE_EXT, ORIGINAL_DATA_EXT
 from studio.app.dir_path import DIRPATH
+from studio.app.optinist.routers.mat import MatGetter
 
 router = APIRouter(prefix="/outputs", tags=["outputs"])
 
@@ -237,3 +241,91 @@ async def get_csv(filepath: str, workspace_id: str):
 
     JsonWriter.write_as_split(json_filepath, pd.read_csv(filepath, header=None))
     return JsonReader.read_as_output(json_filepath)
+
+
+@router.get("/structured/{workspace_id}/{unique_id}/{node_id}")
+async def get_structured_data(
+    workspace_id: str,
+    unique_id: str,
+    node_id: str,
+    start_index: Optional[int] = 0,
+    end_index: Optional[int] = 10,
+):
+    try:
+        config = WorkflowConfigReader.read(workspace_id, unique_id)
+    except Exception:
+        raise HTTPException(status_code=404, detail="Workflow config not found")
+
+    node = config.nodeDict.get(node_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail=f"Node {node_id} not found")
+
+    file_path = node.data.path
+    if isinstance(file_path, list):
+        file_path = file_path[0] if file_path else None
+    if not file_path:
+        raise HTTPException(status_code=400, detail="Node has no file path")
+
+    full_path = join_filepath([DIRPATH.INPUT_DIR, workspace_id, file_path])
+    if not os.path.exists(full_path):
+        raise HTTPException(status_code=404, detail=f"File not found: {file_path}")
+
+    hdf5_path = node.data.hdf5Path
+    mat_path = node.data.matPath
+
+    try:
+        if hdf5_path is not None:
+            with h5py.File(full_path, "r") as f:
+                dataset = f[hdf5_path]
+                shape = dataset.shape
+                ndim = dataset.ndim
+                if ndim == 3:
+                    si = max(0, start_index)
+                    ei = min(shape[0], end_index)
+                    data = dataset[si:ei]
+                else:
+                    data = dataset[:]
+        elif mat_path is not None:
+            raw = MatGetter.data(full_path, mat_path)
+            data = np.asarray(raw)
+            shape = data.shape
+            ndim = data.ndim
+            if ndim == 3:
+                si = max(0, start_index)
+                ei = min(shape[0], end_index)
+                data = data[si:ei]
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="Node has no hdf5Path or matPath",
+            )
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=f"Dataset not found: {e}")
+
+    data = np.asarray(data)
+
+    if ndim == 3:
+        return {
+            "data": data.tolist(),
+            "data_type": "images",
+            "total_frames": int(shape[0]),
+        }
+    elif ndim == 2:
+        df = pd.DataFrame(data)
+        return {
+            "data": df.to_dict(orient="split")["data"],
+            "columns": [str(c) for c in df.columns.tolist()],
+            "index": [str(i) for i in df.index.tolist()],
+            "data_type": "timeseries",
+        }
+    elif ndim == 1:
+        return {
+            "data": data.tolist(),
+            "index": list(range(len(data))),
+            "data_type": "bar",
+        }
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported data dimensionality: {ndim}",
+        )

--- a/studio/tests/app/common/routers/test_structured_outputs.py
+++ b/studio/tests/app/common/routers/test_structured_outputs.py
@@ -1,0 +1,327 @@
+import os
+import shutil
+
+import h5py
+import numpy as np
+import pytest
+import scipy.io
+import yaml
+
+from studio.app.dir_path import DIRPATH
+
+WORKSPACE_ID = "test_structured"
+UNIQUE_ID = "run_001"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_structured_test_data():
+    """Create temporary HDF5/MAT files and a workflow.yaml for testing."""
+    input_dir = os.path.join(DIRPATH.INPUT_DIR, WORKSPACE_ID)
+    output_dir = os.path.join(DIRPATH.OUTPUT_DIR, WORKSPACE_ID, UNIQUE_ID)
+    os.makedirs(input_dir, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Create a 2D HDF5 file (should resolve to timeseries)
+    hdf5_2d_path = os.path.join(input_dir, "data_2d.h5")
+    with h5py.File(hdf5_2d_path, "w") as f:
+        f.create_dataset("recording/traces", data=np.random.rand(100, 5))
+
+    # Create a 3D HDF5 file (should resolve to images)
+    hdf5_3d_path = os.path.join(input_dir, "data_3d.h5")
+    with h5py.File(hdf5_3d_path, "w") as f:
+        f.create_dataset("recording/frames", data=np.random.rand(10, 64, 64))
+
+    # Create a 1D HDF5 file (should resolve to bar)
+    hdf5_1d_path = os.path.join(input_dir, "data_1d.h5")
+    with h5py.File(hdf5_1d_path, "w") as f:
+        f.create_dataset("values", data=np.random.rand(50))
+
+    # Create a MAT file with 2D data (should resolve to timeseries)
+    mat_path = os.path.join(input_dir, "data.mat")
+    scipy.io.savemat(mat_path, {"data": {"behavior": np.random.rand(80, 4)}})
+
+    # Create workflow.yaml with nodes referencing these files
+    workflow = {
+        "nodeDict": {
+            "hdf5_2d_node": {
+                "data": {
+                    "label": "HDF5 2D",
+                    "param": {},
+                    "path": "data_2d.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": "recording/traces",
+                    "matPath": None,
+                },
+                "id": "hdf5_2d_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "hdf5_3d_node": {
+                "data": {
+                    "label": "HDF5 3D",
+                    "param": {},
+                    "path": "data_3d.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": "recording/frames",
+                    "matPath": None,
+                },
+                "id": "hdf5_3d_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "hdf5_1d_node": {
+                "data": {
+                    "label": "HDF5 1D",
+                    "param": {},
+                    "path": "data_1d.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": "values",
+                    "matPath": None,
+                },
+                "id": "hdf5_1d_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "mat_node": {
+                "data": {
+                    "label": "MAT 2D",
+                    "param": {},
+                    "path": "data.mat",
+                    "type": "input",
+                    "fileType": "matlab",
+                    "hdf5Path": None,
+                    "matPath": "data/behavior",
+                },
+                "id": "mat_node",
+                "type": "MatlabFileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "no_path_node": {
+                "data": {
+                    "label": "No Path",
+                    "param": {},
+                    "path": "data_2d.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": None,
+                    "matPath": None,
+                },
+                "id": "no_path_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "missing_file_node": {
+                "data": {
+                    "label": "Missing File",
+                    "param": {},
+                    "path": "nonexistent.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": "data",
+                    "matPath": None,
+                },
+                "id": "missing_file_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+            "bad_dataset_node": {
+                "data": {
+                    "label": "Bad Dataset",
+                    "param": {},
+                    "path": "data_2d.h5",
+                    "type": "input",
+                    "fileType": "hdf5",
+                    "hdf5Path": "nonexistent/path",
+                    "matPath": None,
+                },
+                "id": "bad_dataset_node",
+                "type": "HDF5FileNode",
+                "position": {"x": 0, "y": 0},
+                "style": {
+                    "border": None,
+                    "borderRadius": None,
+                    "height": None,
+                    "padding": None,
+                    "width": None,
+                },
+            },
+        },
+        "edgeDict": {},
+    }
+
+    workflow_path = os.path.join(output_dir, "workflow.yaml")
+    with open(workflow_path, "w") as f:
+        yaml.dump(workflow, f)
+
+    yield
+
+    # Cleanup
+    shutil.rmtree(input_dir, ignore_errors=True)
+    shutil.rmtree(os.path.join(DIRPATH.OUTPUT_DIR, WORKSPACE_ID), ignore_errors=True)
+
+
+def test_structured_hdf5_2d_returns_timeseries(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/hdf5_2d_node"
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "timeseries"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) == 100
+    assert len(data["data"][0]) == 5
+    assert isinstance(data["columns"], list)
+    assert isinstance(data["index"], list)
+
+
+def test_structured_hdf5_3d_returns_images(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/hdf5_3d_node",
+        params={"start_index": 0, "end_index": 10},
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "images"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) == 10
+    assert len(data["data"][0]) == 64
+    assert len(data["data"][0][0]) == 64
+    assert data["total_frames"] == 10
+
+
+def test_structured_hdf5_3d_pagination(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/hdf5_3d_node",
+        params={"start_index": 2, "end_index": 5},
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "images"
+    assert len(data["data"]) == 3
+    assert data["total_frames"] == 10
+
+
+def test_structured_hdf5_1d_returns_bar(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/hdf5_1d_node"
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "bar"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) == 50
+    assert isinstance(data["index"], list)
+    assert len(data["index"]) == 50
+
+
+def test_structured_missing_workflow(client):
+    response = client.get(
+        "/outputs/structured/nonexistent_ws/nonexistent_uid/some_node"
+    )
+    assert response.status_code == 404
+
+
+def test_structured_missing_node(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/nonexistent_node"
+    )
+    assert response.status_code == 404
+
+
+def test_structured_no_hdf5path_or_matpath(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/no_path_node"
+    )
+    assert response.status_code == 400
+    assert "hdf5Path or matPath" in response.json()["detail"]
+
+
+def test_structured_mat_2d_returns_timeseries(client):
+    response = client.get(f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/mat_node")
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "timeseries"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) == 80
+    assert len(data["data"][0]) == 4
+    assert isinstance(data["columns"], list)
+    assert isinstance(data["index"], list)
+
+
+def test_structured_missing_file(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/missing_file_node"
+    )
+    assert response.status_code == 404
+    assert "File not found" in response.json()["detail"]
+
+
+def test_structured_bad_dataset_path(client):
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/bad_dataset_node"
+    )
+    assert response.status_code == 404
+    assert "Dataset not found" in response.json()["detail"]
+
+
+def test_structured_3d_default_pagination(client):
+    """When start_index/end_index are omitted, defaults to 0-10."""
+    response = client.get(
+        f"/outputs/structured/{WORKSPACE_ID}/{UNIQUE_ID}/hdf5_3d_node"
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["data_type"] == "images"
+    assert len(data["data"]) == 10
+    assert data["total_frames"] == 10

--- a/studio/tests/app/common/routers/test_structured_outputs.py
+++ b/studio/tests/app/common/routers/test_structured_outputs.py
@@ -218,6 +218,7 @@ def test_structured_hdf5_2d_returns_timeseries(client):
     assert len(data["data"][0]) == 5
     assert isinstance(data["columns"], list)
     assert isinstance(data["index"], list)
+    assert data["dataset_path"] == "recording/traces"
 
 
 def test_structured_hdf5_3d_returns_images(client):
@@ -234,6 +235,7 @@ def test_structured_hdf5_3d_returns_images(client):
     assert len(data["data"][0]) == 64
     assert len(data["data"][0][0]) == 64
     assert data["total_frames"] == 10
+    assert data["dataset_path"] == "recording/frames"
 
 
 def test_structured_hdf5_3d_pagination(client):
@@ -261,6 +263,7 @@ def test_structured_hdf5_1d_returns_bar(client):
     assert len(data["data"]) == 50
     assert isinstance(data["index"], list)
     assert len(data["index"]) == 50
+    assert data["dataset_path"] == "values"
 
 
 def test_structured_missing_workflow(client):
@@ -295,6 +298,7 @@ def test_structured_mat_2d_returns_timeseries(client):
     assert len(data["data"]) == 80
     assert len(data["data"][0]) == 4
     assert isinstance(data["columns"], list)
+    assert data["dataset_path"] == "data/behavior"
     assert isinstance(data["index"], list)
 
 


### PR DESCRIPTION
### Content

#### Summary
- HDF5 and MAT input files can now be visualised directly on the Visualise page by selecting them from the data dropdown, without needing algorithm node outputs.
- A new backend endpoint (`GET /outputs/structured/{workspace_id}/{unique_id}/{node_id}`) reads the dataset path (`hdf5Path`/`matPath`) from the saved `workflow.yaml` and returns the data with automatic type detection (1D -> bar, 2D -> timeseries, 3D -> images).
- 3D image data uses pagination (`start_index`/`end_index`) matching the existing TIFF pattern, loading 10 frames at a time to avoid multi-megabyte JSON responses.
- A new `StructuredFilePlot` frontend component renders the data using Plotly (line chart for timeseries, heatmap with slider for images, bar chart for 1D).

#### Design Decisions
- **Reads from `workflow.yaml` instead of re-uploading data** -- The workflow config already stores the file path and dataset path (`hdf5Path`/`matPath`) for each input node. The endpoint resolves the data at request time from these saved references, avoiding duplication.
- **Pagination for 3D data only** -- 2D and 1D data are small enough to return in full. 3D image stacks (e.g. 500x128x128) would produce ~50MB JSON responses, so the same `start_index`/`end_index` pattern used by the TIFF image endpoint is applied. Default window is 10 frames.
- **`ndim` determined before slicing** -- The original array dimensionality is captured before any pagination slicing so the response `data_type` is always correct. `total_frames` is returned for 3D data so the frontend knows the full dataset size.
- **Keyed by `itemId` not `filePath`** -- Unlike other display data types that use file paths as Redux keys, structured data uses the visualise item ID. This avoids collisions when the same input file appears in multiple visualise items.
- **`StructuredFilePlot` follows `ImagePlot` patterns** -- Uses `LinearProgress` for loading, `useEffect` for data fetching with the same guard pattern (`workspaceId && uid && nodeId`), and `PlotlyChart` for rendering.

### Evidence
- Backend endpoint tested manually against real tutorial4 data (HDF5: 500x128x128 images, MAT: 500x8 timeseries)
- Paginated HDF5 response: ~1MB (10 frames) vs ~50MB (all 500 frames)
- MAT timeseries response: ~32KB
- All 11 backend tests and 17 frontend test suites pass

### References
- Tutorial 4 workflow (suite2p + CCA with HDF5 image input and MAT behavior input)
- Existing TIFF pagination: `GET /outputs/image/{filepath}?start_index=1&end_index=10`

#### Files changed

##### Backend
- `studio/app/common/routers/outputs.py` -- New `GET /outputs/structured/` endpoint with pagination support for 3D data; reads `hdf5Path`/`matPath` from workflow config

##### Frontend
- `frontend/src/api/outputs/Outputs.ts` -- New `StructuredData` type and `getStructuredDataApi` function with `startIndex`/`endIndex` params
- `frontend/src/store/slice/DisplayData/DisplayDataActions.ts` -- New `getStructuredData` async thunk
- `frontend/src/store/slice/DisplayData/DisplayDataSlice.ts` -- Reducers for structured data (pending/fulfilled/rejected) and cleanup handling for HDF5/MATLAB types
- `frontend/src/store/slice/DisplayData/DisplayDataType.ts` -- New `StructuredDisplayData` interface and `structured` state field
- `frontend/src/components/Workspace/Visualize/Plot/StructuredFilePlot.tsx` -- New component: fetches structured data and renders as timeseries (line), images (heatmap + slider), or bar chart
- `frontend/src/components/Workspace/Visualize/DisplayDataItem.tsx` -- Route `HDF5`/`MATLAB` data types to `StructuredFilePlot`
- `frontend/src/components/Workspace/Visualize/VisualizeItemEditor.tsx` -- Add HDF5/MATLAB to SaveFig editor cases

##### Tests
- `studio/tests/app/common/routers/test_structured_outputs.py` -- New: 11 tests covering HDF5 (1D/2D/3D), MAT files, pagination, default params, and error cases (missing workflow/node/file, bad dataset path, no hdf5Path/matPath)
- `frontend/src/components/Workspace/__tests__/Experiment/ExperimentTable.test.tsx` -- Added `structured: {}` to mock DisplayData state

### Manual Testcases
- Run tutorial4 workflow with HDF5 and MAT input files
- Navigate to the Visualise page
- Click "+" to add a new visualise item
- From the "Select Item" dropdown, select `sample_hdf5.h5` -- verify a heatmap image renders with a frame slider (10 frames loaded)
- Add another item, select `sample_matlab.mat` -- verify a timeseries line chart renders (500 rows x 8 columns)
- Verify algorithm outputs (suite2p images, CCA scatter/bar) still render correctly from the dropdown
- `make test_backend` -- all backend tests pass (including 11 structured output tests)
- `make test_frontend` -- all 17 frontend test suites pass (79 tests)

<img width="553" height="593" alt="Screenshot 2026-03-16 at 15 29 24" src="https://github.com/user-attachments/assets/cc0d8c63-8e56-4013-af06-e975228384dd" />

<img width="558" height="561" alt="Screenshot 2026-03-16 at 15 29 30" src="https://github.com/user-attachments/assets/be723996-255b-4774-982e-53b813abf472" />


### Unit, Integration, Contract Test Coverage

| Area | Coverage |
|------|----------|
| HDF5 1D/2D/3D data types | Unit tests via TestClient |
| MAT file via matPath | Unit test via TestClient |
| 3D pagination (custom range) | Unit test |
| 3D pagination (default params) | Unit test |
| Error: missing workflow | Unit test (404) |
| Error: missing node | Unit test (404) |
| Error: missing file | Unit test (404) |
| Error: bad dataset path | Unit test (404) |
| Error: no hdf5Path/matPath | Unit test (400) |
| Frontend Redux state shape | ExperimentTable test (structured field) |

### Others

#### Difficulties
- The frontend dev server (`.env.development`) was configured for ports 3001/8001 but `docker-compose.dev.multiuser.yml` mapped port 3000, causing the dev server to be unreachable. This made it appear that code changes weren't taking effect when the user was accessing the app through the backend's production build (port 8000) instead.
- The HDF5 image dataset (500x128x128 uint16) serialised to ~50MB of JSON, which would hang the browser. Resolved by adding pagination matching the existing TIFF pattern.

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Structured data endpoint | Low | New endpoint, no changes to existing endpoints; isolated code path |
| 3D pagination | Low | Follows established TIFF pattern; default 10 frames matches existing behaviour |
| Redux `structured` state | Low | New state field with no interaction with existing display data types |
| `StructuredFilePlot` component | Low | New component, only rendered for HDF5/MATLAB types; no impact on existing plots |
| MAT file reading via `MatGetter` | Low | Reuses existing `MatGetter.data()` which is already used by the `/mat/` endpoint |
