### PR TITLE
Resolved GitHub Action Test Error

### DIFF
--- a/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
+++ b/studio/app/optinist/wrappers/optinist/conda/optinist.yaml
@@ -7,7 +7,7 @@ dependencies:
   - pip:
       - scikit-learn==1.1.*
       - statsmodels==0.13.*
-      - pynwb==2.2.0
+      - pynwb<3
       - numexpr
       - numba
       - dpca


### PR DESCRIPTION
## Content

- An error occurred in testing with the latest GitHub Action (as of March 2026).
- It appears that the issue was caused by an outdated and fixed version of a certain module (pnwb).

### Error log

```
FAILED studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py::test_snakemake_execute
FAILED studio/tests/app/common/core/snakemake/test_snakemake_executor_lccd.py::test_snakemake_delete_dependencies
= 2 failed, 1070 passed, 15 skipped, 2 deselected, 5 warnings in 111.89s (0:01:51) =
```

### Expected Cause

The version of a specific module (pynwb) was outdated and its version was fixed, which apparently caused compatibility issues with the setuptools version.
This resulted in a situation where "the Python 3.9 conda environment was loading the jaraco.context package from the host (Python 3.11)."

### Solution

One of the following solutions is possible, but option 1 was chosen for its maintainability.
1. Upgrade the pynwb version (latest version of 2.x)
2. Downgrade the setuptools version (<71, etc.)

## Testcase

- [x] Verify that the error is resolved using `act` (GitHub Action Simulator).

### Note

GitHub Actions can be simulated using `act`.
- https://github.com/nektos/act

Verification will be performed using the above.
*It appears that verification work using act was also performed for a similar issue in the past.
- arayabrain/barebone-studio#910
