### PR TITLE
Added functionality to display the Backend unavailable screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,17 @@
-import { FC, useEffect } from "react"
+import { FC, useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
 
+import { isAxiosError } from "axios"
 import { SnackbarProvider, SnackbarKey, useSnackbar } from "notistack"
 
 import Close from "@mui/icons-material/Close"
 import IconButton from "@mui/material/IconButton"
 
+import BackendUnavailable from "components/common/BackendUnavailable"
 import Loading from "components/common/Loading"
 import Layout from "components/Layout"
-import { RETRY_WAIT } from "const/Mode"
+import { RETRY_MAX_COUNT, RETRY_WAIT, RETRY_WAIT_LONG } from "const/Mode"
 import Account from "pages/Account"
 import AccountDelete from "pages/AccountDelete"
 import AccountManager from "pages/AccountManager"
@@ -25,24 +27,74 @@ import {
 } from "store/slice/Standalone/StandaloneSeclector"
 import { AppDispatch } from "store/store"
 
+/**
+ * Returns whether the error from getModeStandalone should be retried.
+ *
+ * - Treat as "backend down" (retry): network/timeout errors and HTTP 5xx.
+ * - Treat as terminal (no retry): HTTP 4xx. Non-axios errors are retried for safety.
+ */
+const isRetryableBackendError = (error: unknown): boolean => {
+  if (!isAxiosError(error)) return true
+  if (!error.response) return true
+  const status = error.response.status
+  return status >= 500 && status < 600
+}
+
 const App: FC = () => {
   const dispatch = useDispatch<AppDispatch>()
   const isStandalone = useSelector(selectModeStandalone)
   const loading = useSelector(selectLoading)
-  const getMode = () => {
-    dispatch(getModeStandalone())
-      .unwrap()
-      .catch(() => {
-        new Promise((resolve) => setTimeout(resolve, RETRY_WAIT)).then(() => {
-          getMode()
-        })
-      })
-  }
+  // Show the "backend unavailable" screen instead of the normal layout.
+  const [showBackendError, setShowBackendError] = useState(false)
+  // false = background polling has stopped (4xx); user must reload manually.
+  const [isRetrying, setIsRetrying] = useState(true)
 
   useEffect(() => {
+    let cancelled = false
+    let timerId: ReturnType<typeof setTimeout> | undefined
+    let retryCount = 0
+
+    const getMode = () => {
+      dispatch(getModeStandalone())
+        .unwrap()
+        .then(() => {
+          if (cancelled) return
+          // Recovered: hide the error screen.
+          setShowBackendError(false)
+          setIsRetrying(true)
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return
+          if (!isRetryableBackendError(error)) {
+            // Terminal error (4xx): stop polling, require manual reload.
+            setShowBackendError(true)
+            setIsRetrying(false)
+            return
+          }
+          retryCount += 1
+          const reachedMax = retryCount >= RETRY_MAX_COUNT
+          if (reachedMax) {
+            setShowBackendError(true)
+          }
+          const wait = reachedMax ? RETRY_WAIT_LONG : RETRY_WAIT
+          timerId = setTimeout(() => {
+            getMode()
+          }, wait)
+        })
+    }
+
     getMode()
+
+    return () => {
+      cancelled = true
+      if (timerId !== undefined) clearTimeout(timerId)
+    }
     //eslint-disable-next-line
   }, [])
+
+  if (showBackendError) {
+    return <BackendUnavailable isRetrying={isRetrying} />
+  }
 
   return loading ? (
     <Loading loading={true} />

--- a/frontend/src/components/common/BackendUnavailable.tsx
+++ b/frontend/src/components/common/BackendUnavailable.tsx
@@ -1,0 +1,65 @@
+import { FC } from "react"
+
+import { Box, Stack, styled, Typography } from "@mui/material"
+
+type Props = {
+  // true: background retries are running and the page will auto-recover.
+  // false: polling has stopped and the user must reload manually.
+  isRetrying: boolean
+}
+
+const BackendUnavailable: FC<Props> = ({ isRetrying }) => {
+  return (
+    <Wrapper>
+      <Content>
+        <Title>Cannot connect to the OptiNiSt server</Title>
+        <Message>
+          The server is currently unavailable. Please try again after a while.
+        </Message>
+        {isRetrying ? (
+          <SubMessage>
+            This page will automatically recover once the connection is
+            restored.
+          </SubMessage>
+        ) : (
+          <SubMessage>Please reload this page to retry.</SubMessage>
+        )}
+      </Content>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Box)({
+  width: "100vw",
+  height: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+})
+
+const Content = styled(Stack)({
+  padding: 32,
+  boxShadow: "2px 1px 3px 1px rgba(0,0,0,0.1)",
+  borderRadius: 4,
+  maxWidth: 480,
+  textAlign: "center",
+  gap: 12,
+})
+
+const Title = styled(Typography)({
+  fontSize: 18,
+  fontWeight: 600,
+})
+
+const Message = styled(Typography)({
+  fontSize: 14,
+  color: "rgba(0, 0, 0, 0.75)",
+})
+
+const SubMessage = styled(Typography)({
+  fontSize: 12,
+  color: "rgba(0, 0, 0, 0.55)",
+})
+
+export default BackendUnavailable

--- a/frontend/src/const/Mode.ts
+++ b/frontend/src/const/Mode.ts
@@ -1,2 +1,6 @@
 export const RETRY_WAIT = 5000
+// Max retries at RETRY_WAIT before showing the backend-unavailable screen.
+export const RETRY_MAX_COUNT = 5
+// Retry interval used while the backend-unavailable screen is shown.
+export const RETRY_WAIT_LONG = 30000
 export const STANDALONE_WORKSPACE_ID = 1


### PR DESCRIPTION
### Content

Added functionality to display an appropriate error screen and retry access if the backend is down.

- Porting from arayabrain/araya-optinist#502

### Testcase

See the test case in arayabrain/araya-optinist#502
